### PR TITLE
riot-rs-embassy: switch from `riot-rs-core` to `riot-rs-threads`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,9 +2405,9 @@ dependencies = [
  "heapless 0.8.0",
  "linkme",
  "once_cell",
- "riot-rs-core",
  "riot-rs-debug",
  "riot-rs-rt",
+ "riot-rs-threads",
  "riot-rs-utils",
  "static_cell",
 ]

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -22,7 +22,6 @@ embassy-sync = { workspace = true }
 embassy-time = { workspace = true, optional = true }
 embassy-usb = { workspace = true, optional = true }
 
-# always
 riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 riot-rs-debug = { workspace = true }
 riot-rs-rt = { path = "../riot-rs-rt" }

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -23,7 +23,7 @@ embassy-time = { workspace = true, optional = true }
 embassy-usb = { workspace = true, optional = true }
 
 # always
-riot-rs-core = { path = "../riot-rs-core", optional = true }
+riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 riot-rs-debug = { workspace = true }
 riot-rs-rt = { path = "../riot-rs-rt" }
 riot-rs-utils = { path = "../riot-rs-utils" }
@@ -101,7 +101,7 @@ wifi-cyw43 = [
 ]
 wifi-esp = ["dep:esp-wifi", "dep:embassy-net-driver-channel", "net", "wifi"]
 
-threading = ["dep:riot-rs-core"]
+threading = ["dep:riot-rs-threads"]
 override-network-config = []
 override-usb-config = []
 

--- a/src/riot-rs-embassy/src/blocker.rs
+++ b/src/riot-rs-embassy/src/blocker.rs
@@ -1,7 +1,7 @@
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
-use riot_rs_core::thread::{current_pid, flags, flags::ThreadFlags, ThreadId};
+use riot_rs_threads::{current_pid, flags, flags::ThreadFlags, ThreadId};
 
 const THREAD_FLAG_WAKER: ThreadFlags = 1; // TODO: find more appropriate value
 


### PR DESCRIPTION
riot-rs-embassy's `blocker` module depended on `riot-rs-core`, just to use it's re-export of `riot-rs-threads`. This PR makes it depend directly on `riot-rs-threads`.