### PR TITLE
COC: fix broken link to Reporting Guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -23,7 +23,7 @@ affect a person's ability to participate within them.
 
 If you believe someone is violating the code of conduct, we ask that you report
 it by emailing <conduct@riot-rs.org>. For more details please see our [Reporting
-Guidelines](https://future-proof-iot.github.io/RIOT-rs/dev/CoC_reporting.html).
+Guidelines](https://future-proof-iot.github.io/RIOT-rs/dev/COC_reporting.html).
 
 -   **Be friendly and patient.**
 -   **Be welcoming.** We strive to be a community that welcomes and supports


### PR DESCRIPTION
## Contribution description

This commit changes the link to the Reporting Guidelines to the correct location in the CODE_OF_CONDUCT.md file. 
The old link was incorrect, it referred to a non-existent location.

## Testing procedure

Test the link, check if it is redirecting to the correct location.