### PR TITLE
riot-rs-embassy: define_peripherals: fix type alias, allow non_camel_…

### DIFF
--- a/src/riot-rs-embassy/src/define_peripherals.rs
+++ b/src/riot-rs-embassy/src/define_peripherals.rs
@@ -34,10 +34,10 @@ macro_rules! define_peripherals {
             ),*
         }
 
-        $($($(
-            #[allow(missing_docs)]
+        $($(
+            #[allow(missing_docs, non_camel_case_types)]
             pub type $peripheral_alias = peripherals::$peripheral_field;
-        )?)*)*
+        )?)*
 
         impl $peripherals {
             pub fn take_from(


### PR DESCRIPTION
…case_types

This PR fixes setting a type alias like [here](https://gist.github.com/kaspar030/690ab0135547cc5783684fde379112f9#file-cyw43-rs-L18-L25).

Previously:
```
error: attempted to repeat an expression containing no syntax variables matched as repeating at this depth
  --> src/riot-rs-embassy/src/define_peripherals.rs:37:14
   |
37 |           $($($(
   |  ______________^
38 | |             #[allow(missing_docs)]
39 | |             pub type $peripheral_alias = peripherals::$peripheral_field;
40 | |         )?)*)*
   | |_________^

```

... and some non_camel_case linter warnings.