### PR TITLE
feat(embassy-arch): return OptionalPeripherals from init()

### DIFF
--- a/src/riot-rs-embassy/src/arch/dummy.rs
+++ b/src/riot-rs-embassy/src/arch/dummy.rs
@@ -43,8 +43,11 @@ mod executor {
 }
 pub use executor::{Executor, Spawner};
 
-pub fn init(_: OptionalPeripherals) -> Peripherals {
-    Peripherals {}
+#[derive(Default)]
+pub struct Config;
+
+pub fn init(_config: Config) -> OptionalPeripherals {
+    unimplemented!();
 }
 
 pub struct SWI;

--- a/src/riot-rs-embassy/src/arch/nrf52.rs
+++ b/src/riot-rs-embassy/src/arch/nrf52.rs
@@ -1,17 +1,6 @@
 pub(crate) use embassy_executor::InterruptExecutor as Executor;
 pub use embassy_nrf::interrupt::SWI0_EGU0 as SWI;
-pub use embassy_nrf::{init, OptionalPeripherals};
-pub use embassy_nrf::{interrupt, peripherals};
-
-#[cfg(feature = "usb")]
-use embassy_nrf::{bind_interrupts, rng, usb as nrf_usb};
-
-#[cfg(feature = "usb")]
-bind_interrupts!(struct Irqs {
-    USBD => nrf_usb::InterruptHandler<peripherals::USBD>;
-    POWER_CLOCK => nrf_usb::vbus_detect::InterruptHandler;
-    RNG => rng::InterruptHandler<peripherals::RNG>;
-});
+pub use embassy_nrf::{config::Config, interrupt, peripherals, OptionalPeripherals};
 
 #[interrupt]
 unsafe fn SWI0_EGU0() {
@@ -21,18 +10,31 @@ unsafe fn SWI0_EGU0() {
 #[cfg(feature = "usb")]
 pub mod usb {
     use embassy_nrf::{
-        peripherals,
-        usb::{vbus_detect::HardwareVbusDetect, Driver},
+        bind_interrupts, peripherals, rng,
+        usb::{
+            self,
+            vbus_detect::{self, HardwareVbusDetect},
+            Driver,
+        },
     };
 
     use crate::arch;
 
+    bind_interrupts!(struct Irqs {
+        USBD => usb::InterruptHandler<peripherals::USBD>;
+        POWER_CLOCK => vbus_detect::InterruptHandler;
+        RNG => rng::InterruptHandler<peripherals::RNG>;
+    });
+
     pub type UsbDriver = Driver<'static, peripherals::USBD, HardwareVbusDetect>;
 
     pub fn driver(peripherals: &mut arch::OptionalPeripherals) -> UsbDriver {
-        use super::Irqs;
-
         let usbd = peripherals.USBD.take().unwrap();
         Driver::new(usbd, Irqs, HardwareVbusDetect::new(Irqs))
     }
+}
+
+pub fn init(config: Config) -> OptionalPeripherals {
+    let peripherals = embassy_nrf::init(config);
+    OptionalPeripherals::from(peripherals)
 }

--- a/src/riot-rs-embassy/src/arch/rp2040.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040.rs
@@ -1,16 +1,7 @@
 pub(crate) use embassy_executor::InterruptExecutor as Executor;
 pub use embassy_rp::interrupt;
 pub use embassy_rp::interrupt::SWI_IRQ_1 as SWI;
-pub use embassy_rp::{config::Config, peripherals, OptionalPeripherals, Peripherals};
-
-#[cfg(feature = "usb")]
-use embassy_rp::{bind_interrupts, peripherals::USB, usb::InterruptHandler};
-
-// rp2040 usb start
-#[cfg(feature = "usb")]
-bind_interrupts!(struct Irqs {
-    USBCTRL_IRQ => InterruptHandler<USB>;
-});
+pub use embassy_rp::{config::Config, peripherals, OptionalPeripherals};
 
 #[interrupt]
 unsafe fn SWI_IRQ_1() {
@@ -19,23 +10,30 @@ unsafe fn SWI_IRQ_1() {
 
 #[cfg(feature = "usb")]
 pub mod usb {
-    use embassy_rp::peripherals;
-    use embassy_rp::usb::Driver;
+    use embassy_rp::{
+        bind_interrupts, peripherals,
+        usb::{Driver, InterruptHandler},
+    };
 
     use crate::arch;
+
+    bind_interrupts!(struct Irqs {
+        USBCTRL_IRQ => InterruptHandler<peripherals::USB>;
+    });
 
     pub type UsbDriver = Driver<'static, peripherals::USB>;
 
     pub fn driver(peripherals: &mut arch::OptionalPeripherals) -> UsbDriver {
         let usb = peripherals.USB.take().unwrap();
-        Driver::new(usb, super::Irqs)
+        Driver::new(usb, Irqs)
     }
 }
 
-pub fn init(config: Config) -> Peripherals {
+pub fn init(config: Config) -> OptionalPeripherals {
     // SWI & DMA priority need to match. DMA is hard-coded to P3 by upstream.
     use embassy_rp::interrupt::{InterruptExt, Priority};
     SWI.set_priority(Priority::P3);
 
-    embassy_rp::init(config)
+    let peripherals = embassy_rp::init(config);
+    OptionalPeripherals::from(peripherals)
 }

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -56,7 +56,7 @@ pub static EMBASSY_TASKS: [Task] = [..];
 #[distributed_slice(riot_rs_rt::INIT_FUNCS)]
 pub(crate) fn init() {
     riot_rs_rt::debug::println!("riot-rs-embassy::init()");
-    let p = arch::OptionalPeripherals::from(arch::init(Default::default()));
+    let p = arch::init(Default::default());
     EXECUTOR.start(arch::SWI);
     EXECUTOR.spawner().spawn(init_task(p)).unwrap();
 


### PR DESCRIPTION
Useful for #121