### PR TITLE
ci(docs): check doc generation for the riot-rs crate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,10 +99,9 @@ jobs:
       with:
         args: --verbose --locked -p riot-rs-embassy
 
-    # TODO: we'll eventually want to generate docs for riot-rs instead
     # TODO: we'll eventually want to enable relevant features
     - name: "rustdoc"
-      run: cargo rustdoc -p riot-rs-embassy -- -D warnings
+      run: cargo rustdoc -p riot-rs --features no-boards -- -D warnings
 
     - name: rustfmt
       run: cargo fmt --check --all


### PR DESCRIPTION
We need to select no boards to allow for platform-independent doc generation.