### PR TITLE
feat: initial probe-run support

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -248,15 +248,13 @@ modules:
 
   - name: release-arch
     context: cortex-m
-    selects:
-      - ?no-semihosting
 
-  - name: no-semihosting
-    context: cortex-m
+  - name: debug-console
+    context: riot-rs
     env:
       global:
         FEATURES:
-          - riot-rs/no-semihosting
+          - riot-rs/debug-console
 
   - name: silent-panic
     context: riot-rs

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -74,12 +74,17 @@ contexts:
     tasks:
       cargo:
         cmd:
-          - cd ${relpath} && ${RIOT_ENV} ${CARGO_ENV} cargo
+          - cd ${relpath} && ${RIOT_ENV} ${CARGO_ENV} cargo ${CARGO_ARGS}
         build: false
+
+      run:
+        build: false
+        cmd:
+          - cd ${appdir} && ${RIOT_ENV} ${CARGO_ENV} cargo ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
 
       cargo-test:
         cmd:
-          - cd ${relpath} && ${RIOT_ENV} ${CARGO_ENV} cargo test --${PROFILE} --features=riot-rs-boards/${builder} --manifest-path ${app}/Cargo.toml
+          - cd ${relpath} && ${RIOT_ENV} ${CARGO_ENV} cargo test --${PROFILE} --features=riot-rs-boards/${builder},riot-rs-rt/debug-console --manifest-path ${app}/Cargo.toml
         build: false
 
       debug:
@@ -217,7 +222,7 @@ contexts:
   - name: nrf52840
     parent: nrf52
     env:
-      PROBE_RS_CHIP: nrf52840
+      PROBE_RS_CHIP: nrf52840_xxAA
 
     tasks:
       flash-rs:
@@ -339,7 +344,7 @@ modules:
     env:
       global:
         RUSTFLAGS:
-          - "-Clinker-plugin-lto -Clinker=clang -Clink-arg=-fuse-ld=lld -Clink-arg=--target=${RUSTC_TARGET} -Clink-arg=-v"
+          - "-Clinker-plugin-lto -Clinker=clang -Clink-arg=-fuse-ld=lld -Clink-arg=--target=${RUSTC_TARGET} -Clink-arg=-v -Clink-arg=-Wl,--no-eh-frame-hdr"
 
   - name: riotboot
     context: nrf52840
@@ -373,6 +378,14 @@ modules:
 
   - name: testable
     context: lm3s6965evb
+
+  - name: probe-run
+    context: nrf52
+    selects:
+      - ?debug-console
+    env:
+      global:
+        CARGO_RUNNER: "'probe-run --chip ${PROBE_RS_CHIP}'"
 
 builders:
   # host builder (for housekeeping tasks)

--- a/src/riot-rs-boards/lm3s6965evb/Cargo.toml
+++ b/src/riot-rs-boards/lm3s6965evb/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riot-rs-rt = { path = "../../riot-rs-rt" }
+riot-rs-rt = { path = "../../riot-rs-rt", features = [ "cortex-m-semihosting" ] }

--- a/src/riot-rs-boards/nrf52/Cargo.toml
+++ b/src/riot-rs-boards/nrf52/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riot-rs-rt = { path = "../../riot-rs-rt" }
+riot-rs-rt = { path = "../../riot-rs-rt", features = [ "rtt-target" ] }

--- a/src/riot-rs-core/Cargo.toml
+++ b/src/riot-rs-core/Cargo.toml
@@ -28,7 +28,6 @@ cortex-m-semihosting = { optional = true, version = "0.5.0" }
 cstr_core = { version = "0.2.6", default-features = false }
 
 [features]
-no-semihosting = [ "cortex-m-semihosting/no-semihosting" ]
 thread_info = []
 
 [build-dependencies]

--- a/src/riot-rs-rt/Cargo.toml
+++ b/src/riot-rs-rt/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2021"
 [dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
-cortex-m-semihosting = "0.5.0"
+cortex-m-semihosting = { version = "0.5.0", optional = true }
+rtt-target = { version = "0.4.0", optional = true }
 
 [features]
+debug-console = []
 silent-panic = []
 
 [dev-dependencies]

--- a/src/riot-rs-rt/src/debug.rs
+++ b/src/riot-rs-rt/src/debug.rs
@@ -1,0 +1,50 @@
+#[cfg(all(feature = "rtt-target", feature = "cortex-m-semihosting"))]
+compile_error!("feature \"rtt-target\" and feature \"cortex-m-semihosting\" cannot be enabled at the same time");
+
+#[cfg(all(feature = "debug-console", feature = "cortex-m-semihosting"))]
+mod backend {
+    pub use cortex_m_semihosting::debug::{exit, EXIT_FAILURE, EXIT_SUCCESS};
+    pub use cortex_m_semihosting::hprint as print;
+    pub use cortex_m_semihosting::hprintln as println;
+}
+
+#[cfg(all(feature = "debug-console", feature = "rtt-target"))]
+mod backend {
+    pub const EXIT_SUCCESS: u32 = 0;
+    pub const EXIT_FAILURE: u32 = 1;
+    pub fn exit(_code: u32) {
+        loop {
+            cortex_m::asm::bkpt();
+        }
+    }
+    pub use rtt_target::rprint as print;
+    pub use rtt_target::rprintln as println;
+}
+
+#[cfg(not(feature = "debug-console"))]
+mod backend {
+    pub const EXIT_SUCCESS: u32 = 0;
+    pub const EXIT_FAILURE: u32 = 1;
+    pub fn exit(_code: u32) {
+        loop {}
+    }
+
+    #[macro_export]
+    macro_rules! nop_println {
+        ($($arg:tt)*) => {{
+            // Do nothing
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! nop_print {
+        ($($arg:tt)*) => {{
+            // Do nothing
+        }};
+    }
+
+    pub use nop_print as print;
+    pub use nop_println as println;
+}
+
+pub use backend::*;

--- a/src/riot-rs-rt/src/lib.rs
+++ b/src/riot-rs-rt/src/lib.rs
@@ -18,11 +18,8 @@ use cortex_m_rt::{entry, exception, ExceptionFrame, __RESET_VECTOR};
 
 use core::panic::PanicInfo;
 
-pub mod debug {
-    pub use cortex_m_semihosting::debug::{exit, EXIT_FAILURE, EXIT_SUCCESS};
-    pub use cortex_m_semihosting::hprint as print;
-    pub use cortex_m_semihosting::hprintln as println;
-}
+pub mod debug;
+pub use debug::*;
 
 // Table 2.5
 // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CHDBIBGJ.html
@@ -211,6 +208,7 @@ unsafe fn DefaultHandler(_irqn: i16) {
     loop {}
 }
 
+#[cfg(not(test))]
 extern "C" {
     fn riot_rs_rt_startup();
 }
@@ -229,6 +227,9 @@ fn main() -> ! {
             .vtor
             .write(&__RESET_VECTOR as *const _ as u32 - 4)
     };
+
+    #[cfg(all(feature = "debug-console", feature = "rtt-target"))]
+    rtt_target::rtt_init_print!();
 
     debug::println!("riot_rs_rt::main()");
 

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -12,6 +12,6 @@ riot-rs-boards = { path = "../riot-rs-boards" }
 
 [features]
 newlib = [ "riot-build/newlib" ]
-no-semihosting = [ "riot-rs-core/no-semihosting" ]
+debug-console = [ "riot-rs-rt/debug-console" ]
 silent-panic = [ "riot-rs-rt/silent-panic" ]
 thread_info = [ "riot-rs-core/thread_info" ]


### PR DESCRIPTION
This introduces multiple backends for `riot-rs-rt::debug`.
Currently there are:

- a dummy backend
- semihosting (which supports printing through qemu)
- rtt_target (to be used with probe-run)