### PR TITLE
riot-rs-rt: make `cortexm::benchmark()` `steal()` Peripherals

### DIFF
--- a/src/riot-rs-rt/src/cortexm.rs
+++ b/src/riot-rs-rt/src/cortexm.rs
@@ -211,7 +211,7 @@ pub fn benchmark<F: Fn() -> ()>(iterations: usize, f: F) -> core::result::Result
     use cortex_m::peripheral::syst::SystClkSource;
     use cortex_m::Peripherals;
 
-    let mut p = Peripherals::take().unwrap();
+    let mut p = unsafe { Peripherals::steal() };
     //
     p.SCB.clear_sleepdeep();
 
@@ -234,6 +234,6 @@ pub fn benchmark<F: Fn() -> ()>(iterations: usize, f: F) -> core::result::Result
     if p.SYST.has_wrapped() {
         Err(())
     } else {
-        Ok((total * 10) as usize / iterations)
+        Ok((total) as usize / iterations)
     }
 }


### PR DESCRIPTION
With embassy taking over the cortexm Peripherals,  `benchmark()` cannot take them anymore.
Let's see if it gets away with `steal()`ing them.