### PR TITLE
feat(benchmark-example): print benchmark errors if any

### DIFF
--- a/examples/benchmark/src/main.rs
+++ b/examples/benchmark/src/main.rs
@@ -7,14 +7,15 @@ use riot_rs::debug::println;
 
 #[riot_rs::thread(autostart)]
 fn main() {
-    match riot_rs::bench::benchmark(10000, || {
-        //
+    match riot_rs::bench::benchmark(1000, || {
+        // Insert the function to benchmark here.
+        // Consider using `core::hint::black_box()` where necessary.
     }) {
         Ok(ticks) => {
             println!("took {} per iteration", ticks);
         }
-        Err(_) => {
-            println!("benchmark returned error");
+        Err(err) => {
+            println!("benchmark returned error: {}", err);
         }
     }
 }


### PR DESCRIPTION
Depends on #208.