### PR TITLE
docs(riot-rs): document Cargo features aimed at users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
 name = "riot-rs"
 version = "0.1.0"
 dependencies = [
+ "document-features",
  "linkme",
  "riot-rs-boards",
  "riot-rs-buildinfo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ riot-rs-rt = { path = "src/riot-rs-rt" }
 riot-rs-runqueue = { path = "src/riot-rs-runqueue" }
 
 const_panic = { version = "0.2.8", default_features = false }
+document-features = "0.2.8"
 heapless = { version = "0.8.0", default-features = false }
 konst = { version = "0.3.8", default_features = false }
 ld-memory = { version = "0.2.9" }

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
+document-features = { workspace = true }
 linkme = { workspace = true }
 riot-rs-boards = { path = "../riot-rs-boards" }
 riot-rs-buildinfo = { path = "../riot-rs-buildinfo" }
@@ -32,21 +33,50 @@ riot-rs-rt = { path = "../riot-rs-rt", features = ["executor-single-thread"] }
 [features]
 default = ["riot-rs-rt/_panic-handler"]
 
-debug-console = ["riot-rs-rt/debug-console"]
-net = ["riot-rs-embassy/net"]
-# Allows to have no boards selected, useful to run platform-independent tooling
-no-boards = ["riot-rs-boards/no-boards"]
-override-network-config = ["riot-rs-embassy/override-network-config"]
-override-usb-config = ["riot-rs-embassy/override-usb-config"]
-silent-panic = ["riot-rs-rt/silent-panic"]
+#! ## System functionality
+## Enables threading support, see the [`macro@thread`] attribute macro.
 threading = [
   "dep:riot-rs-threads",
   "riot-rs-rt/threading",
   "riot-rs-embassy/threading",
 ]
+## Enables support for timeouts in the internal executor---required to use
+## `embassy_time::Timer`.
 time = ["riot-rs-embassy/time"]
+
+#! ## Wired communication
+## Enables USB support.
 usb = ["riot-rs-embassy/usb"]
 
+#! ## System configuration
+#! The [`macro@config`] attribute macro allows to provide configuration for
+#! specific system functionality.
+#! The features below need to be enabled so that the provided custom
+#! configuration is taken into account.
+## Enables custom network configuration.
+override-network-config = ["riot-rs-embassy/override-network-config"]
+## Enables custom USB configuration.
+override-usb-config = ["riot-rs-embassy/override-usb-config"]
+
+#! ## Network type selection
+#! At most one of the features below can be enabled at once.
+#! These features are normally automatically selected by
+#! [laze](https://github.com/kaspar030/laze) based on what the board supports,
+#! and don't need to be selected manually.
+## Selects Ethernet over USB (USB CDC-NCM).
 usb-ethernet = ["riot-rs-embassy/usb-ethernet"]
-wifi-esp = ["riot-rs-embassy/wifi-esp"]
+## Selects Wi-Fi (with the CYW43 chip).
 wifi-cyw43 = ["riot-rs-embassy/wifi-cyw43"]
+## Selects Wi-Fi (on ESP chips).
+wifi-esp = ["riot-rs-embassy/wifi-esp"]
+
+#! ## Development and debugging
+## Enables the debug console, required to use
+## [`println!`](riot_rs_debug::println).
+debug-console = ["riot-rs-rt/debug-console"]
+## Prints nothing in case of panics (may help reduce binary size).
+silent-panic = ["riot-rs-rt/silent-panic"]
+## Allows to have no boards selected, useful to run target-independent tooling.
+no-boards = ["riot-rs-boards/no-boards"]
+
+net = ["riot-rs-embassy/net"]

--- a/src/riot-rs/src/lib.rs
+++ b/src/riot-rs/src/lib.rs
@@ -1,8 +1,11 @@
 //! riot-rs
 //!
 //! This is a meta-package, pulling in the sub-crates of RIOT-rs.
-
+//!
+//! # Cargo features
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![no_std]
+#![feature(doc_cfg)]
 
 pub use riot_rs_buildinfo as buildinfo;
 pub use riot_rs_debug as debug;
@@ -11,7 +14,8 @@ pub use riot_rs_rt as rt;
 
 // Attribute macros
 pub use riot_rs_macros::config;
-#[cfg(feature = "threading")]
+#[cfg(any(feature = "threading", doc))]
+#[doc(cfg(feature = "threading"))]
 pub use riot_rs_macros::thread;
 
 #[cfg(feature = "threading")]


### PR DESCRIPTION
It currently looks like this on the root page of `riot-rs`:

![Screenshot_20240315_164042](https://github.com/future-proof-iot/RIOT-rs/assets/152802150/45253678-1a76-4dac-8c17-49e11cad922c)
