### PR TITLE
threads: add support for RISC-V (esp32 only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,6 +3334,7 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-semihosting",
  "critical-section",
+ "esp-hal",
  "linkme",
  "panic-semihosting",
  "riot-rs-runqueue",

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -19,6 +19,9 @@ riot-rs-runqueue.workspace = true
 [target.'cfg(context = "esp32c3")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c3"] }
 
+[target.'cfg(context = "esp32c6")'.dependencies]
+esp-hal = { workspace = true, features = ["esp32c6"] }
+
 [target.'cfg(context = "cortex-m")'.dependencies]
 # cortex-m specifics
 cortex-m.workspace = true

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -16,6 +16,9 @@ critical-section.workspace = true
 linkme = { workspace = true }
 riot-rs-runqueue.workspace = true
 
+[target.'cfg(context = "esp32c3")'.dependencies]
+esp-hal = { workspace = true, features = ["esp32c3"] }
+
 [target.'cfg(context = "cortex-m")'.dependencies]
 # cortex-m specifics
 cortex-m.workspace = true

--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -1,4 +1,5 @@
 use super::Arch;
+use crate::Thread;
 use core::arch::asm;
 use core::ptr::write_volatile;
 use cortex_m::peripheral::SCB;
@@ -29,7 +30,7 @@ impl Arch for Cpu {
     /// |   PC    |
     /// |   PSR   |
     /// +---------+
-    fn setup_stack(stack: &mut [u8], func: usize, arg: usize) -> usize {
+    fn setup_stack(thread: &mut Thread, stack: &mut [u8], func: usize, arg: usize) {
         let stack_start = stack.as_ptr() as usize;
 
         // 1. The stack starts at the highest address and grows downwards.
@@ -50,7 +51,7 @@ impl Arch for Cpu {
             write_volatile(stack_pos.offset(7), 0x01000000); // -> APSR
         }
 
-        stack_pos as usize
+        thread.sp = stack_pos as usize;
     }
 
     /// Triggers a PendSV exception.

--- a/src/riot-rs-threads/src/arch/mod.rs
+++ b/src/riot-rs-threads/src/arch/mod.rs
@@ -29,7 +29,7 @@ cfg_if::cfg_if! {
         mod cortex_m;
         pub use cortex_m::Cpu;
     }
-    else if #[cfg(context = "esp32c3")] {
+    else if #[cfg(any(context = "esp32c3", context = "esp32c6"))] {
         mod riscv;
         pub use riscv::Cpu;
     }

--- a/src/riot-rs-threads/src/arch/mod.rs
+++ b/src/riot-rs-threads/src/arch/mod.rs
@@ -29,6 +29,10 @@ cfg_if::cfg_if! {
         mod cortex_m;
         pub use cortex_m::Cpu;
     }
+    else if #[cfg(context = "esp32c3")] {
+        mod riscv;
+        pub use riscv::Cpu;
+    }
     else {
         pub struct Cpu;
         impl Arch for Cpu {

--- a/src/riot-rs-threads/src/arch/mod.rs
+++ b/src/riot-rs-threads/src/arch/mod.rs
@@ -1,3 +1,5 @@
+use crate::Thread;
+
 /// Arch-specific implementations for the scheduler.
 pub trait Arch {
     const DEFAULT_THREAD_DATA: Self::ThreadData;
@@ -13,7 +15,7 @@ pub trait Arch {
     /// it starts executing `func` with argument `arg`.
     /// Furthermore, it sets up the link-register with the [`crate::cleanup`] function that
     /// will be executed after the thread function returned.
-    fn setup_stack(stack: &mut [u8], func: usize, arg: usize) -> usize;
+    fn setup_stack(thread: &mut Thread, stack: &mut [u8], func: usize, arg: usize);
 
     /// Trigger a context switch.
     fn schedule();
@@ -33,7 +35,7 @@ cfg_if::cfg_if! {
             type ThreadData = ();
             const DEFAULT_THREAD_DATA: Self::ThreadData = ();
 
-            fn setup_stack(_: &mut [u8], _: usize, _: usize) -> usize {
+            fn setup_stack( _: &mut Thread, _: &mut [u8], _: usize, _: usize) {
                 unimplemented!()
             }
             fn start_threading() {

--- a/src/riot-rs-threads/src/arch/riscv.rs
+++ b/src/riot-rs-threads/src/arch/riscv.rs
@@ -1,8 +1,11 @@
 use crate::{cleanup, Arch, Thread, THREADS};
-use critical_section::CriticalSection;
+#[cfg(context = "esp32c6")]
+use esp_hal::peripherals::INTPRI as SYSTEM;
+#[cfg(context = "esp32c3")]
+use esp_hal::peripherals::SYSTEM;
 use esp_hal::{
     interrupt::{self, TrapFrame},
-    peripherals::{Interrupt, SYSTEM},
+    peripherals::Interrupt,
     prelude::*,
     riscv, Cpu as EspHalCpu,
 };

--- a/src/riot-rs-threads/src/arch/riscv.rs
+++ b/src/riot-rs-threads/src/arch/riscv.rs
@@ -1,0 +1,142 @@
+use crate::{cleanup, Arch, Thread, THREADS};
+use critical_section::CriticalSection;
+use esp_hal::{
+    interrupt::{self, TrapFrame},
+    peripherals::{Interrupt, SYSTEM},
+    prelude::*,
+    riscv, Cpu as EspHalCpu,
+};
+
+pub struct Cpu;
+
+impl Arch for Cpu {
+    type ThreadData = TrapFrame;
+    const DEFAULT_THREAD_DATA: Self::ThreadData = default_trap_frame();
+
+    /// Triggers software interrupt for the context switch.
+    fn schedule() {
+        unsafe {
+            (&*SYSTEM::PTR)
+                .cpu_intr_from_cpu_3()
+                .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
+        }
+    }
+
+    /// On RISC-V (ESP32), the stack doesn't need to be set up with any register values since
+    /// they are restored from the stored [`TrapFrame`].
+    fn setup_stack(thread: &mut Thread, stack: &mut [u8], func: usize, arg: usize) {
+        let stack_start = stack.as_ptr() as usize;
+        // 16 byte alignment.
+        let stack_pos = (stack_start + stack.len()) & 0xFFFFFFE0;
+        // Set up PC, SP, RA and first argument for function.
+        thread.sp = stack_pos;
+        thread.data.sp = stack_pos;
+        thread.data.a0 = arg;
+        thread.data.ra = cleanup as usize;
+        thread.data.pc = func;
+    }
+
+    /// Enable and trigger the appropriate software interrupt.
+    fn start_threading() {
+        interrupt::disable(EspHalCpu::ProCpu, Interrupt::FROM_CPU_INTR3);
+        Self::schedule();
+        // TODO: handle unwrap error?
+        interrupt::enable(Interrupt::FROM_CPU_INTR3, interrupt::Priority::min()).unwrap();
+    }
+}
+
+const fn default_trap_frame() -> TrapFrame {
+    TrapFrame {
+        ra: 0,
+        t0: 0,
+        t1: 0,
+        t2: 0,
+        t3: 0,
+        t4: 0,
+        t5: 0,
+        t6: 0,
+        a0: 0,
+        a1: 0,
+        a2: 0,
+        a3: 0,
+        a4: 0,
+        a5: 0,
+        a6: 0,
+        a7: 0,
+        s0: 0,
+        s1: 0,
+        s2: 0,
+        s3: 0,
+        s4: 0,
+        s5: 0,
+        s6: 0,
+        s7: 0,
+        s8: 0,
+        s9: 0,
+        s10: 0,
+        s11: 0,
+        gp: 0,
+        tp: 0,
+        sp: 0,
+        pc: 0,
+        mstatus: 0,
+        mcause: 0,
+        mtval: 0,
+    }
+}
+
+/// Copies the register state from `src` to `dst`.
+///
+/// It copies state from the `TrapFrame` except for CSR registers
+/// `mstatus`, `mcause` and `mtval`.
+fn copy_registers(src: &TrapFrame, dst: &mut TrapFrame) {
+    let (mstatus, mcause, mtval) = (dst.mstatus, dst.mcause, dst.mtval);
+    dst.clone_from(src);
+    dst.mstatus = mstatus;
+    dst.mcause = mcause;
+    dst.mtval = mtval;
+}
+
+/// Handler for software interrupt 3, which we use for context switching.
+#[allow(non_snake_case)]
+#[interrupt]
+fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
+    unsafe {
+        // clear FROM_CPU_INTR3
+        (&*SYSTEM::PTR)
+            .cpu_intr_from_cpu_3()
+            .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
+
+        sched(trap_frame)
+    }
+}
+
+/// Probes the runqueue for the next thread and switches context if needed.
+///
+/// # Safety
+///
+/// This method might switch the current register state that is saved in the
+/// `trap_frame`.
+/// It should only be called from inside the trap handler that is responsible for
+/// context switching.
+unsafe fn sched(trap_frame: &mut TrapFrame) {
+    unsafe {
+        let cs = CriticalSection::new();
+        let next_pid = if let Some(pid) = (&*THREADS.as_ptr(cs)).runqueue.get_next() {
+            pid
+        } else {
+            todo!();
+        };
+
+        let threads = &mut *THREADS.as_ptr(cs);
+
+        if let Some(current_pid) = threads.current_pid() {
+            if next_pid == current_pid {
+                return;
+            }
+            copy_registers(trap_frame, &mut threads.threads[current_pid as usize].data);
+        }
+        threads.current_thread = Some(next_pid);
+        copy_registers(&threads.threads[next_pid as usize].data, trap_frame);
+    }
+}

--- a/src/riot-rs-threads/src/arch/riscv.rs
+++ b/src/riot-rs-threads/src/arch/riscv.rs
@@ -20,8 +20,8 @@ impl Arch for Cpu {
     fn schedule() {
         unsafe {
             (&*SYSTEM::PTR)
-                .cpu_intr_from_cpu_3()
-                .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
+                .cpu_intr_from_cpu_1()
+                .modify(|_, w| w.cpu_intr_from_cpu_1().set_bit());
         }
     }
 
@@ -41,10 +41,10 @@ impl Arch for Cpu {
 
     /// Enable and trigger the appropriate software interrupt.
     fn start_threading() {
-        interrupt::disable(EspHalCpu::ProCpu, Interrupt::FROM_CPU_INTR3);
+        interrupt::disable(EspHalCpu::ProCpu, Interrupt::FROM_CPU_INTR1);
         Self::schedule();
         // TODO: handle unwrap error?
-        interrupt::enable(Interrupt::FROM_CPU_INTR3, interrupt::Priority::min()).unwrap();
+        interrupt::enable(Interrupt::FROM_CPU_INTR1, interrupt::Priority::min()).unwrap();
     }
 }
 
@@ -100,15 +100,15 @@ fn copy_registers(src: &TrapFrame, dst: &mut TrapFrame) {
     dst.mtval = mtval;
 }
 
-/// Handler for software interrupt 3, which we use for context switching.
+/// Handler for software interrupt 0, which we use for context switching.
 #[allow(non_snake_case)]
 #[interrupt]
-fn FROM_CPU_INTR3(trap_frame: &mut TrapFrame) {
+fn FROM_CPU_INTR1(trap_frame: &mut TrapFrame) {
     unsafe {
-        // clear FROM_CPU_INTR3
+        // clear FROM_CPU_INTR1
         (&*SYSTEM::PTR)
-            .cpu_intr_from_cpu_3()
-            .modify(|_, w| w.cpu_intr_from_cpu_3().clear_bit());
+            .cpu_intr_from_cpu_1()
+            .modify(|_, w| w.cpu_intr_from_cpu_1().clear_bit());
 
         sched(trap_frame)
     }

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -89,7 +89,7 @@ impl Threads {
         prio: u8,
     ) -> Option<&mut Thread> {
         if let Some((thread, pid)) = self.get_unused() {
-            thread.sp = Cpu::setup_stack(stack, func, arg);
+            Cpu::setup_stack(thread, stack, func, arg);
             thread.prio = prio;
             thread.pid = pid;
             thread.state = ThreadState::Paused;


### PR DESCRIPTION
Initial support for threading on RISCV.

For now this only supports the `esp32c3` and `esp32c6` boards since we depend on specific features from `esp-hal`.
Adding support for other esp boards can be done in follow up PRs. 

Most of the changes are only within the new `riscv` module, but one general change I'd like to mention:
- Setting `threads.current_id` to the very first running thread is now done within `sched` when the thread actually starts running. Before, this was done already in `start_threading`, but it caused some problems in the RISC-V implementation because then we couldn't differentiate between the thread running for the first time and `current_id == next_id`. I've tested on both arch'es and it still works with this change, so I think it should be alright?

Note: I have not tested using threading and embassy tasks together. But we also don't have any examples that tested this for cortex-m, so I'd argue that it's out of scope for this PR. Wdyt?

Part of #157.