### PR TITLE
feat: allow overriding  the usb configuration

### DIFF
--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -60,3 +60,4 @@ usb_ethernet = [ "usb", "net" ]
 
 threading = ["dep:riot-rs-core"]
 override_network_config = []
+override_usb_config = []

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -1,3 +1,14 @@
+//! This module provides an opinionated integration of `embassy`.
+//!
+//! To provide a custom USB configuration, enable the feature
+//! `riot_rs_embassy/override_usb_config`, then add this to your code:
+//! ```rust
+//! #[no_mangle]
+//! pub fn riot_rs_usb_config() -> embassy_usb::Config<'static> {
+//!     /// create config here
+//! }
+//! ```
+
 #![no_std]
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]


### PR DESCRIPTION
This PR adds a mechanism for providing custom USB configuration, similar to how it is implemented for network configuration.