### PR TITLE
feat: define our own `assign_resources` macro

### DIFF
--- a/src/riot-rs-embassy/src/assign_resources.rs
+++ b/src/riot-rs-embassy/src/assign_resources.rs
@@ -1,0 +1,51 @@
+// Based on https://github.com/adamgreig/assign-resources/tree/94ad10e2729afdf0fd5a77cd12e68409a982f58a
+// under MIT license
+#[macro_export]
+macro_rules! assign_resources {
+    {
+        $resources: ident,
+        $(
+            $(#[$outer:meta])*
+            $group_name:ident : $group_struct:ident {
+                $(
+                    $(#[$inner:meta])*
+                    $resource_name:ident : $resource_field:ident $(=$resource_alias:ident)?),*
+                $(,)?
+            }
+            $(,)?
+        )+
+    } => {
+        #[allow(dead_code,non_snake_case,missing_docs)]
+        pub struct $resources {
+            $(pub $group_name : $group_struct),*
+        }
+        $(
+            #[allow(dead_code,non_snake_case)]
+            $(#[$outer])*
+            pub struct $group_struct {
+                $(
+                    $(#[$inner])*
+                    pub $resource_name: peripherals::$resource_field
+                ),*
+            }
+        )+
+
+
+        $($($(
+            #[allow(missing_docs)]
+            pub type $resource_alias = peripherals::$resource_field;
+        )?)*)*
+
+        #[macro_export]
+        /// `split_resources!` macro
+        macro_rules! split_resources (
+            ($p:ident) => {
+                $resources {
+                    $($group_name: $group_struct {
+                        $($resource_name: $p.$resource_field.take().ok_or(1)?),*
+                    }),*
+                }
+            }
+        );
+    }
+}

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -2,6 +2,8 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
+pub mod assign_resources;
+
 use linkme::distributed_slice;
 
 use embassy_executor::{InterruptExecutor, Spawner};

--- a/src/riot-rs/src/lib.rs
+++ b/src/riot-rs/src/lib.rs
@@ -6,7 +6,7 @@
 
 pub use riot_rs_buildinfo as buildinfo;
 pub use riot_rs_core::thread;
-pub use riot_rs_embassy as embassy;
+pub use riot_rs_embassy::{self as embassy, assign_resources};
 pub use riot_rs_rt as rt;
 
 // ensure this gets linked


### PR DESCRIPTION
We need our own peripheral-extraction macro compatible with `OptionalPeripherals`.