### PR TITLE
tests/benchmarks/bench_sched_yield: initial commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bench_sched_yield"
+version = "0.1.0"
+dependencies = [
+ "riot-rs",
+ "riot-rs-boards",
+]
+
+[[package]]
 name = "benchmark"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "src/riot-rs-chips",
   "src/riot-rs-debug",
   "src/riot-rs-macros",
+  "tests/benchmarks/bench_sched_yield",
 ]
 
 exclude = ["src/lib"]
@@ -50,6 +51,7 @@ esp-wifi = { git = "https://github.com/kaspar030/esp-wifi", branch = "update-esp
 linkme = { version = "0.3.21", features = ["used_linker"] }
 
 riot-rs = { path = "src/riot-rs", default-features = false }
+riot-rs-boards = { path = "src/riot-rs-boards", default-features = false }
 riot-rs-debug = { path = "src/riot-rs-debug", default-features = false }
 riot-rs-rt = { path = "src/riot-rs-rt" }
 riot-rs-runqueue = { path = "src/riot-rs-runqueue" }

--- a/examples/benchmark/laze.yml
+++ b/examples/benchmark/laze.yml
@@ -2,3 +2,4 @@ apps:
   - name: benchmark
     depends:
       - ?release
+      - sw/benchmark

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -499,6 +499,13 @@ modules:
         RUSTFLAGS:
           - --cfg capability=\"hw/usb-device-port\"
 
+  - name: sw/benchmark
+    help: provided if a target supports `benchmark()`
+    # Currently there's only one implementation based on Systick, so Cortex-M only.
+    context:
+      - nrf
+      - rp
+
   - name: wifi-esp
     context:
       - esp
@@ -609,3 +616,4 @@ apps:
 subdirs:
   - examples
   - src
+  - tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,5 @@
+# Introduction
+
+This folder contains tests & benchmarks used for developing RIOT-rs.
+
+- [benchmarks/](./benchmarks): contains benchmark applications we're using to keep performance high.

--- a/tests/benchmarks/bench_sched_yield/Cargo.toml
+++ b/tests/benchmarks/bench_sched_yield/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bench_sched_yield"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+riot-rs = { workspace = true, default-features = true, features = [
+  "threading",
+] }
+riot-rs-boards = { workspace = true }

--- a/tests/benchmarks/bench_sched_yield/README.md
+++ b/tests/benchmarks/bench_sched_yield/README.md
@@ -1,0 +1,11 @@
+# bench_sched_yield
+
+## About
+
+This benchmark tests basic context switch performance.
+
+## How to run
+
+In this folder, run
+
+    laze build -b nrf52840dk -s probe-rs-run run

--- a/tests/benchmarks/bench_sched_yield/laze.yml
+++ b/tests/benchmarks/bench_sched_yield/laze.yml
@@ -1,0 +1,5 @@
+apps:
+  - name: bench_sched_yield
+    selects:
+      - sw/benchmark
+      - ?release

--- a/tests/benchmarks/bench_sched_yield/src/main.rs
+++ b/tests/benchmarks/bench_sched_yield/src/main.rs
@@ -1,0 +1,29 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::{debug::println, thread};
+
+#[riot_rs::thread(autostart)]
+fn thread0() {
+    match riot_rs::rt::benchmark(10000, || thread::yield_same()) {
+        Ok(ticks) => {
+            println!(
+                "took {} ticks per iteration ({} per context switch)",
+                ticks,
+                ticks / 2
+            );
+        }
+        Err(_) => {
+            println!("benchmark returned error");
+        }
+    }
+}
+
+#[riot_rs::thread(autostart)]
+fn thread1() {
+    loop {
+        thread::yield_same()
+    }
+}

--- a/tests/benchmarks/laze.yml
+++ b/tests/benchmarks/laze.yml
@@ -1,0 +1,2 @@
+subdirs:
+  - bench_sched_yield

--- a/tests/laze.yml
+++ b/tests/laze.yml
@@ -1,0 +1,2 @@
+subdirs:
+  - benchmarks


### PR DESCRIPTION
This PR adds a new folder hierarchy `tests/`, with `tests/benchmarks`, and a first benchmark that I probably ad-hoc coded 5 times already.