### PR TITLE
feat(rt): make the custom panic handler optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ embassy-usb = { version = "0.1", default-features = false }
 
 linkme = { version = "0.3.21", features = ["used_linker"] }
 
-riot-rs = { path = "src/riot-rs" }
+riot-rs = { path = "src/riot-rs", default-features = false }
 riot-rs-rt = { path = "src/riot-rs-rt" }
 riot-rs-runqueue = { path = "src/riot-rs-runqueue" }
 

--- a/src/riot-rs-rt/Cargo.toml
+++ b/src/riot-rs-rt/Cargo.toml
@@ -22,6 +22,7 @@ rtt-target = { version = "0.4.0", optional = true }
 threading = ["dep:riot-rs-threads"]
 debug-console = []
 silent-panic = []
+_panic-handler = []
 
 [dev-dependencies]
 riot-rs-boards = { path = "../riot-rs-boards" }

--- a/src/riot-rs-rt/src/lib.rs
+++ b/src/riot-rs-rt/src/lib.rs
@@ -15,8 +15,6 @@
 #![reexport_test_harness_main = "test_main"]
 pub mod testing;
 
-use core::panic::PanicInfo;
-
 pub mod debug;
 pub use debug::*;
 
@@ -47,8 +45,9 @@ const ISR_STACKSIZE: usize =
 #[used(linker)]
 static ISR_STACK: [u8; ISR_STACKSIZE] = [0u8; ISR_STACKSIZE];
 
+#[cfg(feature = "_panic-handler")]
 #[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo) -> ! {
     #[cfg(not(feature = "silent-panic"))]
     {
         debug::println!("panic: {}\n", _info);

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -15,6 +15,8 @@ riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 static_cell = { workspace = true }
 
 [features]
+default = ["riot-rs-rt/_panic-handler"]
+
 debug-console = ["riot-rs-rt/debug-console"]
 net = ["riot-rs-embassy/net"]
 # Allows to have no boards selected, useful to run platform-independent tooling


### PR DESCRIPTION
This is useful to be able to compile the riot-rs-rt crate with std, otherwise the panic_impls conflict.