### PR TITLE
examples/embassy-http-server: some fixes for rpi-pico-w

### DIFF
--- a/examples/embassy-http-server/laze.yml
+++ b/examples/embassy-http-server/laze.yml
@@ -3,7 +3,7 @@ apps:
     env:
       global:
         CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=16384
+          - CONFIG_ISR_STACKSIZE=32768
     selects:
       - ?release
       - network

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -79,6 +79,9 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
 
     let spawner = Spawner::for_current_executor().await;
 
+    #[cfg(feature = "net")]
+    let stack_lock = network::STACK_LOCK.lock().await;
+
     for task in EMBASSY_TASKS {
         task(&spawner, &mut peripherals);
     }
@@ -186,6 +189,9 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
             unreachable!();
         }
     }
+
+    #[cfg(feature = "net")]
+    drop(stack_lock);
 
     #[cfg(feature = "wifi-cyw43")]
     {

--- a/src/riot-rs-embassy/src/network.rs
+++ b/src/riot-rs-embassy/src/network.rs
@@ -2,7 +2,9 @@ use core::cell::OnceCell;
 
 use embassy_executor::Spawner;
 use embassy_net::Stack;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::blocking_mutex::CriticalSectionMutex;
+use embassy_sync::mutex::Mutex;
 
 use crate::sendcell::SendCell;
 use crate::NetworkDevice;
@@ -12,12 +14,18 @@ pub const ETHERNET_MTU: usize = 1514;
 
 pub type NetworkStack = Stack<NetworkDevice>;
 
+// this lock is held early on by `crate::init_task()` and only released once
+// the stack objectis actually available.
+pub(crate) static STACK_LOCK: Mutex<CriticalSectionRawMutex, ()> = Mutex::new(());
 pub(crate) static STACK: CriticalSectionMutex<OnceCell<SendCell<&'static NetworkStack>>> =
     CriticalSectionMutex::new(OnceCell::new());
 
 pub async fn network_stack() -> Option<&'static NetworkStack> {
     let spawner = Spawner::for_current_executor().await;
-    STACK.lock(|cell| cell.get().map(|x| *x.get(spawner).unwrap()))
+    {
+        let _lock = STACK_LOCK.lock().await;
+        STACK.lock(|cell| cell.get().map(|x| *x.get(spawner).unwrap()))
+    }
 }
 
 #[embassy_executor::task]


### PR DESCRIPTION
- increase stack size
- add an extra barrier so `network_stack()` doesn't panic if the stack is not done configurint (e.g., b/c device initialization is await'ing something)

marking as draft as both changes should maybe guarded.