### PR TITLE
riot-rs-threads: improve API documentation

### DIFF
--- a/src/riot-rs-threads/src/channel.rs
+++ b/src/riot-rs-threads/src/channel.rs
@@ -1,3 +1,5 @@
+//! Synchronous channel implementation for sending data between threads.
+
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;

--- a/src/riot-rs-threads/src/ensure_once.rs
+++ b/src/riot-rs-threads/src/ensure_once.rs
@@ -1,5 +1,5 @@
-/// This module provides a Mutex-protected RefCell - basically a way to ensure
-/// at runtime that some reference is used only once.
+//! This module provides a Mutex-protected RefCell --- basically a way to ensure
+//! at runtime that some reference is used only once.
 use core::cell::{Ref, RefCell, RefMut};
 use critical_section::{with, CriticalSection, Mutex};
 

--- a/src/riot-rs-threads/src/lock.rs
+++ b/src/riot-rs-threads/src/lock.rs
@@ -4,7 +4,7 @@ use core::cell::UnsafeCell;
 use super::threadlist::ThreadList;
 use super::ThreadState;
 
-/// A basic locking object
+/// A basic locking object.
 ///
 /// A `Lock` behaves like a Mutex, but carries no data.
 /// This is supposed to be used to implement other locking primitives.
@@ -93,7 +93,7 @@ impl Lock {
         critical_section::with(|cs| {
             let state = unsafe { &mut *self.state.get() };
             match state {
-                LockState::Unlocked => {} // TODO: panic?
+                LockState::Unlocked => {}
                 LockState::Locked(waiters) => {
                     if waiters.pop(cs).is_none() {
                         *state = LockState::Unlocked

--- a/src/riot-rs-threads/src/thread.rs
+++ b/src/riot-rs-threads/src/thread.rs
@@ -1,31 +1,49 @@
 pub use crate::{thread_flags::ThreadFlags, RunqueueId, ThreadId};
 
-/// Main struct for holding thread data
+/// Main struct for holding thread data.
 #[derive(Debug)]
 pub struct Thread {
+    /// Saved stack pointer after context switch.
     pub sp: usize,
+    /// The thread's current state.
     pub state: ThreadState,
+    /// Priority of the thread between 0..[`super::SCHED_PRIO_LEVELS`].
+    /// Multiple threads may have the same priority.
     pub prio: RunqueueId,
+    /// Id of the thread between 0..[`super::THREADS_NUMOF`].
+    /// Ids are unique while a thread is alive but reused after a thread finished.
     pub pid: ThreadId,
+    /// Flags set for the thread.
     pub flags: ThreadFlags,
+    /// Saved non-volatile registers.
     pub(crate) high_regs: [usize; 8],
 }
 
 /// Possible states of a thread
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum ThreadState {
+    /// No active thread.
     Invalid,
+    /// Ready to run.
+    ///
+    /// This doesn't necessarily mean that the thread is currently running,
+    /// but rather that it is in the runqueue.
     Running,
+    /// Suspended / paused.
     Paused,
+    /// Waiting to acquire a [`super::lock::Lock`].
     LockBlocked,
+    /// Waiting for [`ThreadFlags`] to be set.
     FlagBlocked(crate::thread_flags::WaitMode),
+    /// Waiting to receive on a [`super::channel::Channel`], i.e. waiting for the sender.
     ChannelRxBlocked(usize),
+    /// Waiting to send on a [`super::channel::Channel`], i.e. waiting for the receiver.
     ChannelTxBlocked(usize),
     Zombie,
 }
 
 impl Thread {
-    /// create a default Thread object
+    /// Creates an empty [`Thread`] object with [`ThreadState::Invalid`].
     pub const fn default() -> Thread {
         Thread {
             sp: 0,

--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -1,19 +1,35 @@
+//! Thread flags.
 use crate::{ThreadId, ThreadState, Threads, THREADS};
 
-/// type of thread flags
+/// Bitmask that represent the flags that are set for a thread.
 pub type ThreadFlags = u16;
 
-/// Possible waiting modes for thread flags
+/// Possible waiting modes for [`ThreadFlags`].
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum WaitMode {
     Any(ThreadFlags),
     All(ThreadFlags),
 }
 
+/// Sets flags for a thread.
+///
+/// If the thread was blocked on these flags it's unblocked and added
+/// to the runqueue.
+///
+/// # Panics
+///
+/// Panics if no valid thread for `thread_id` exists.
 pub fn set(thread_id: ThreadId, mask: ThreadFlags) {
     THREADS.with_mut(|mut threads| threads.flag_set(thread_id, mask))
 }
 
+/// Waits until all flags in `mask` are set for the current thread.
+///
+/// Returns the set flags for this mask and clears them for the thread.
+///
+/// # Panics
+///
+/// Panics if this is called outside of a thread context.
 pub fn wait_all(mask: ThreadFlags) -> ThreadFlags {
     loop {
         if let Some(flags) = THREADS.with_mut(|mut threads| threads.flag_wait_all(mask)) {
@@ -22,6 +38,13 @@ pub fn wait_all(mask: ThreadFlags) -> ThreadFlags {
     }
 }
 
+/// Waits until any flag in `mask` is set for the current thread.
+///
+/// Returns all set flags for this mask and clears them for the thread.
+///
+/// # Panics
+///
+/// Panics if this is called outside of a thread context.
 pub fn wait_any(mask: ThreadFlags) -> ThreadFlags {
     loop {
         if let Some(flags) = THREADS.with_mut(|mut threads| threads.flag_wait_any(mask)) {
@@ -30,6 +53,14 @@ pub fn wait_any(mask: ThreadFlags) -> ThreadFlags {
     }
 }
 
+/// Waits until any flag in `mask` is set for the current thread.
+///
+/// Compared to [`wait_any`], this returns and clears only one flag
+/// from the mask.
+///
+/// # Panics
+///
+/// Panics if this is called outside of a thread context.
 pub fn wait_one(mask: ThreadFlags) -> ThreadFlags {
     loop {
         if let Some(flags) = THREADS.with_mut(|mut threads| threads.flag_wait_one(mask)) {
@@ -38,6 +69,11 @@ pub fn wait_one(mask: ThreadFlags) -> ThreadFlags {
     }
 }
 
+/// Clears flags for the current thread.
+///
+/// # Panics
+///
+/// Panics if this is called outside of a thread context.
 pub fn clear(mask: ThreadFlags) -> ThreadFlags {
     THREADS.with_mut(|mut threads| {
         let thread = threads.current().unwrap();
@@ -47,6 +83,11 @@ pub fn clear(mask: ThreadFlags) -> ThreadFlags {
     })
 }
 
+/// Returns the flags set for the current thread.
+///
+/// # Panics
+///
+/// Panics if this is called outside of a thread context.
 pub fn get() -> ThreadFlags {
     // TODO: current() requires us to use mutable `threads` here
     THREADS.with_mut(|mut threads| threads.current().unwrap().flags)

--- a/src/riot-rs-threads/src/threadlist.rs
+++ b/src/riot-rs-threads/src/threadlist.rs
@@ -2,18 +2,20 @@ use critical_section::CriticalSection;
 
 use crate::{arch, ThreadId, ThreadState, THREADS};
 
+/// Manages blocked [`super::Thread`]s for a resource, and triggering the scheduler when needed.
 #[derive(Debug)]
 pub struct ThreadList {
+    /// Next thread to run once the resource is available.
     pub head: Option<ThreadId>,
 }
 
 impl ThreadList {
-    /// Creates a new empty`ThreadList`
+    /// Creates a new empty [`ThreadList`]
     pub const fn new() -> Self {
         Self { head: None }
     }
 
-    /// Puts the current thread into this `ThreadList`.
+    /// Puts the current (blocked) thread into this [`ThreadList`] and triggers the scheduler.
     pub fn put_current(&mut self, cs: CriticalSection, state: ThreadState) {
         THREADS.with_mut_cs(cs, |mut threads| {
             let thread_id = threads.current_thread.unwrap();
@@ -24,12 +26,12 @@ impl ThreadList {
         });
     }
 
-    /// Removes the head from this `ThreadList`
+    /// Removes the head from this [`ThreadList`].
     ///
-    /// Sets the thread's `ThreadState` to `ThreadState::Running` and triggers
+    /// Sets the thread's [`ThreadState`] to [`ThreadState::Running`] and triggers
     /// the scheduler.
     ///
-    /// Returns the thread's `ThreadId` and it's previous `ThreadState`.
+    /// Returns the thread's [`ThreadId`] and its previous [`ThreadState`].
     pub fn pop(&mut self, cs: CriticalSection) -> Option<(ThreadId, ThreadState)> {
         if let Some(head) = self.head {
             let old_state = THREADS.with_mut_cs(cs, |mut threads| {
@@ -44,7 +46,7 @@ impl ThreadList {
         }
     }
 
-    /// Determines if this `ThreadList` is empty
+    /// Determines if this [`ThreadList`] is empty.
     pub fn is_empty(&self, _cs: CriticalSection) -> bool {
         self.head.is_none()
     }


### PR DESCRIPTION
Extracted from #133. 

Improve API documentation in `riot-rs-threads`.