### PR TITLE
fix: rpi-pico-w cyw43 compile fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sccache --start-server || true # work around https://github.com/ninja-build/ninja/issues/2052
 
-        laze build --partition hash:${{ matrix.partition }} --builders microbit-v2,nrf52840dk,rpi-pico -g
+        laze build --partition hash:${{ matrix.partition }} --builders microbit-v2,nrf52840dk,rpi-pico,rpi-pico-w -g
 
   CI-success:
       if: ${{ always() }}

--- a/src/riot-rs-embassy/src/wifi/cyw43.rs
+++ b/src/riot-rs-embassy/src/wifi/cyw43.rs
@@ -9,9 +9,8 @@ use embassy_rp::{
 
 use riot_rs_utils::str_from_env_or;
 
+use self::rpi_pico_w::{Cyw43Periphs, CywSpi, Irqs, CYW43_PWR};
 use crate::{arch::OptionalPeripherals, make_static};
-
-use self::rpi_pico_w::{Cyw43Periphs, CywSpi, Irqs};
 
 const WIFI_NETWORK: &str = str_from_env_or!("CONFIG_WIFI_NETWORK", "test_network");
 const WIFI_PASSWORD: &str = str_from_env_or!("CONFIG_WIFI_PASSWORD", "test_password");
@@ -31,7 +30,7 @@ pub async fn join(mut control: cyw43::Control<'static>) {
 }
 
 #[embassy_executor::task]
-async fn wifi_cyw43_task(runner: Runner<'static, Output<'static>, CywSpi>) -> ! {
+async fn wifi_cyw43_task(runner: Runner<'static, Output<'static, CYW43_PWR>, CywSpi>) -> ! {
     runner.run().await
 }
 

--- a/src/riot-rs-embassy/src/wifi/cyw43/rpi-pico-w.rs
+++ b/src/riot-rs-embassy/src/wifi/cyw43/rpi-pico-w.rs
@@ -6,8 +6,8 @@ use embassy_rp::{bind_interrupts, pio::InterruptHandler};
 use crate::{arch::peripherals, define_peripherals};
 
 define_peripherals!(Cyw43Periphs {
-    pwr: PIN_23,
-    cs: PIN_25,
+    pwr: PIN_23 = CYW43_PWR,
+    cs: PIN_25 = CYW43_CS,
     pio: PIO0 = CYW43_PIO,
     dma: DMA_CH0 = CYW43_DMA_CH,
     dio: PIN_24,
@@ -18,4 +18,4 @@ bind_interrupts!(pub struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<CYW43_PIO>;
 });
 
-pub type CywSpi = PioSpi<'static, CYW43_PIO, 0, CYW43_DMA_CH>;
+pub type CywSpi = PioSpi<'static, CYW43_CS, CYW43_PIO, 0, CYW43_DMA_CH>;


### PR DESCRIPTION
We're using the released `cyw43`/`cyw43-pio`/`embassy_rp` now, adapt accordingly.