### PR TITLE
threads: extract arch-independent scheduling logic

### DIFF
--- a/src/riot-rs-threads/src/arch/mod.rs
+++ b/src/riot-rs-threads/src/arch/mod.rs
@@ -1,17 +1,53 @@
+/// Arch-specific implementations for the scheduler.
+pub trait Arch {
+    const DEFAULT_THREAD_DATA: Self::ThreadData;
+
+    type ThreadData;
+
+    /// Sets up the stack for newly created threads and returns the sp.
+    ///
+    /// After running this, the stack should look as if the thread was
+    /// interrupted by an ISR.
+    ///
+    /// It sets up the stack so when the context is switched to this thread,
+    /// it starts executing `func` with argument `arg`.
+    /// Furthermore, it sets up the link-register with the [`crate::cleanup`] function that
+    /// will be executed after the thread function returned.
+    fn setup_stack(stack: &mut [u8], func: usize, arg: usize) -> usize;
+
+    /// Trigger a context switch.
+    fn schedule();
+
+    /// Setup and initiate the first context switch.
+    fn start_threading(next_sp: usize);
+}
+
 cfg_if::cfg_if! {
     if #[cfg(context = "cortex-m")] {
         mod cortex_m;
-        pub use self::cortex_m::*;
+        pub use cortex_m::Cpu;
     }
     else {
-        pub(crate) fn setup_stack(_stack: &mut [u8], _func: usize, _arg: usize) -> usize {
-            unimplemented!()
-        }
-        pub fn schedule() {
-            unimplemented!();
-        }
-        pub(crate) fn start_threading(_next_sp: usize) {
-            unimplemented!();
+        pub struct Cpu;
+        impl Arch for Cpu {
+            type ThreadData = ();
+            const DEFAULT_THREAD_DATA: Self::ThreadData = ();
+
+            fn setup_stack(_: &mut [u8], _: usize, _: usize) -> usize {
+                unimplemented!()
+            }
+            fn start_threading(_: usize) {
+                unimplemented!()
+            }
+            fn schedule() {
+                unimplemented!()
+            }
         }
     }
+}
+
+pub type ThreadData = <Cpu as Arch>::ThreadData;
+
+pub fn schedule() {
+    Cpu::schedule()
 }

--- a/src/riot-rs-threads/src/thread.rs
+++ b/src/riot-rs-threads/src/thread.rs
@@ -1,4 +1,4 @@
-pub use crate::{thread_flags::ThreadFlags, RunqueueId, ThreadId};
+use crate::{thread_flags::ThreadFlags, Arch, Cpu, RunqueueId, ThreadData, ThreadId};
 
 /// Main struct for holding thread data.
 #[derive(Debug)]
@@ -15,8 +15,8 @@ pub struct Thread {
     pub pid: ThreadId,
     /// Flags set for the thread.
     pub flags: ThreadFlags,
-    /// Saved non-volatile registers.
-    pub(crate) high_regs: [usize; 8],
+    /// Arch-specific thread data.
+    pub(crate) data: ThreadData,
 }
 
 /// Possible states of a thread
@@ -48,7 +48,7 @@ impl Thread {
         Thread {
             sp: 0,
             state: ThreadState::Invalid,
-            high_regs: [0; 8],
+            data: Cpu::DEFAULT_THREAD_DATA,
             flags: 0,
             prio: 0,
             pid: 0,

--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -106,7 +106,7 @@ impl Threads {
             _ => false,
         } {
             self.set_state(thread_id, ThreadState::Running);
-            super::schedule();
+            crate::schedule();
         }
     }
 
@@ -118,7 +118,7 @@ impl Threads {
         } else {
             let thread_id = thread.pid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::All(mask)));
-            super::schedule();
+            crate::schedule();
             None
         }
     }
@@ -132,7 +132,7 @@ impl Threads {
         } else {
             let thread_id = thread.pid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::Any(mask)));
-            super::schedule();
+            crate::schedule();
             None
         }
     }
@@ -148,7 +148,7 @@ impl Threads {
         } else {
             let thread_id = thread.pid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::Any(mask)));
-            super::schedule();
+            crate::schedule();
             None
         }
     }

--- a/src/riot-rs-threads/src/threadlist.rs
+++ b/src/riot-rs-threads/src/threadlist.rs
@@ -1,6 +1,6 @@
 use critical_section::CriticalSection;
 
-use crate::{arch, ThreadId, ThreadState, THREADS};
+use crate::{ThreadId, ThreadState, THREADS};
 
 /// Manages blocked [`super::Thread`]s for a resource, and triggering the scheduler when needed.
 #[derive(Debug)]
@@ -22,7 +22,7 @@ impl ThreadList {
             threads.thread_blocklist[thread_id as usize] = self.head;
             self.head = Some(thread_id);
             threads.set_state(thread_id, state);
-            arch::schedule();
+            crate::schedule();
         });
     }
 
@@ -37,7 +37,7 @@ impl ThreadList {
             let old_state = THREADS.with_mut_cs(cs, |mut threads| {
                 self.head = threads.thread_blocklist[head as usize].take();
                 let old_state = threads.set_state(head, ThreadState::Running);
-                arch::schedule();
+                crate::schedule();
                 old_state
             });
             Some((head, old_state))


### PR DESCRIPTION
Part of #157.

This PR:
- introduces an `Arch` trait for arch-specific logic in the scheduler 
- extracts the arch-independent scheduling logic out of the `cortex_m` module.

Details of the new `Arch` trait will probably still change once a second arch is added, but I think this is already a useful first step.
Wdyt?

Reviewing by commit might be easier; I tried to split it up a bit.