### PR TITLE
riot-rs-threads: bail out on unspecified ARM variant

### DIFF
--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -6,6 +6,9 @@ use critical_section::CriticalSection;
 
 use crate::{cleanup, THREADS};
 
+#[cfg(not(any(armv6m, armv7m, armv8m)))]
+compile_error!("no supported ARM variant selected");
+
 pub struct Cpu;
 
 impl Arch for Cpu {


### PR DESCRIPTION
I stumbled over this when adding the nrf5340 (armv8), which silently failed at runtime.