### PR TITLE
riot-rs-macros: use `thread_create_noarg()` in thread macro

### DIFF
--- a/src/riot-rs-macros/src/thread.rs
+++ b/src/riot-rs-macros/src/thread.rs
@@ -58,17 +58,13 @@ pub fn thread(args: TokenStream, item: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         #no_mangle_attr
-        #[inline(always)]
         #thread_function
 
         #[#riot_rs_crate::linkme::distributed_slice(#riot_rs_crate::thread::THREAD_FNS)]
         #[linkme(crate = #riot_rs_crate::linkme)]
         fn #slice_fn_name_ident() {
-            fn trampoline(_arg: ()) {
-                #fn_name();
-            }
             let stack = #riot_rs_crate::static_cell::make_static!([0u8; #stack_size as usize]);
-            #riot_rs_crate::thread::thread_create(trampoline, (), stack, #priority);
+            #riot_rs_crate::thread::thread_create_noarg(#fn_name, stack, #priority);
         }
     };
 

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -194,6 +194,11 @@ pub fn thread_create<T: Arguable + Send>(
     unsafe { thread_create_raw(func as usize, arg, stack, prio) }
 }
 
+/// Low-level function to create a thread without argument
+pub fn thread_create_noarg(func: fn(), stack: &mut [u8], prio: u8) -> ThreadId {
+    unsafe { thread_create_raw(func as usize, 0, stack, prio) }
+}
+
 /// Create a thread, low-level
 ///
 /// # Safety


### PR DESCRIPTION
This PR makes the thread macro use `thread_create_raw()` instead of `thread_create()`.

While `thread_create_raw()` is unsafe, this drops the need for the trampoline function.
IMO that makes debugging more natural, as e.g., thread function `module::fn_name()` ends up called like that in the linker output, and not `module::__start_thread_fn_name::trampoline()`.