### PR TITLE
feat(nrf-embassy): re-export the peripherals module

### DIFF
--- a/examples/embassy-http-server/src/pins.rs
+++ b/examples/embassy-http-server/src/pins.rs
@@ -1,7 +1,7 @@
 use riot_rs::define_peripherals;
 
-#[cfg(all(feature = "button-readings", builder = "nrf52840dk"))]
-use embassy_nrf::peripherals;
+#[cfg(feature = "button-readings")]
+use riot_rs::embassy::arch::peripherals;
 
 #[cfg(all(feature = "button-readings", builder = "nrf52840dk"))]
 define_peripherals!(Buttons {

--- a/src/riot-rs-embassy/src/arch/nrf52.rs
+++ b/src/riot-rs-embassy/src/arch/nrf52.rs
@@ -1,10 +1,10 @@
 pub(crate) use embassy_executor::InterruptExecutor as Executor;
-pub use embassy_nrf::interrupt;
 pub use embassy_nrf::interrupt::SWI0_EGU0 as SWI;
 pub use embassy_nrf::{init, OptionalPeripherals};
+pub use embassy_nrf::{interrupt, peripherals};
 
 #[cfg(feature = "usb")]
-use embassy_nrf::{bind_interrupts, peripherals, rng, usb as nrf_usb};
+use embassy_nrf::{bind_interrupts, rng, usb as nrf_usb};
 
 #[cfg(feature = "usb")]
 bind_interrupts!(struct Irqs {
@@ -20,8 +20,10 @@ unsafe fn SWI0_EGU0() {
 
 #[cfg(feature = "usb")]
 pub mod usb {
-    use embassy_nrf::peripherals;
-    use embassy_nrf::usb::{vbus_detect::HardwareVbusDetect, Driver};
+    use embassy_nrf::{
+        peripherals,
+        usb::{vbus_detect::HardwareVbusDetect, Driver},
+    };
 
     use crate::arch;
 


### PR DESCRIPTION
This allows applications to not directly depend on the architecture Embassy crates to get access to peripherals.