### PR TITLE
lib/rbi: use wrapping_sub to calculate available slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
  "embassy-net",
  "embassy-time",
  "embedded-io-async",
+ "heapless 0.8.0",
  "riot-rs",
  "riot-rs-boards",
 ]
@@ -832,6 +833,7 @@ dependencies = [
  "embassy-net",
  "embassy-time",
  "embedded-io-async",
+ "heapless 0.8.0",
  "riot-rs",
  "riot-rs-boards",
 ]

--- a/src/lib/rbi/src/lib.rs
+++ b/src/lib/rbi/src/lib.rs
@@ -42,7 +42,7 @@ impl RingBufferIndex {
 
     /// Returns the number of slots available for `get()`
     pub fn available(&self) -> u8 {
-        self.writes - self.reads
+        self.writes.wrapping_sub(self.reads)
     }
 
     /// Returns `true` if no element is available for `get()`
@@ -152,6 +152,7 @@ mod tests {
                 rb.put(),
                 Some(i as u8 % super::next_smaller_power_of_two(size))
             );
+            assert_eq!(rb.available(), 1);
             assert_eq!(
                 rb.get(),
                 Some(i as u8 % super::next_smaller_power_of_two(size))


### PR DESCRIPTION
Small bug I noticed while viewing the code.

Currently, the `rbi::RingBufferIndex` panics if the more than `u8::MAX`-times elements have been added and removed again. 
The reason for this is that in `RingBufferIndex::available` the `writes` counter has wrapped over, but the `reads` counter hasn't and thus an overflow occurs in the subtraction.
The `counter_overflow_size*` tests didn't catch this because it only occurs if the `writes` counter is already 1 "ahead" of the `reads` counter and then `available` is called (either directly, of by `put`ting another element into the buffer).

This is fixed by simply using `wrapping_sub` as it is done in the other methods.

I added this check to the test, which panicked without this fix. The panic would alternatively also be visible if in said test per iteration always two items would be put and removed again to the rbi.

Lmk if I am missing something.