### PR TITLE
examples/embassy-net-tcp: document tcp echo server access via telnet

### DIFF
--- a/examples/embassy-net-tcp/README.md
+++ b/examples/embassy-net-tcp/README.md
@@ -12,4 +12,8 @@ In this folder, run
     laze build -b nrf52840dk run
 
 With the device USB cable connected, a USB ethernet device should pop up.
-RIOT-rs will reply to ping requests on 10.42.0.61.
+RIOT-rs will reply to ping requests on 10.42.0.61 and host a tcp service on
+port 1234 that will echo the input back to the client. It can be accessed with
+e.g., `telnet`:
+
+    telnet 10.42.0.61 1234


### PR DESCRIPTION
This extends the README.md of the embassy-net-tcp example with a line or two about the running telnet server, which seems to be *the feature* of this example.