### PR TITLE
(WIP) docs: improve docs for `riot-rs-threads`

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -4,7 +4,56 @@
 
 # User Guide
 
+## Multi-threading
+
+Riot-rs implements a scheduler based on fixed priorities and preemption.
+Within the same priority level, threads are scheduled cooperatively.
+
+Threading can be enabled with the `threading` feature.
+If the feature is enabled, at least one thread **must** be defined.  
+Threads should be implemented using the `riot_rs_macros::thread` proc macro, which takes care of calling the necessary initialization methods and linking the thread function element it into the binary.
+A `ThreadId` between 0 and `riot_rs_threads::THREADS_NUMOF` is assigned to each thread in the order in which the threads are declared (*TODO: is this a defined behavior? Would ease e.g. setting thread\_flags for other threads because the ids are known at compile time, but is it really always ensured?*).
+Optionally, the stacksize and a priority between 1 and `riot_rs_threads::SCHED_PRIO_LEVELS` can be configured. Per default, the stack size is 2048 bytes and priority is 1.
+
+The `riot_rs_threading` crate supports basic synchronization primitives:
+- a synchronous (blocking) channel for sending data between threads (the data must implement `Copy`)
+- a lock that can be used to implement mutually exclusive access to a resource
+- a thread-flags implementation that enables threads to wait for specific flags
+  (*TODO: should the thread\_flags even be mentioned here/ are they meant to be used by users?*)
+
+### Example
+
+```rs
+static CHANNEL: Channel<u8> = riot_rs::thread::channel::Channel::new();
+
+#[riot_rs::thread]
+fn thread0() {
+    println!("Hello from thread 0.");
+    CHANNEL.send(&42);
+}
+
+#[riot_rs::thread(stacksize = 4096, priority = 2)]
+fn thread1() {
+    println!("Hello from thread 1.");
+    let recv = CHANNEL.recv();
+    println!("The answer to the Ultimate Question of Life, the Universe, and Everything is {}.", recv);
+}
+```
+
+(*TODO*)
+
 # Developer Guide
+
+## riot-rs-threads
+
+The `riot-rs-threads` crate implements multi-threading and the scheduler.
+
+It makes heavy use of the `critical_section` crate to ensure that there are no conflicting accesses to the shared thread state.
+
+Threads are managed through the static `Threads` structure, that contains all thread data, runqueues and state information.
+The `EnsureOnce` wrapper around it uses a [`critical_section::Mutex`](https://docs.rs/critical-section/latest/critical_section/struct.Mutex.html) to ensures that each access is marked as a [`critical_section`](https://doc.rust-lang.org/std/cell/struct.RefCell.html), and that a reference is dropped directly after the access.
+
+(*TODO*)
 
 - [Appendices](./appendices.md)
   - [Coding Conventions](./coding-conventions.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -50,8 +50,55 @@ The `riot-rs-threads` crate implements multi-threading and the scheduler.
 
 It makes heavy use of the `critical_section` crate to ensure that there are no conflicting accesses to the shared thread state.
 
-Threads are managed through the static `Threads` structure, that contains all thread data, runqueues and state information.
+Threads are managed through the static `Threads` structure, that contains all thread data, runqueues, and state information.
 The `EnsureOnce` wrapper around it uses a [`critical_section::Mutex`](https://docs.rs/critical-section/latest/critical_section/struct.Mutex.html) to ensures that each access is marked as a [`critical_section`](https://doc.rust-lang.org/std/cell/struct.RefCell.html), and that a reference is dropped directly after the access.
+
+Thread data is stored in the `Thread` structure.
+Apart from general management info like the `ThreadId` and runqueue number (`RunqueueId`), it stores the thread's execution state after a context switch.
+A context switch may happen after the scheduler was triggered.
+On ARM Cortex-M, it is initiated through a PendSV exception, by calling the public function `riot_rs_threads::arch::schedule()`.
+
+### Scheduling
+
+The scheduler is triggered in the following cases:
+- The current thread is blocked on a resource.
+- The current thread cooperatively yields to another thread with the same priority.
+- The current thread sleeps.
+- The current thread has run to completion.
+- Another thread was unblocked on a resource or woken up from sleep.
+
+Triggering the scheduler doesn't necessarily imply a thread switch.
+In particular in the last case, the switch only occurs if the now unblocked thread has a higher priority than the current one.
+
+The runqueue lives in a separate crate `riot_rs_runqueue`.
+It is implemented as circular linked lists for each priority level, to which `ThreadId`s can be added and removed.
+The runqueue always returns the head from the highest-priority list.
+Within a priority list, the head can be advanced if a thread cooperatively yields.
+
+If the scheduler is triggered and all runqueues are empty, sleep mode is entered until an interrupt occurs.
+
+### Context Switching
+
+(*TODO: is this arch-specific or always the case?*)
+
+Context switching is implemented in the `riot_rs-threads::arch` module.
+
+Following the initial PendSV exception (for Cortex-M), the arch-specific exception handler calls the scheduler to prompt for a context switch.  
+If a context switch is required, the following steps occur:
+1. the scheduler:
+   - updates the state in `Threads`
+   - stores the stack pointer of the old thread
+   - returns:
+      - pointer to memory for storing the register state of the old thread
+      - pointer to memory location for loading the register state of the new thread
+      - the new stack pointer
+2. the arch-specific handler:
+   - stores the current register state
+   - loads the new register state
+   - updates the stack pointer
+3. return from exception
+
+### Thread Creation
 
 (*TODO*)
 

--- a/src/riot-rs-rt/src/threading.rs
+++ b/src/riot-rs-rt/src/threading.rs
@@ -3,6 +3,10 @@ use riot_rs_threads::{start_threading, THREAD_FNS};
 /// # Safety
 ///
 /// The caller must ensure that this function is only called once.
+///
+/// # Panics
+///
+/// Panics if no thread exists.
 pub unsafe fn start() -> ! {
     for thread_fn in THREAD_FNS {
         thread_fn();

--- a/src/riot-rs-runqueue/src/runqueue.rs
+++ b/src/riot-rs-runqueue/src/runqueue.rs
@@ -4,23 +4,26 @@ use self::clist::CList;
 
 const USIZE_BITS: usize = mem::size_of::<usize>() * 8;
 
+/// Runqueue number
 pub type RunqueueId = u8;
 pub type ThreadId = u8;
 
 /// Runqueue for `N_QUEUES`, supporting `N_THREADS` total.
 ///
 /// Assumptions:
-/// - higher [`RunqueueId`] means higher priority
 /// - runqueue numbers (corresponding priorities) are 0..N_QUEUES (exclusive)
+/// - higher runqueue number ([`RunqueueId`]) means higher priority
 /// - runqueue numbers fit in usize bits (supporting max 32 priority levels)
-/// - pids range from 0..N_THREADS
-/// - N_THREADS is <255 (as u8 is used to store them, but 0xFF is used as
+/// - [`ThreadId`]s range from 0..N_THREADS
+/// - `N_THREADS`` is <255 (as u8 is used to store them, but 0xFF is used as
 ///   special value)
 ///
-///   The current implementation needs an usize for the bit cache,
-///   an [u8; N_QUEUES] array for the list tail indexes
-///   and an [u8; N_THREADS] for the list next indexes.
+/// The current implementation needs an usize for the bit cache,
+/// an `[u8; N_QUEUES]` array for the list tail indexes
+/// and an `[u8; N_THREADS]` for the list next indexes.
 pub struct RunQueue<const N_QUEUES: usize, const N_THREADS: usize> {
+    /// Bitcache that represents the currently used queues 
+    /// in `0..N_QUEUES`.
     bitcache: usize,
     queues: clist::CList<N_QUEUES, N_THREADS>,
 }
@@ -35,7 +38,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         }
     }
 
-    /// add thread with pid n to runqueue number rq
+    /// Add thread with pid `n` to runqueue number `rq`.
     pub fn add(&mut self, n: ThreadId, rq: RunqueueId) {
         debug_assert!((n as usize) < N_THREADS);
         debug_assert!((rq as usize) < N_QUEUES);
@@ -43,9 +46,12 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         self.queues.push(n, rq);
     }
 
-    /// remove thread with pid n from runqueue number rq
-    /// @note: this implementation fails if "n" is not the queue's head.
-    /// This is fine, RIOT-rs only ever calls del() for the current thread.
+    /// Remove thread with pid `n` from runqueue number `rq`
+    /// 
+    /// # Safety 
+    /// 
+    /// Panics if `n` is not the queue's head.
+    /// This is fine, RIOT-rs only ever calls `del()` for the current thread.
     pub fn del(&mut self, n: ThreadId, rq: RunqueueId) {
         debug_assert!((n as usize) < N_THREADS);
         debug_assert!((rq as usize) < N_QUEUES);
@@ -61,9 +67,12 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         USIZE_BITS as u32 - val.leading_zeros()
     }
 
-    /// get pid that should run next
-    /// returns the next runnable thread of
-    /// the runqueue with the highest index
+    /// Get the pid that should run next.
+    /// 
+    /// Returns the next runnable thread of
+    /// the runqueue with the highest index.
+    // 
+    // TODO: Return `ThreadId` instead of u8?
     pub fn get_next(&self) -> Option<u8> {
         let rq_ffs = Self::ffs(self.bitcache);
         if rq_ffs > 0 {
@@ -74,8 +83,9 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         }
     }
 
-    /// advance runqueue number rq
-    /// (this is used to "yield" to another thread of *the same* priority)
+    /// Advance runqueue number `rq`.
+    /// 
+    /// This is used to "yield" to another thread of *the same* priority.
     pub fn advance(&mut self, rq: RunqueueId) {
         debug_assert!((rq as usize) < N_QUEUES);
         self.queues.advance(rq)
@@ -83,10 +93,10 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
 }
 
 mod clist {
-    // this module implements an array of N_QUEUES circular linked lists over an
-    // array of size N_THREADS.
-    // the array is used for "next" pointers, so each integer value in the array
-    // corresponds to one element, which can only be in one of the lists.
+    //! This module implements an array of `N_QUEUES`` circular linked lists over an
+    //! array of size `N_THREADS`.
+    //! The array is used for "next" pointers, so each integer value in the array
+    //! corresponds to one element, which can only be in one of the lists.
     use super::{RunqueueId, ThreadId};
 
     #[derive(Debug, Copy, Clone)]

--- a/src/riot-rs-runqueue/src/runqueue.rs
+++ b/src/riot-rs-runqueue/src/runqueue.rs
@@ -22,7 +22,7 @@ pub type ThreadId = u8;
 /// an `[u8; N_QUEUES]` array for the list tail indexes
 /// and an `[u8; N_THREADS]` for the list next indexes.
 pub struct RunQueue<const N_QUEUES: usize, const N_THREADS: usize> {
-    /// Bitcache that represents the currently used queues 
+    /// Bitcache that represents the currently used queues
     /// in `0..N_QUEUES`.
     bitcache: usize,
     queues: clist::CList<N_QUEUES, N_THREADS>,
@@ -47,9 +47,9 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
     }
 
     /// Remove thread with pid `n` from runqueue number `rq`
-    /// 
-    /// # Safety 
-    /// 
+    ///
+    /// # Safety
+    ///
     /// Panics if `n` is not the queue's head.
     /// This is fine, RIOT-rs only ever calls `del()` for the current thread.
     pub fn del(&mut self, n: ThreadId, rq: RunqueueId) {
@@ -68,10 +68,10 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
     }
 
     /// Get the pid that should run next.
-    /// 
+    ///
     /// Returns the next runnable thread of
     /// the runqueue with the highest index.
-    // 
+    //
     // TODO: Return `ThreadId` instead of u8?
     pub fn get_next(&self) -> Option<u8> {
         let rq_ffs = Self::ffs(self.bitcache);
@@ -84,7 +84,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
     }
 
     /// Advance runqueue number `rq`.
-    /// 
+    ///
     /// This is used to "yield" to another thread of *the same* priority.
     pub fn advance(&mut self, rq: RunqueueId) {
         debug_assert!((rq as usize) < N_QUEUES);

--- a/src/riot-rs-runqueue/src/runqueue.rs
+++ b/src/riot-rs-runqueue/src/runqueue.rs
@@ -4,7 +4,7 @@ use self::clist::CList;
 
 const USIZE_BITS: usize = mem::size_of::<usize>() * 8;
 
-/// Runqueue number
+/// Runqueue number.
 pub type RunqueueId = u8;
 pub type ThreadId = u8;
 
@@ -15,7 +15,7 @@ pub type ThreadId = u8;
 /// - higher runqueue number ([`RunqueueId`]) means higher priority
 /// - runqueue numbers fit in usize bits (supporting max 32 priority levels)
 /// - [`ThreadId`]s range from 0..N_THREADS
-/// - `N_THREADS`` is <255 (as u8 is used to store them, but 0xFF is used as
+/// - `N_THREADS` is <255 (as u8 is used to store them, but 0xFF is used as
 ///   special value)
 ///
 /// The current implementation needs an usize for the bit cache,
@@ -38,7 +38,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         }
     }
 
-    /// Add thread with pid `n` to runqueue number `rq`.
+    /// Adds thread with pid `n` to runqueue number `rq`.
     pub fn add(&mut self, n: ThreadId, rq: RunqueueId) {
         debug_assert!((n as usize) < N_THREADS);
         debug_assert!((rq as usize) < N_QUEUES);
@@ -46,9 +46,9 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         self.queues.push(n, rq);
     }
 
-    /// Remove thread with pid `n` from runqueue number `rq`
+    /// Removes thread with pid `n` from runqueue number `rq`.
     ///
-    /// # Safety
+    /// # Panics
     ///
     /// Panics if `n` is not the queue's head.
     /// This is fine, RIOT-rs only ever calls `del()` for the current thread.
@@ -67,7 +67,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         USIZE_BITS as u32 - val.leading_zeros()
     }
 
-    /// Get the pid that should run next.
+    /// Returns the pid that should run next.
     ///
     /// Returns the next runnable thread of
     /// the runqueue with the highest index.
@@ -83,7 +83,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         }
     }
 
-    /// Advance runqueue number `rq`.
+    /// Advances runqueue number `rq`.
     ///
     /// This is used to "yield" to another thread of *the same* priority.
     pub fn advance(&mut self, rq: RunqueueId) {
@@ -93,7 +93,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
 }
 
 mod clist {
-    //! This module implements an array of `N_QUEUES`` circular linked lists over an
+    //! This module implements an array of `N_QUEUES` circular linked lists over an
     //! array of size `N_THREADS`.
     //! The array is used for "next" pointers, so each integer value in the array
     //! corresponds to one element, which can only be in one of the lists.

--- a/src/riot-rs-runqueue/src/runqueue.rs
+++ b/src/riot-rs-runqueue/src/runqueue.rs
@@ -7,10 +7,10 @@ const USIZE_BITS: usize = mem::size_of::<usize>() * 8;
 pub type RunqueueId = u8;
 pub type ThreadId = u8;
 
-/// Runqueue for N_QUEUES, supporting N_THREADS total.
+/// Runqueue for `N_QUEUES`, supporting `N_THREADS` total.
 ///
-/// assumptions:
-/// - higher runqueue number means higher priority
+/// Assumptions:
+/// - higher [`RunqueueId`] means higher priority
 /// - runqueue numbers (corresponding priorities) are 0..N_QUEUES (exclusive)
 /// - runqueue numbers fit in usize bits (supporting max 32 priority levels)
 /// - pids range from 0..N_THREADS

--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -12,14 +12,14 @@ use crate::{cleanup, THREADS};
 /// `func`.
 ///
 ///  +-------------+ <- sp
-///  |    arg      | 
-///  | (dummy r1)  | 
-///  | (dummy r2)  | 
-///  | (dummy r3)  | 
-///  | (dummy r12) | 
+///  |    arg      |
+///  | (dummy r1)  |
+///  | (dummy r2)  |
+///  | (dummy r3)  |
+///  | (dummy r12) |
 ///  | *cleanup    |
-///  |  *func      | 
-///  | 0x01000000  | 
+///  |  *func      |
+///  | 0x01000000  |
 ///  +-------------+
 ///
 /// returns the sp
@@ -42,8 +42,8 @@ pub(crate) fn setup_stack(stack: &mut [u8], func: usize, arg: usize) -> usize {
 }
 
 /// Triggers a PendSV exception to initiate a context switch.
-/// 
-/// If this is called from within a critical section the exception 
+///
+/// If this is called from within a critical section the exception
 /// happens after the critical section was left.
 #[inline(always)]
 pub fn schedule() {
@@ -194,7 +194,7 @@ unsafe extern "C" fn PendSV() {
 ///
 /// It selects the next thread that should run from the runqueue.
 /// This may equal be current thread, or a new one.
-/// 
+///
 /// Input:
 /// - old_sp (`r0``): the stack pointer of the currently running thread.
 ///

--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -193,7 +193,7 @@ unsafe extern "C" fn PendSV() {
 /// Scheduler
 ///
 /// It selects the next thread that should run from the runqueue.
-/// This may equal be current thread, or a new one.
+/// This may be current thread, or a new one.
 ///
 /// Input:
 /// - old_sp (`r0``): the stack pointer of the currently running thread.
@@ -204,7 +204,7 @@ unsafe extern "C" fn PendSV() {
 ///   - `r0`: pointer to [`Thread::high_regs`] from old thread (to store old register state)
 ///   - `r1`: pointer to [`Thread::high_regs`] from new thread (to load new register state)
 ///   - `r2`: stack-pointer for new thread
-//
+///
 /// On Cortex-M, this is called in PendSV.
 // TODO: make arch independent, or move to arch
 #[no_mangle]

--- a/src/riot-rs-threads/src/channel.rs
+++ b/src/riot-rs-threads/src/channel.rs
@@ -1,3 +1,5 @@
+//! Synchronous channel implementation for sending data between threads.
+
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;

--- a/src/riot-rs-threads/src/ensure_once.rs
+++ b/src/riot-rs-threads/src/ensure_once.rs
@@ -1,4 +1,4 @@
-//! This module provides a Mutex-protected RefCell - basically a way to ensure
+//! This module provides a Mutex-protected RefCell --- basically a way to ensure
 //! at runtime that some reference is used only once.
 use core::cell::{Ref, RefCell, RefMut};
 use critical_section::{with, CriticalSection, Mutex};

--- a/src/riot-rs-threads/src/ensure_once.rs
+++ b/src/riot-rs-threads/src/ensure_once.rs
@@ -1,5 +1,5 @@
-/// This module provides a Mutex-protected RefCell - basically a way to ensure
-/// at runtime that some reference is used only once.
+//! This module provides a Mutex-protected RefCell - basically a way to ensure
+//! at runtime that some reference is used only once.
 use core::cell::{Ref, RefCell, RefMut};
 use critical_section::{with, CriticalSection, Mutex};
 

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -13,11 +13,8 @@ mod ensure_once;
 mod thread;
 mod threadlist;
 
-/// Synchronous channel implementation for sending data between threads.
 pub mod channel;
-/// Lock implementation that doesn't hold data.
 pub mod lock;
-/// Thread flags.
 pub mod thread_flags;
 
 pub use arch::schedule;
@@ -42,9 +39,9 @@ pub static THREAD_FNS: [ThreadFn] = [..];
 
 /// Struct holding all scheduler state
 pub struct Threads {
-    /// global thread runqueue
+    /// Global thread runqueue.
     runqueue: RunQueue<SCHED_PRIO_LEVELS, THREADS_NUMOF>,
-    /// The actual TCBs
+    /// The actual TCBs.
     threads: [Thread; THREADS_NUMOF],
     /// `Some` when a thread is blocking another thread due to conflicting
     /// resource access.
@@ -67,7 +64,7 @@ impl Threads {
     //     &mut self.threads[thread_id as usize]
     // }
 
-    /// Get checked mutable access to the thread data of the currently
+    /// Returns checked mutable access to the thread data of the currently
     /// running thread.
     ///
     /// Returns `None` if there is no current thread.
@@ -80,7 +77,7 @@ impl Threads {
         self.current_thread
     }
 
-    /// Create a new thread.
+    /// Creates a new thread.
     ///
     /// This sets up the stack and TCB for this thread.
     ///
@@ -108,9 +105,10 @@ impl Threads {
     //     &self.threads[thread_id as usize]
     // }
 
-    /// Get mutable access to any thread data.
+    /// Returns mutable access to any thread data.
     ///
-    /// # Safety
+    /// # Panics
+    ///
     /// Panics if `thread_id` is >= [`THREADS_NUMOF`].
     /// If the thread for this `thread_id` is in an invalid state, the
     /// data in the returned [`Thread`] is undefined, i.e. empty or outdated.
@@ -137,9 +135,9 @@ impl Threads {
         }
     }
 
-    /// Set the state of a thread.
+    /// Sets the state of a thread.
     ///
-    /// This function handles adding/removing the thread to the Runqueue depending
+    /// This function handles adding/ removing the thread to the Runqueue depending
     /// on its previous or new state.
     pub(crate) fn set_state(&mut self, pid: ThreadId, state: ThreadState) -> ThreadState {
         let thread = &mut self.threads[pid as usize];
@@ -163,7 +161,7 @@ impl Threads {
     }
 }
 
-/// Start threading.
+/// Starts threading.
 ///
 /// Supposed to be started early on by OS startup code.
 ///
@@ -206,7 +204,7 @@ impl<T> Arguable for &T {
 }
 
 /// Low-level function to create a thread that runs
-///  `func` with `arg`.
+/// `func` with `arg`.
 ///
 /// This sets up the stack for the thread and adds it to
 /// the runqueue.
@@ -220,7 +218,7 @@ pub fn thread_create<T: Arguable + Send>(
     unsafe { thread_create_raw(func as usize, arg, stack, prio) }
 }
 
-/// Create a thread, low-level
+/// Creates a thread, low-level.
 ///
 /// # Safety
 /// only use when you know what you are doing.
@@ -232,7 +230,7 @@ pub unsafe fn thread_create_raw(func: usize, arg: usize, stack: &mut [u8], prio:
     })
 }
 
-/// Get the [`ThreadState`] for this `thread_id`.
+/// Returns the [`ThreadState`] for this `thread_id`.
 ///
 /// Returns `None` if `thread_id` is out of bound or no thread with
 /// valid state exists.
@@ -248,7 +246,7 @@ pub fn current_pid() -> Option<ThreadId> {
     THREADS.with(|threads| threads.current_pid())
 }
 
-/// Check if a given [`ThreadId`] is valid
+/// Checks if a given [`ThreadId`] is valid
 pub fn is_valid_pid(thread_id: ThreadId) -> bool {
     THREADS.with(|threads| threads.is_valid_pid(thread_id))
 }
@@ -269,7 +267,7 @@ fn cleanup() -> ! {
     unreachable!();
 }
 
-/// "Yield" to another thread with the same priority.
+/// "Yields" to another thread with the same priority.
 pub fn yield_same() {
     THREADS.with_mut(|mut threads| {
         let runqueue = threads.current().unwrap().prio;
@@ -278,7 +276,7 @@ pub fn yield_same() {
     })
 }
 
-/// Suspend/pause the current thread's execution.
+/// Suspends/ pauses the current thread's execution.
 pub fn sleep() {
     THREADS.with_mut(|mut threads| {
         let pid = threads.current_pid().unwrap();
@@ -287,7 +285,7 @@ pub fn sleep() {
     });
 }
 
-/// Wake-up a thread and add it to the runqueue.
+/// Wakes up a thread and adds it to the runqueue.
 ///
 /// Returns `false` if no paused thread exists for `thread_id`.
 pub fn wakeup(thread_id: ThreadId) -> bool {

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -10,8 +10,8 @@ pub use riot_rs_runqueue::{RunqueueId, ThreadId};
 
 mod arch;
 mod ensure_once;
-mod threadlist;
 mod thread;
+mod threadlist;
 
 /// Synchronous channel implementation for sending data between threads.
 pub mod channel;
@@ -67,9 +67,9 @@ impl Threads {
     //     &mut self.threads[thread_id as usize]
     // }
 
-    /// Get checked mutable access to the thread data of the currently 
+    /// Get checked mutable access to the thread data of the currently
     /// running thread.
-    /// 
+    ///
     /// Returns `None` if there is no current thread.
     pub(crate) fn current(&mut self) -> Option<&mut Thread> {
         self.current_thread
@@ -81,9 +81,9 @@ impl Threads {
     }
 
     /// Create a new thread.
-    /// 
+    ///
     /// This sets up the stack and TCB for this thread.
-    /// 
+    ///
     /// Returns `None` if there is no free thread slot.
     pub(crate) fn create(
         &mut self,
@@ -109,7 +109,7 @@ impl Threads {
     // }
 
     /// Get mutable access to any thread data.
-    /// 
+    ///
     /// # Safety
     /// Panics if `thread_id` is >= [`THREADS_NUMOF`].
     /// If the thread for this `thread_id` is in an invalid state, the
@@ -207,7 +207,7 @@ impl<T> Arguable for &T {
 
 /// Low-level function to create a thread that runs
 ///  `func` with `arg`.
-/// 
+///
 /// This sets up the stack for the thread and adds it to
 /// the runqueue.
 pub fn thread_create<T: Arguable + Send>(
@@ -232,8 +232,8 @@ pub unsafe fn thread_create_raw(func: usize, arg: usize, stack: &mut [u8], prio:
     })
 }
 
-/// Get the [`ThreadState`] for this `thread_id`. 
-/// 
+/// Get the [`ThreadState`] for this `thread_id`.
+///
 /// Returns `None` if `thread_id` is out of bound or no thread with
 /// valid state exists.
 pub fn get_state(thread_id: ThreadId) -> Option<ThreadState> {
@@ -288,8 +288,8 @@ pub fn sleep() {
 }
 
 /// Wake-up a thread and add it to the runqueue.
-/// 
-/// Returns `false` if no paused thread exists for `thread_id`. 
+///
+/// Returns `false` if no paused thread exists for `thread_id`.
 pub fn wakeup(thread_id: ThreadId) -> bool {
     THREADS.with_mut(|mut threads| {
         if let Some(state) = threads.get_state(thread_id) {

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -166,7 +166,12 @@ impl Threads {
 /// Supposed to be started early on by OS startup code.
 ///
 /// # Safety
+///
 /// This may only be called once.
+///
+/// # Panics
+///
+/// Panics if no thread exists.
 pub unsafe fn start_threading() {
     // faking a critical section to get THREADS
     let cs = CriticalSection::new();

--- a/src/riot-rs-threads/src/lock.rs
+++ b/src/riot-rs-threads/src/lock.rs
@@ -93,7 +93,7 @@ impl Lock {
         critical_section::with(|cs| {
             let state = unsafe { &mut *self.state.get() };
             match state {
-                LockState::Unlocked => {} // TODO: panic?
+                LockState::Unlocked => {}
                 LockState::Locked(waiters) => {
                     if waiters.pop(cs).is_none() {
                         *state = LockState::Unlocked

--- a/src/riot-rs-threads/src/lock.rs
+++ b/src/riot-rs-threads/src/lock.rs
@@ -4,7 +4,7 @@ use core::cell::UnsafeCell;
 use super::threadlist::ThreadList;
 use super::ThreadState;
 
-/// A basic locking object
+/// A basic locking object.
 ///
 /// A `Lock` behaves like a Mutex, but carries no data.
 /// This is supposed to be used to implement other locking primitives.

--- a/src/riot-rs-threads/src/thread.rs
+++ b/src/riot-rs-threads/src/thread.rs
@@ -13,9 +13,9 @@ pub struct Thread {
     /// Id of the thread between 0..[`super::THREADS_NUMOF`].
     /// Ids are unique while a thread is alive but reused after a thread finished.
     pub pid: ThreadId,
-    // TODO
+    /// Flags set for the thread.
     pub flags: ThreadFlags,
-    // Saved non-volatile registers.
+    /// Saved non-volatile registers.
     pub(crate) high_regs: [usize; 8],
 }
 
@@ -24,9 +24,12 @@ pub struct Thread {
 pub enum ThreadState {
     /// No active thread.
     Invalid,
-    /// Currently running.
+    /// Ready to run.
+    /// 
+    /// This doesn't necessarily mean that the thread is currently running,
+    /// but rather that it is in the runqueue.
     Running,
-    /// Suspended / paused, but ready to run.
+    /// Suspended / paused.
     Paused,
     /// Waiting to acquire a [`super::lock::Lock`].
     LockBlocked,

--- a/src/riot-rs-threads/src/thread.rs
+++ b/src/riot-rs-threads/src/thread.rs
@@ -25,7 +25,7 @@ pub enum ThreadState {
     /// No active thread.
     Invalid,
     /// Ready to run.
-    /// 
+    ///
     /// This doesn't necessarily mean that the thread is currently running,
     /// but rather that it is in the runqueue.
     Running,

--- a/src/riot-rs-threads/src/thread.rs
+++ b/src/riot-rs-threads/src/thread.rs
@@ -1,31 +1,46 @@
 pub use crate::{thread_flags::ThreadFlags, RunqueueId, ThreadId};
 
-/// Main struct for holding thread data
+/// Main struct for holding thread data.
 #[derive(Debug)]
 pub struct Thread {
+    /// Saved stack pointer after context switch.
     pub sp: usize,
+    /// The thread's current state.
     pub state: ThreadState,
+    /// Priority of the thread between 0..[`super::SCHED_PRIO_LEVELS`].
+    /// Multiple threads may have the same priority.
     pub prio: RunqueueId,
+    /// Id of the thread between 0..[`super::THREADS_NUMOF`].
+    /// Ids are unique while a thread is alive but reused after a thread finished.
     pub pid: ThreadId,
+    // TODO
     pub flags: ThreadFlags,
+    // Saved non-volatile registers.
     pub(crate) high_regs: [usize; 8],
 }
 
 /// Possible states of a thread
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum ThreadState {
+    /// No active thread.
     Invalid,
+    /// Currently running.
     Running,
+    /// Suspended / paused, but ready to run.
     Paused,
+    /// Waiting to acquire a [`super::lock::Lock`].
     LockBlocked,
+    /// Waiting for [`ThreadFlags`] to be set.
     FlagBlocked(crate::thread_flags::WaitMode),
+    /// Waiting to receive on a [`super::channel::Channel`], i.e. waiting for the sender.
     ChannelRxBlocked(usize),
+    /// Waiting to send on a [`super::channel::Channel`], i.e. waiting for the receiver.
     ChannelTxBlocked(usize),
     Zombie,
 }
 
 impl Thread {
-    /// create a default Thread object
+    /// Create an empty [`Thread`] object with [`ThreadState::Invalid`].
     pub const fn default() -> Thread {
         Thread {
             sp: 0,

--- a/src/riot-rs-threads/src/thread.rs
+++ b/src/riot-rs-threads/src/thread.rs
@@ -43,7 +43,7 @@ pub enum ThreadState {
 }
 
 impl Thread {
-    /// Create an empty [`Thread`] object with [`ThreadState::Invalid`].
+    /// Creates an empty [`Thread`] object with [`ThreadState::Invalid`].
     pub const fn default() -> Thread {
         Thread {
             sp: 0,

--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -24,6 +24,8 @@ pub fn set(thread_id: ThreadId, mask: ThreadFlags) {
 }
 
 /// Waits until all flags in `mask` are set for the current thread.
+/// 
+/// Returns the set flags for this mask and clears them for the thread.
 ///
 /// # Panics
 ///
@@ -37,6 +39,8 @@ pub fn wait_all(mask: ThreadFlags) -> ThreadFlags {
 }
 
 /// Waits until any flag in `mask` is set for the current thread.
+/// 
+/// Returns all set flags for this mask and clears them for the thread.
 ///
 /// # Panics
 ///
@@ -49,6 +53,14 @@ pub fn wait_any(mask: ThreadFlags) -> ThreadFlags {
     }
 }
 
+/// Waits until any flag in `mask` is set for the current thread.
+/// 
+/// Compared to [`wait_any`], this returns and clears only one flag 
+/// from the mask.
+///
+/// # Panics
+///
+/// Panics if this is called outside of a thread context.
 pub fn wait_one(mask: ThreadFlags) -> ThreadFlags {
     loop {
         if let Some(flags) = THREADS.with_mut(|mut threads| threads.flag_wait_one(mask)) {

--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -11,10 +11,10 @@ pub enum WaitMode {
 }
 
 /// Set flags for a thread.
-/// 
+///
 /// If the thread was blocked on these flags it's unblocked and added
 /// to the runqueue.
-/// 
+///
 /// # Safety
 /// Panics if no valid thread for `thread_id` exists.
 pub fn set(thread_id: ThreadId, mask: ThreadFlags) {
@@ -22,7 +22,7 @@ pub fn set(thread_id: ThreadId, mask: ThreadFlags) {
 }
 
 /// Wait until all flags in `mask` are set for the current thread.
-/// 
+///
 /// # Safety
 /// Panics if this is called outside of a thread context.
 pub fn wait_all(mask: ThreadFlags) -> ThreadFlags {
@@ -34,7 +34,7 @@ pub fn wait_all(mask: ThreadFlags) -> ThreadFlags {
 }
 
 /// Wait until any flag in `mask` is set for the current thread.
-/// 
+///
 /// # Safety
 /// Panics if this is called outside of a thread context.
 pub fn wait_any(mask: ThreadFlags) -> ThreadFlags {
@@ -54,7 +54,7 @@ pub fn wait_one(mask: ThreadFlags) -> ThreadFlags {
 }
 
 /// Clear flags for the current thread.
-/// 
+///
 /// # Safety
 /// Panics if this is called outside of a thread context.
 pub fn clear(mask: ThreadFlags) -> ThreadFlags {
@@ -67,7 +67,7 @@ pub fn clear(mask: ThreadFlags) -> ThreadFlags {
 }
 
 /// Get the flags set for the current thread.
-/// 
+///
 /// # Safety
 /// Panics if this is called outside of a thread context.
 pub fn get() -> ThreadFlags {

--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -1,3 +1,4 @@
+//! Thread flags.
 use crate::{ThreadId, ThreadState, Threads, THREADS};
 
 /// Bitmask that represent the flags that are set for a thread.
@@ -10,20 +11,22 @@ pub enum WaitMode {
     All(ThreadFlags),
 }
 
-/// Set flags for a thread.
+/// Sets flags for a thread.
 ///
 /// If the thread was blocked on these flags it's unblocked and added
 /// to the runqueue.
 ///
-/// # Safety
+/// # Panics
+///
 /// Panics if no valid thread for `thread_id` exists.
 pub fn set(thread_id: ThreadId, mask: ThreadFlags) {
     THREADS.with_mut(|mut threads| threads.flag_set(thread_id, mask))
 }
 
-/// Wait until all flags in `mask` are set for the current thread.
+/// Waits until all flags in `mask` are set for the current thread.
 ///
-/// # Safety
+/// # Panics
+///
 /// Panics if this is called outside of a thread context.
 pub fn wait_all(mask: ThreadFlags) -> ThreadFlags {
     loop {
@@ -33,9 +36,10 @@ pub fn wait_all(mask: ThreadFlags) -> ThreadFlags {
     }
 }
 
-/// Wait until any flag in `mask` is set for the current thread.
+/// Waits until any flag in `mask` is set for the current thread.
 ///
-/// # Safety
+/// # Panics
+///
 /// Panics if this is called outside of a thread context.
 pub fn wait_any(mask: ThreadFlags) -> ThreadFlags {
     loop {
@@ -53,9 +57,10 @@ pub fn wait_one(mask: ThreadFlags) -> ThreadFlags {
     }
 }
 
-/// Clear flags for the current thread.
+/// Clears flags for the current thread.
 ///
-/// # Safety
+/// # Panics
+///
 /// Panics if this is called outside of a thread context.
 pub fn clear(mask: ThreadFlags) -> ThreadFlags {
     THREADS.with_mut(|mut threads| {
@@ -66,9 +71,10 @@ pub fn clear(mask: ThreadFlags) -> ThreadFlags {
     })
 }
 
-/// Get the flags set for the current thread.
+/// Returns the flags set for the current thread.
 ///
-/// # Safety
+/// # Panics
+///
 /// Panics if this is called outside of a thread context.
 pub fn get() -> ThreadFlags {
     // TODO: current() requires us to use mutable `threads` here

--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -24,7 +24,7 @@ pub fn set(thread_id: ThreadId, mask: ThreadFlags) {
 }
 
 /// Waits until all flags in `mask` are set for the current thread.
-/// 
+///
 /// Returns the set flags for this mask and clears them for the thread.
 ///
 /// # Panics
@@ -39,7 +39,7 @@ pub fn wait_all(mask: ThreadFlags) -> ThreadFlags {
 }
 
 /// Waits until any flag in `mask` is set for the current thread.
-/// 
+///
 /// Returns all set flags for this mask and clears them for the thread.
 ///
 /// # Panics
@@ -54,8 +54,8 @@ pub fn wait_any(mask: ThreadFlags) -> ThreadFlags {
 }
 
 /// Waits until any flag in `mask` is set for the current thread.
-/// 
-/// Compared to [`wait_any`], this returns and clears only one flag 
+///
+/// Compared to [`wait_any`], this returns and clears only one flag
 /// from the mask.
 ///
 /// # Panics

--- a/src/riot-rs-threads/src/threadlist.rs
+++ b/src/riot-rs-threads/src/threadlist.rs
@@ -2,18 +2,20 @@ use critical_section::CriticalSection;
 
 use crate::{arch, ThreadId, ThreadState, THREADS};
 
+/// Manages blocked [`super::Thread`]s for a resource, and triggering the scheduler when needed.
 #[derive(Debug)]
 pub struct ThreadList {
+    /// Next thread to run once the resource is available.
     pub head: Option<ThreadId>,
 }
 
 impl ThreadList {
-    /// Creates a new empty`ThreadList`
+    /// Creates a new empty [`ThreadList`]
     pub const fn new() -> Self {
         Self { head: None }
     }
 
-    /// Puts the current thread into this `ThreadList`.
+    /// Puts the current (blocked) thread into this [`ThreadList`] and triggers the scheduler.
     pub fn put_current(&mut self, cs: CriticalSection, state: ThreadState) {
         THREADS.with_mut_cs(cs, |mut threads| {
             let thread_id = threads.current_thread.unwrap();
@@ -24,12 +26,12 @@ impl ThreadList {
         });
     }
 
-    /// Removes the head from this `ThreadList`
+    /// Removes the head from this [`ThreadList`].
     ///
-    /// Sets the thread's `ThreadState` to `ThreadState::Running` and triggers
+    /// Sets the thread's [`ThreadState`] to [`ThreadState::Running`] and triggers
     /// the scheduler.
     ///
-    /// Returns the thread's `ThreadId` and it's previous `ThreadState`.
+    /// Returns the thread's [`ThreadId`] and it's previous [`ThreadState`].
     pub fn pop(&mut self, cs: CriticalSection) -> Option<(ThreadId, ThreadState)> {
         if let Some(head) = self.head {
             let old_state = THREADS.with_mut_cs(cs, |mut threads| {
@@ -44,7 +46,7 @@ impl ThreadList {
         }
     }
 
-    /// Determines if this `ThreadList` is empty
+    /// Determines if this [`ThreadList`] is empty
     pub fn is_empty(&self, _cs: CriticalSection) -> bool {
         self.head.is_none()
     }

--- a/src/riot-rs-threads/src/threadlist.rs
+++ b/src/riot-rs-threads/src/threadlist.rs
@@ -31,7 +31,7 @@ impl ThreadList {
     /// Sets the thread's [`ThreadState`] to [`ThreadState::Running`] and triggers
     /// the scheduler.
     ///
-    /// Returns the thread's [`ThreadId`] and it's previous [`ThreadState`].
+    /// Returns the thread's [`ThreadId`] and its previous [`ThreadState`].
     pub fn pop(&mut self, cs: CriticalSection) -> Option<(ThreadId, ThreadState)> {
         if let Some(head) = self.head {
             let old_state = THREADS.with_mut_cs(cs, |mut threads| {
@@ -46,7 +46,7 @@ impl ThreadList {
         }
     }
 
-    /// Determines if this [`ThreadList`] is empty
+    /// Determines if this [`ThreadList`] is empty.
     pub fn is_empty(&self, _cs: CriticalSection) -> bool {
         self.head.is_none()
     }


### PR DESCRIPTION
Improve API documentation for `riot-rs-threads` and `riot-rs-runqueue`. 
I'll work on next to extract the essence about scheduling in riot-rs into a markdown file in the book (most likely as _User Guide_ and _Developer Guide_?) but I thought that it might make sense to already open this as a draft PR now.

Open Questions:

- Should the user/developer guide be in the `book/` or `docs/` folder?
- I don't fully understand `Threads::flag_wait_one` - @kaspar030 could you help me here?

