### PR TITLE
riot-rs-embassy: add some `unsafe{}` around the interrupt executors

### DIFF
--- a/src/riot-rs-embassy/src/arch/nrf52.rs
+++ b/src/riot-rs-embassy/src/arch/nrf52.rs
@@ -4,7 +4,11 @@ pub use embassy_nrf::{config::Config, interrupt, peripherals, OptionalPeripheral
 
 #[interrupt]
 unsafe fn SWI0_EGU0() {
-    crate::EXECUTOR.on_interrupt()
+    // SAFETY:
+    // - called from ISR
+    // - not called before `start()`, as the interrupt is enabled by `start()`
+    //   itself
+    unsafe { crate::EXECUTOR.on_interrupt() }
 }
 
 #[cfg(feature = "usb")]

--- a/src/riot-rs-embassy/src/arch/rp2040.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040.rs
@@ -5,7 +5,11 @@ pub use embassy_rp::{config::Config, peripherals, OptionalPeripherals};
 
 #[interrupt]
 unsafe fn SWI_IRQ_1() {
-    crate::EXECUTOR.on_interrupt()
+    // SAFETY:
+    // - called from ISR
+    // - not called before `start()`, as the interrupt is enabled by `start()`
+    //   itself
+    unsafe { crate::EXECUTOR.on_interrupt() }
 }
 
 #[cfg(feature = "usb")]


### PR DESCRIPTION
Fixes these:

```
warning: call to unsafe function `embassy_executor::InterruptExecutor::on_interrupt` is unsafe and requires unsafe block (error E0133)
 --> src/riot-rs-embassy/src/arch/rp2040.rs:8:5     
  | 
8 |     crate::EXECUTOR.on_interrupt()                                                                                                                         
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function                                                                                                 
  | 
  = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
  = note: consult the function's documentation for information on how to avoid undefined behavior
note: an unsafe function restricts its caller, but its body is safe by default                                                                                 
 --> src/riot-rs-embassy/src/arch/rp2040.rs:7:1             
  |
7 | unsafe fn SWI_IRQ_1() {
  | ^^^^^^^^^^^^^^^^^^^^^
  = note: requested on the command line with `-W unsafe-op-in-unsafe-fn`
