### PR TITLE
pin toolchain to nightly-2024-03-11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,14 @@ jobs:
         if: steps.result-cache.outputs.cache-hit != 'true'
         uses: mozilla-actions/sccache-action@v0.0.4
 
+      - id: get_toolchain
+        run: echo "toolchain=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
+
       - name: Install toolchain
         if: steps.result-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
           targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,thumbv6m-none-eabi,thumbv7m-none-eabi,thumbv7em-none-eabi
           components: rust-src
 
@@ -101,8 +105,13 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - id: get_toolchain
+        run: echo "toolchain=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
+
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
 
       # TODO: we'll eventually want to test the whole workspace with --workspace
       # TODO: we'll eventually want to enable relevant features
@@ -118,9 +127,13 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
+      - id: get_toolchain
+        run: echo "toolchain=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
+
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
           components: clippy, rustfmt
 
       - name: rust cache

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2024-03-11


### PR DESCRIPTION
Prevents this nightly breakage:

```
error: concrete type differs from previous defining opaque type use
  --> src/riot-rs-embassy/src/usb.rs:23:5
   |                                                                                                                                                           
23 |     #[embassy_executor::task]
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usb_ncm_task::Fut`, got `impl Future<Output = !>`
   |                                                                           
note: previous use here                                                                                                                                          --> src/riot-rs-embassy/src/usb.rs:23:5                                                                                                                         |                                                                                                                                                           23 |     #[embassy_executor::task]                                                                                                                                |     ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                = note: this error originates in the attribute macro `embassy_executor::task` (in Nightly builds, run with -Z macro-backtrace for more info)            
                                                                               
error: concrete type differs from previous defining opaque type use
  --> src/riot-rs-embassy/src/usb.rs:10:1                 
   |   
10 | #[embassy_executor::task]       
   | ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `usb_task::Fut`, got `impl Future<Output = !>`
   |                        
note: previous use here
  --> src/riot-rs-embassy/src/usb.rs:10:1
   |
10 | #[embassy_executor::task]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the attribute macro `embassy_executor::task` (in Nightly builds, run with -Z macro-backtrace for more info)
