### PR TITLE
riot-rs-boards: make "dummy" a (non-default) choice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sccache --start-server || true # work around https://github.com/ninja-build/ninja/issues/2052
 
-        laze build --partition hash:${{ matrix.partition }} --builders nrf52840dk,rpi-pico -g
+        laze build --partition hash:${{ matrix.partition }} --builders microbit-v2,nrf52840dk,rpi-pico -g
 
   CI-success:
       if: ${{ always() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,19 +717,6 @@ dependencies = [
 
 [[package]]
 name = "embassy-net"
-version = "0.1.0"
-dependencies = [
- "embassy-executor",
- "embassy-net 0.2.1",
- "embassy-time",
- "embedded-io-async",
- "linkme",
- "riot-rs",
- "riot-rs-boards",
-]
-
-[[package]]
-name = "embassy-net"
 version = "0.2.1"
 source = "git+https://github.com/embassy-rs/embassy#e0727fe1f6bd1b8c9c356f33991b522956251ba1"
 dependencies = [
@@ -1504,6 +1491,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "microbit-v2"
+version = "0.1.0"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+ "nrf52",
+ "riot-rs-rt",
+]
+
+[[package]]
 name = "minicbor"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2118,7 @@ dependencies = [
  "dwm1001",
  "lm3s6965evb",
  "microbit",
+ "microbit-v2",
  "nrf52840-mdk",
  "nrf52840dk",
  "nrf52dk",
@@ -2158,7 +2156,7 @@ version = "0.1.0"
 dependencies = [
  "critical-section",
  "embassy-executor",
- "embassy-net 0.2.1",
+ "embassy-net",
  "embassy-nrf",
  "embassy-rp",
  "embassy-sync 0.3.0",

--- a/src/riot-rs-boards/src/lib.rs
+++ b/src/riot-rs-boards/src/lib.rs
@@ -2,10 +2,6 @@
 
 use cfg_if::cfg_if;
 
-pub mod dummy {
-    pub fn init() {}
-}
-
 cfg_if! {
     if #[cfg(feature = "nrf52dk")] {
         pub use nrf52dk as board;
@@ -24,7 +20,7 @@ cfg_if! {
     } else if #[cfg(feature = "rpi-pico")] {
         pub use rpi_pico as board;
     } else {
-        pub use dummy as board;
+        compile_error!("no board feature selected");
     }
 }
 

--- a/src/riot-rs-boards/src/lib.rs
+++ b/src/riot-rs-boards/src/lib.rs
@@ -13,6 +13,8 @@ cfg_if! {
         pub use nrf52840_mdk as board;
     } else if #[cfg(feature = "microbit")] {
         pub use microbit as board;
+    } else if #[cfg(feature = "microbit-v2")] {
+        pub use microbit_v2 as board;
     } else if #[cfg(feature = "nucleo-f401re")] {
         pub use nucleo_f401re as board;
     } else if #[cfg(feature = "lm3s6965evb")] {


### PR DESCRIPTION
This PR:

- make "dummy" a (non-default) choice in riot-rs-boards dispatching
- adds microbit-v2 to the cfg_if dispatch in riot-rs-boards
- adds microbit-v2 building to CI