### PR TITLE
doc: Fix hardcoded IP address

### DIFF
--- a/examples/embassy-net-tcp/README.md
+++ b/examples/embassy-net-tcp/README.md
@@ -12,4 +12,4 @@ In this folder, run
     laze build -b nrf52840dk run
 
 With the device USB cable connected, a USB ethernet device should pop up.
-RIOT-rs will reply to ping requests on 10.0.42.61.
+RIOT-rs will reply to ping requests on 10.42.0.61.

--- a/examples/embassy-net-udp/README.md
+++ b/examples/embassy-net-udp/README.md
@@ -12,4 +12,4 @@ In this folder, run
     laze build -b nrf52840dk run
 
 With the device USB cable connected, a USB ethernet device should pop up.
-RIOT-rs will reply to ping requests on 10.0.42.61.
+RIOT-rs will reply to ping requests on 10.42.0.61.


### PR DESCRIPTION
Docs say 10.0.42.61, `src/riot-rs-embassy/src/lib.rs` says `10, 42, 0, 61`.

I didn't test the TCP version, but given it doesn't have its own setup, I trust it's the same issue.

May this be the last code I'm doing IPv4 fixes for in a long time ;-)