### PR TITLE
initial Nordic nrf5340 / nrf5340dk support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
-          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,thumbv6m-none-eabi,thumbv7m-none-eabi,thumbv7em-none-eabi
+          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,thumbv6m-none-eabi,thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv8m.main-none-eabi
           components: rust-src
 
       - name: rust cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       - name: "limit build unless nightly build"
         if: github.event_name != 'schedule'
         run: |
-          echo "LAZE_BUILDERS=ai-c3,expressif-esp32-c6-devkitc-1,microbit-v2,nrf52840dk,rpi-pico,rpi-pico-w" >> "$GITHUB_ENV"
+          echo "LAZE_BUILDERS=ai-c3,expressif-esp32-c6-devkitc-1,microbit-v2,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w" >> "$GITHUB_ENV"
 
       - name: "riot-rs compilation test"
         if: steps.result-cache.outputs.cache-hit != 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,6 +1982,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nrf5340"
+version = "0.1.0"
+dependencies = [
+ "ld-memory",
+ "riot-rs-debug",
+]
+
+[[package]]
 name = "nrf5340-app-pac"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2009,16 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "vcell",
+]
+
+[[package]]
+name = "nrf5340dk"
+version = "0.1.0"
+dependencies = [
+ "cortex-m",
+ "cortex-m-rt",
+ "nrf5340",
+ "riot-rs-debug",
 ]
 
 [[package]]
@@ -2431,6 +2449,7 @@ dependencies = [
  "nrf52840-mdk",
  "nrf52840dk",
  "nrf52dk",
+ "nrf5340dk",
  "nucleo-f401re",
  "riot-rs-rt",
  "rpi-pico",

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -154,6 +154,16 @@ contexts:
   - name: nrf
     help: Nordic MCU support (based on embassy-nrf)
     parent: riot-rs
+    env:
+      RUSTFLAGS:
+        - --cfg context=\"nrf\"
+    tasks:
+      flash-erase-all:
+        help: Erases the whole chip including user data. Unlocks it if locked.
+        build: false
+        cmd:
+          - probe-rs erase --chip ${PROBE_RS_CHIP} --allow-erase-all
+
 
   - name: nrf51
     parent: nrf
@@ -185,12 +195,15 @@ contexts:
       RUSTFLAGS:
         - --cfg context=\"nrf52\"
 
-    tasks:
-      flash-erase-all:
-        help: Erases the whole chip including user data. Unlocks it if locked.
-        build: false
-        cmd:
-          - probe-rs erase --chip ${PROBE_RS_CHIP} --allow-erase-all
+  - name: nrf5340
+    parent: nrf
+    selects:
+      - thumbv8m.main-none-eabi # actually eabihf, but riot-rs doesn't support hard float yet
+      - probe-rs-run
+    env:
+      PROBE_RS_CHIP: nrf5340_xxAA
+      RUSTFLAGS:
+        - --cfg context=\"nrf5340\"
 
   - name: nrf52832
     parent: nrf52
@@ -313,6 +326,16 @@ modules:
         CARGO_TARGET_PREFIX: CARGO_TARGET_THUMBV7M_NONE_EABI
         RUSTFLAGS:
           - --cfg armv7m
+
+  - name: thumbv8m.main-none-eabi
+    depends:
+      - cortex-m
+    env:
+      global:
+        RUSTC_TARGET: thumbv8m.main-none-eabi
+        CARGO_TARGET_PREFIX: CARGO_TARGET_THUMBV8M_MAIN_NONE_EABI
+        RUSTFLAGS:
+          - --cfg armv8m
 
   - name: thumbv7em-none-eabihf
     depends:
@@ -466,6 +489,7 @@ modules:
 
   - name: hw/usb-device-port
     context:
+      - nrf5340dk
       - nrf52840dk
       - rpi-pico
       - rpi-pico-w
@@ -571,6 +595,9 @@ builders:
 
   - name: expressif-esp32-c6-devkitc-1
     parent: esp32c6
+
+  - name: nrf5340dk
+    parent: nrf5340
 
 apps:
   # define a dummy host application so the host tasks work

--- a/src/riot-rs-boards/Cargo.toml
+++ b/src/riot-rs-boards/Cargo.toml
@@ -21,6 +21,7 @@ microbit-v2 = { optional = true, path = "microbit-v2" }
 nrf52840-mdk = { optional = true, path = "nrf52840-mdk" }
 nrf52840dk = { optional = true, path = "nrf52840dk" }
 nrf52dk = { optional = true, path = "nrf52dk" }
+nrf5340dk = { optional = true, path = "nrf5340dk" }
 nucleo-f401re = { optional = true, path = "nucleo-f401re" }
 rpi-pico = { optional = true, path = "rpi-pico" }
 

--- a/src/riot-rs-boards/nrf5340/Cargo.toml
+++ b/src/riot-rs-boards/nrf5340/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "nrf5340"
+version = "0.1.0"
+authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
+edition = "2021"
+
+[dependencies]
+riot-rs-debug = { workspace = true, features = ["rtt-target"] }
+
+[build-dependencies]
+ld-memory = { workspace = true, features = ["build-rs"] }

--- a/src/riot-rs-boards/nrf5340/build.rs
+++ b/src/riot-rs-boards/nrf5340/build.rs
@@ -1,0 +1,20 @@
+use ld_memory::{Memory, MemorySection};
+
+// TODO: deduplicate with all "simple" cortex-m SoCs
+
+fn main() {
+    let (ram, rom) = (512, 1024);
+
+    // generate linker script
+    let memory = Memory::new()
+        .add_section(MemorySection::new("RAM", 0x20000000, ram * 1024))
+        .add_section(
+            MemorySection::new("FLASH", 0x0, rom * 1024)
+                .pagesize(4096)
+                .from_env_with_prefix("NRF5340_FLASH"),
+        );
+
+    memory.to_cargo_outdir("memory.x").expect("wrote memory.x");
+
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/src/riot-rs-boards/nrf5340/src/lib.rs
+++ b/src/riot-rs-boards/nrf5340/src/lib.rs
@@ -1,0 +1,7 @@
+#![no_std]
+
+use riot_rs_debug::println;
+
+pub fn init() {
+    println!("nrf5340::init()");
+}

--- a/src/riot-rs-boards/nrf5340dk/Cargo.toml
+++ b/src/riot-rs-boards/nrf5340dk/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nrf5340dk"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+cortex-m.workspace = true
+cortex-m-rt.workspace = true
+
+riot-rs-debug.workspace = true
+
+nrf5340 = { path = "../nrf5340" }

--- a/src/riot-rs-boards/nrf5340dk/src/lib.rs
+++ b/src/riot-rs-boards/nrf5340dk/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+use riot_rs_debug::println;
+
+pub fn init() {
+    println!("nrf5340dk::init()");
+    nrf5340::init();
+}

--- a/src/riot-rs-boards/src/lib.rs
+++ b/src/riot-rs-boards/src/lib.rs
@@ -16,6 +16,8 @@ cfg_if! {
         pub use nrf52840dk as board;
     } else if #[cfg(feature = "nrf52840-mdk")] {
         pub use nrf52840_mdk as board;
+    } else if #[cfg(feature = "nrf5340dk")] {
+        pub use nrf5340dk as board;
     } else if #[cfg(feature = "microbit")] {
         pub use microbit as board;
     } else if #[cfg(feature = "microbit-v2")] {

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -42,7 +42,7 @@ embassy-executor = { workspace = true, features = [
   "executor-interrupt",
 ] }
 
-[target.'cfg(context = "nrf52")'.dependencies]
+[target.'cfg(context = "nrf")'.dependencies]
 embassy-nrf = { workspace = true, features = [
   "time-driver-rtc1",
   "time",
@@ -55,6 +55,9 @@ embassy-nrf = { workspace = true, features = ["nrf52832"] }
 
 [target.'cfg(context = "nrf52840")'.dependencies]
 embassy-nrf = { workspace = true, features = ["nrf52840"] }
+
+[target.'cfg(context = "nrf5340")'.dependencies]
+embassy-nrf = { workspace = true, features = ["nrf5340-app-s"] }
 
 [target.'cfg(context = "rp2040")'.dependencies]
 embassy-rp = { workspace = true, features = [

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -6,11 +6,11 @@
 
 pub mod define_peripherals;
 
-#[cfg_attr(context = "nrf52", path = "arch/nrf52.rs")]
+#[cfg_attr(context = "nrf", path = "arch/nrf52.rs")]
 #[cfg_attr(context = "rp2040", path = "arch/rp2040.rs")]
 #[cfg_attr(context = "esp", path = "arch/esp.rs")]
 #[cfg_attr(
-    not(any(context = "nrf52", context = "rp2040", context = "esp")),
+    not(any(context = "nrf", context = "rp2040", context = "esp")),
     path = "arch/dummy.rs"
 )]
 pub mod arch;
@@ -66,7 +66,7 @@ pub(crate) fn init() {
     println!("riot-rs-embassy::init()");
     let p = arch::init(Default::default());
 
-    #[cfg(any(context = "nrf52", context = "rp2040"))]
+    #[cfg(any(context = "nrf", context = "rp2040"))]
     {
         EXECUTOR.start(arch::SWI);
         EXECUTOR.spawner().must_spawn(init_task(p));
@@ -92,7 +92,7 @@ fn init() -> ! {
 async fn init_task(mut peripherals: arch::OptionalPeripherals) {
     println!("riot-rs-embassy::init_task()");
 
-    #[cfg(all(context = "nrf52", feature = "usb"))]
+    #[cfg(all(context = "nrf", feature = "usb"))]
     {
         // nrf52840
         let clock: embassy_nrf::pac::CLOCK = unsafe { core::mem::transmute(()) };

--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -74,7 +74,7 @@ impl Arch for Cpu {
     }
 }
 
-#[cfg(armv7m)]
+#[cfg(any(armv7m, armv8m))]
 #[naked]
 #[no_mangle]
 #[allow(non_snake_case)]
@@ -114,7 +114,7 @@ unsafe extern "C" fn SVCall() {
     );
 }
 
-#[cfg(armv7m)]
+#[cfg(any(armv7m, armv8m))]
 #[naked]
 #[no_mangle]
 #[allow(non_snake_case)]


### PR DESCRIPTION
This PR adds initial nrf5340 support.

- [x] wire up nrf5340
- [x] add nrf5340dk board
- [x] set up USB
~~- [ ] rename to nrf5340-app, support nrf5340-net~~ postponed
- [x] testing, docs

~~(darn, needs laze release & update)~~ (fixed)

Closes #167.
(includes #170)