### PR TITLE
examples: add new `threading-channel` example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,6 +2882,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "threading-channel"
+version = "0.1.0"
+dependencies = [
+ "riot-rs",
+ "riot-rs-boards",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -14,3 +14,4 @@ subdirs:
   - hello-world
   - minimal
   - threading
+  - threading-channel

--- a/examples/threading-channel/Cargo.toml
+++ b/examples/threading-channel/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "threading-channel"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/threading-channel/README.md
+++ b/examples/threading-channel/README.md
@@ -1,0 +1,13 @@
+# Threading Channel
+
+## About
+
+This application demonstrates the usage of a channel for message passing between threads.
+
+## How to run
+
+In this folder, run
+
+    laze build -b nrf52840dk run
+
+The application will start two threads and print a message that one thread received from the other.

--- a/examples/threading-channel/laze.yml
+++ b/examples/threading-channel/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: threading-channel
+    selects:
+      - ?release

--- a/examples/threading-channel/src/main.rs
+++ b/examples/threading-channel/src/main.rs
@@ -1,0 +1,28 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::debug::println;
+use riot_rs::thread::channel::Channel;
+
+static CHANNEL: Channel<u8> = Channel::new();
+
+#[riot_rs::thread(autostart)]
+fn thread0() {
+    let my_id = riot_rs::thread::current_pid().unwrap();
+    println!("[Thread {}] Sending a message...", my_id);
+    CHANNEL.send(&42);
+}
+
+#[riot_rs::thread(autostart, stacksize = 4096, priority = 2)]
+fn thread1() {
+    let my_id = riot_rs::thread::current_pid().unwrap();
+    println!("[Thread {}] Waiting to receive a message...", my_id);
+    let recv = CHANNEL.recv();
+    println!(
+        "[Thread {}] The answer to the Ultimate Question of Life, the Universe, and Everything is: {}.",
+        my_id,
+        recv
+    );
+}


### PR DESCRIPTION
Demonstrate the usage of a channel for message passing between threads.

See https://github.com/future-proof-iot/RIOT-rs/pull/183#issuecomment-1999231583 and https://github.com/future-proof-iot/RIOT-rs/pull/152#discussion_r1537551699.