### PR TITLE
Expose network stack to user tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "embassy-futures",
  "embassy-sync 0.4.0",
@@ -670,7 +670,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.3.3"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 
 [[package]]
 name = "embassy-gpio"
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-internal"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.2.1"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -720,8 +720,10 @@ name = "embassy-net"
 version = "0.1.0"
 dependencies = [
  "embassy-executor",
- "embassy-sync 0.3.0",
+ "embassy-net 0.2.1",
  "embassy-time",
+ "embedded-io-async",
+ "linkme",
  "riot-rs",
  "riot-rs-boards",
 ]
@@ -729,13 +731,15 @@ dependencies = [
 [[package]]
 name = "embassy-net"
 version = "0.2.1"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "as-slice 0.2.1",
  "atomic-pool",
  "embassy-net-driver",
  "embassy-sync 0.4.0",
  "embassy-time",
+ "embedded-io-async",
+ "embedded-nal-async",
  "futures",
  "generic-array 0.14.7",
  "heapless 0.8.0",
@@ -747,12 +751,12 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 
 [[package]]
 name = "embassy-net-driver-channel"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
@@ -762,7 +766,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -797,7 +801,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "atomic-polyfill 1.0.3",
  "cfg-if",
@@ -842,7 +846,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -853,7 +857,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.1.5"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -867,7 +871,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver-channel",
@@ -879,7 +883,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy#006260feddf4d362a99260a38d86dffddab39d2e"
+source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 
 [[package]]
 name = "embedded-dma"
@@ -946,6 +950,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-nal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a943fad5ed3d3f8a00f1e80f6bba371f1e7f0df28ec38477535eb318dc19cc"
+dependencies = [
+ "nb 1.1.0",
+ "no-std-net",
+]
+
+[[package]]
+name = "embedded-nal-async"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24708d5aedfd9e82aec45d2782cd0f59561822c5f352a3c40bb5824b72337653"
+dependencies = [
+ "embedded-io-async",
+ "embedded-nal",
+ "no-std-net",
+]
+
+[[package]]
 name = "embedded-storage"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,7 +1024,7 @@ checksum = "02c69ce7e7c0f17aa18fdd9d0de39727adb9c6281f2ad12f57cbe54ae6e76e7d"
 dependencies = [
  "az",
  "bytemuck",
- "half 2.3.1",
+ "half",
  "typenum",
 ]
 
@@ -1153,16 +1178,6 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "half"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
 
 [[package]]
 name = "hash32"
@@ -1522,6 +1537,12 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nom"
@@ -1907,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2386,7 +2407,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half 1.8.2",
+ "half",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ cortex-m-rt = { version = "0.7" }
 cortex-m-semihosting = { version = "0.5" }
 critical-section = { version = "1.1.2" }
 
-embassy-executor = { version = "0.3.2", default-features = false }
+embassy-executor = { version = "0.3.3", default-features = false }
 embassy-net = { version = "0.2.1", default-features = false }
 embassy-nrf = { version = "0.1.0", default-features = false }
 embassy-rp = { version = "0.1.0", default-features = false }

--- a/examples/embassy-net/Cargo.toml
+++ b/examples/embassy-net/Cargo.toml
@@ -10,4 +10,6 @@ riot-rs = { path = "../../src/riot-rs", features = [ "time", "usb_ethernet"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }
 embassy-executor = { workspace = true, default-features = false }
 embassy-time = { workspace = true, default-features = false }
-embassy-sync = { workspace = true, default-features = false }
+linkme.workspace = true
+embassy-net = { workspace = true, features = ["tcp", "nightly"] }
+embedded-io-async = "0.6.0"

--- a/examples/embassy-net/src/main.rs
+++ b/examples/embassy-net/src/main.rs
@@ -1,49 +1,76 @@
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
 
 use riot_rs as _;
 
+use riot_rs::embassy::TaskArgs;
 use riot_rs::rt::debug::println;
 
-use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
-use riot_rs::embassy::{blocker, EXECUTOR};
-
-static SIGNAL: Signal<CriticalSectionRawMutex, u32> = Signal::new();
+use embedded_io_async::Write;
 
 #[embassy_executor::task]
-async fn async_task() {
-    use embassy_time::{Duration, Timer, TICK_HZ};
-    let mut counter = 0u32;
+async fn tcp_echo(args: TaskArgs) {
+    use embassy_net::tcp::TcpSocket;
+    let stack = args.stack;
+
+    let mut rx_buffer = [0; 4096];
+    let mut tx_buffer = [0; 4096];
+    let mut buf = [0; 4096];
+
     loop {
-        if counter % 2 == 0 {
-            println!("async_task() signalling");
-            SIGNAL.signal(counter);
-        } else {
-            println!("async_task()");
+        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
+
+        println!("Listening on TCP:1234...");
+        if let Err(e) = socket.accept(1234).await {
+            println!("accept error: {:?}", e);
+            continue;
         }
-        Timer::after(Duration::from_ticks(TICK_HZ / 10)).await;
-        counter += 1;
+
+        println!("Received connection from {:?}", socket.remote_endpoint());
+
+        loop {
+            let n = match socket.read(&mut buf).await {
+                Ok(0) => {
+                    println!("read EOF");
+                    break;
+                }
+                Ok(n) => n,
+                Err(e) => {
+                    println!("read error: {:?}", e);
+                    break;
+                }
+            };
+
+            //println!("rxd {:02x}", &buf[..n]);
+
+            match socket.write_all(&buf[..n]).await {
+                Ok(()) => {}
+                Err(e) => {
+                    println!("write error: {:?}", e);
+                    break;
+                }
+            };
+        }
     }
+}
+
+use linkme::distributed_slice;
+use riot_rs::embassy::EMBASSY_TASKS;
+
+#[distributed_slice(EMBASSY_TASKS)]
+fn __start_tcp_echo(spawner: embassy_executor::Spawner, t: TaskArgs) {
+    spawner.spawn(tcp_echo(t)).unwrap();
 }
 
 #[no_mangle]
 fn riot_main() {
-    use embassy_time::Instant;
     println!(
         "Hello from riot_main()! Running on a {} board.",
         riot_rs::buildinfo::BOARD
     );
 
-    let spawner = EXECUTOR.spawner();
-    spawner.spawn(async_task()).unwrap();
-
-    loop {
-        let val = blocker::block_on(SIGNAL.wait());
-        println!(
-            "now={}ms threadtest() val={}",
-            Instant::now().as_millis(),
-            val
-        );
-    }
+    loop {}
 }

--- a/linkme.x
+++ b/linkme.x
@@ -1,6 +1,8 @@
 SECTIONS {
   linkme_INIT_FUNCS : { *(linkme_INIT_FUNCS) } > FLASH
   linkm2_INIT_FUNCS : { *(linkm2_INIT_FUNCS) } > FLASH
+  linkme_EMBASSY_TASKS : { *(linkme_EMBASSY_TASKS) } > FLASH
+  linkm2_EMBASSY_TASKS : { *(linkm2_EMBASSY_TASKS) } > FLASH
 }
 
 INSERT AFTER .rodata


### PR DESCRIPTION
This PR:

- introduces EMBASSY_TASKS, a distributed slice of async functions that get called after riot-rs-embassy has finished it's initialization.
- TaskArgs, a structure that contains references that get passed to EMBASSY_TASKS
- adds the initialized network stack reference to TaskArgs (if available)
- updates `examples/embassy-net` with a simple tcp echo example

fixes #17.