### PR TITLE
build(boards): allow to have no boards selected

### DIFF
--- a/src/riot-rs-boards/Cargo.toml
+++ b/src/riot-rs-boards/Cargo.toml
@@ -21,4 +21,6 @@ nucleo-f401re = { optional = true, path = "nucleo-f401re" }
 rpi-pico = { optional = true, path = "rpi-pico" }
 
 [features]
+# Allows to have no boards selected, useful to run platform-independent tooling
+no-boards = []
 rpi-pico-w = ["rpi-pico/rpi-pico-w"]

--- a/src/riot-rs-boards/src/lib.rs
+++ b/src/riot-rs-boards/src/lib.rs
@@ -25,15 +25,15 @@ cfg_if! {
     } else if #[cfg(feature = "rpi-pico-w")] {
         // sharing rpi-pico
         pub use rpi_pico as board;
+    } else if #[cfg(feature = "no-boards")] {
+        // Do nothing
     } else {
         compile_error!("no board feature selected");
     }
 }
 
-use linkme::distributed_slice;
-use riot_rs_rt::INIT_FUNCS;
-
-#[distributed_slice(INIT_FUNCS)]
+#[cfg(not(feature = "no-boards"))]
+#[linkme::distributed_slice(riot_rs_rt::INIT_FUNCS)]
 fn init() {
     board::init();
 }

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -17,6 +17,8 @@ static_cell = { workspace = true }
 [features]
 debug-console = ["riot-rs-rt/debug-console"]
 net = ["riot-rs-embassy/net"]
+# Allows to have no boards selected, useful to run platform-independent tooling
+no-boards = ["riot-rs-boards/no-boards"]
 override-network-config = ["riot-rs-embassy/override-network-config"]
 override-usb-config = ["riot-rs-embassy/override-usb-config"]
 silent-panic = ["riot-rs-rt/silent-panic"]


### PR DESCRIPTION
This allows to run rustdoc and clippy on the top-level `riot-rs` crate.

Not sure whether we want to use a Cargo feature for this eventually, but requiring to have a board selected is currently preventing us for using quite a few tools.