### PR TITLE
threads: fix `flag_wait_all`

### DIFF
--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -71,10 +71,9 @@ impl Threads {
 
     fn flag_wait_all(&mut self, mask: ThreadFlags) -> Option<ThreadFlags> {
         let thread = self.current().unwrap();
-        if thread.flags & mask != 0 {
-            let result = thread.flags & mask;
+        if thread.flags & mask == mask {
             thread.flags &= !mask;
-            Some(result)
+            Some(mask)
         } else {
             let thread_id = thread.pid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::All(mask)));


### PR DESCRIPTION
I believe the line should check for all bits in the mask? :slightly_smiling_face: 