### PR TITLE
Establish CoAP playground

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,9 @@ jobs:
         with:
           toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
           targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,thumbv6m-none-eabi,thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv8m.main-none-eabi
-          components: rust-src
+          # rust-src: Used for -Zbuild-std.
+          # rustfmt: Used by bindgen for liboscore
+          components: rust-src, rustfmt
 
       - name: rust cache
         if: steps.result-cache.outputs.cache-hit != 'true'
@@ -75,7 +77,7 @@ jobs:
           git config --global user.name "CI"
           cargo binstall --no-confirm --no-symlinks --force --no-discover-github-token laze
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          sudo apt-get install ninja-build
+          sudo apt-get install ninja-build gcc-arm-none-eabi
 
       - name: "limit build unless nightly build"
         if: github.event_name != 'schedule'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -38,10 +73,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.81"
+name = "alloc-traits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "6b2d54853319fd101b8dd81de382bcbf3e03410a64d8928bbee85a3e7dcde483"
+
+[[package]]
+name = "anyhow"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "arrayvec"
@@ -110,10 +151,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
+name = "atty"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "az"
@@ -135,6 +187,12 @@ name = "bare-metal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "basic-toml"
@@ -159,6 +217,28 @@ version = "0.1.0"
 dependencies = [
  "riot-rs",
  "riot-rs-boards",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.109",
+ "which",
 ]
 
 [[package]]
@@ -196,9 +276,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array 0.14.7",
+]
 
 [[package]]
 name = "bytemuck"
@@ -219,18 +308,140 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbindgen"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b922faaf31122819ec80c4047cc684c6979a087366c069611e33649bf98e18d"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap 1.9.3",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+ "tempfile",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+
+[[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.35"
+name = "chacha20"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_lex",
+ "indexmap 1.9.3",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -238,6 +449,147 @@ name = "clist"
 version = "0.1.1"
 dependencies = [
  "memoffset",
+]
+
+[[package]]
+name = "coap"
+version = "0.1.0"
+dependencies = [
+ "coap-handler",
+ "coap-handler-implementations",
+ "coap-message",
+ "coap-message-demos",
+ "coap-message-implementations",
+ "coap-message-utils",
+ "coap-numbers",
+ "coap-request",
+ "coap-request-implementations",
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-net",
+ "embassy-time",
+ "embedded-io-async",
+ "embedded-nal-async",
+ "embedded-nal-coap",
+ "heapless 0.8.0",
+ "hexlit",
+ "lakers",
+ "lakers-crypto-rustcrypto",
+ "liboscore",
+ "liboscore-msgbackend",
+ "minicbor 0.23.0",
+ "riot-rs",
+ "riot-rs-boards",
+ "smoltcp",
+ "static-alloc",
+]
+
+[[package]]
+name = "coap-handler"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8600ae8e54c9be6e0c5273fad0503e12f827742e4e3fea5a521412478d603b72"
+dependencies = [
+ "coap-message",
+ "coap-numbers",
+]
+
+[[package]]
+name = "coap-handler-implementations"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2735f53da500caae442466ba2126d62458e86116ec1e273919880410f7e187b"
+dependencies = [
+ "ciborium-io",
+ "coap-handler",
+ "coap-message",
+ "coap-message-utils",
+ "coap-numbers",
+ "crc",
+ "document-features",
+ "embedded-io 0.4.0",
+ "minicbor 0.19.1",
+ "serde",
+ "serde_cbor",
+ "windowed-infinity",
+]
+
+[[package]]
+name = "coap-message"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae18782d02e6afdfcfaf48eb7ec591b0cae57b67b637441a490752d4a57db02f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "coap-message-demos"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49342f485367852eb9d5acb6545d0107b5565752c70a9600cf7e58f00482c9a"
+dependencies = [
+ "coap-handler",
+ "coap-handler-implementations",
+ "coap-message",
+ "coap-message-utils",
+ "coap-numbers",
+ "coap-request",
+ "heapless 0.7.17",
+ "serde",
+]
+
+[[package]]
+name = "coap-message-implementations"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b11a790471777e78eb68d908d300034b07a98bc43378a6b81159948c1361cd"
+dependencies = [
+ "coap-message",
+ "coap-message-utils",
+ "coap-numbers",
+ "document-features",
+ "heapless 0.5.6",
+]
+
+[[package]]
+name = "coap-message-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d57c1e386dfabcc211aefd8d0cc64e8fa6ebc799736ee639a888e0e2af2734ea"
+dependencies = [
+ "coap-message",
+ "coap-numbers",
+ "document-features",
+ "heapless 0.5.6",
+ "minicbor 0.19.1",
+]
+
+[[package]]
+name = "coap-numbers"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d78a5634393ab2c11d173d66107200a730e200a3b3ca063c344d4459c90a5f9"
+
+[[package]]
+name = "coap-request"
+version = "0.2.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58d76d947d49b867e8f0268cbd690156fe506335247b538284551fe404d2d16c"
+dependencies = [
+ "coap-message",
+]
+
+[[package]]
+name = "coap-request-implementations"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc15c3be00d32fe7c2b58a7546eff18fb1f3e7d2dea74d91eaacd4346960851f"
+dependencies = [
+ "coap-message",
+ "coap-message-utils",
+ "coap-numbers",
+ "coap-request",
 ]
 
 [[package]]
@@ -249,6 +601,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-sha1"
@@ -298,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee84e813d593101b1723e13ec38b6ab6abbdbaaa4546553f5395ed274079ddb1"
+checksum = "2722f5b7d6ea8583cffa4d247044e280ccbb9fe501bed56552e2ba48b02d5f3d"
 dependencies = [
  "cortex-m-rt-macros",
 ]
@@ -326,6 +684,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
 name = "crc-any"
 version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +709,12 @@ checksum = "c01a5e1f881f6fb6099a7bdf949e946719fd4f1fefa56264890574febf0eb6d0"
 dependencies = [
  "debug-helper",
 ]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -354,6 +736,37 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.7",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cyw43"
@@ -406,7 +819,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -417,7 +830,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -431,6 +844,16 @@ name = "debug-helper"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "derive_more"
@@ -448,6 +871,17 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "dirs-next"
@@ -492,9 +926,28 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array 0.14.7",
+ "group",
+ "hkdf",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embassy"
@@ -527,7 +980,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.5.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#9e283f29b4c76912c4fbf7c792782263c98e6ffb"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#e47fe1e51c52b92b1c07c62a64209c5bdb0b6226"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -546,7 +999,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -558,7 +1011,7 @@ checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
 [[package]]
 name = "embassy-hal-internal"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#9e283f29b4c76912c4fbf7c792782263c98e6ffb"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#e47fe1e51c52b92b1c07c62a64209c5bdb0b6226"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -587,7 +1040,7 @@ dependencies = [
 [[package]]
 name = "embassy-net"
 version = "0.4.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#e47fe1e51c52b92b1c07c62a64209c5bdb0b6226"
 dependencies = [
  "as-slice 0.2.1",
  "atomic-pool",
@@ -608,7 +1061,8 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524eb3c489760508f71360112bca70f6e53173e6fe48fc5f0efd0f5ab217751d"
 
 [[package]]
 name = "embassy-net-driver-channel"
@@ -650,9 +1104,9 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#9e283f29b4c76912c4fbf7c792782263c98e6ffb"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#e47fe1e51c52b92b1c07c62a64209c5bdb0b6226"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "cortex-m",
  "cortex-m-rt",
@@ -667,7 +1121,7 @@ dependencies = [
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
- "embedded-io",
+ "embedded-io 0.6.1",
  "embedded-io-async",
  "embedded-storage",
  "embedded-storage-async",
@@ -709,7 +1163,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-nb",
- "embedded-io",
+ "embedded-io 0.6.1",
  "embedded-io-async",
  "embedded-storage",
  "embedded-storage-async",
@@ -738,7 +1192,8 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.5.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd938f25c0798db4280fcd8026bf4c2f48789aebf8f77b6e5cf8a7693ba114ec"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -750,7 +1205,8 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.3.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c844070d9f80dc66ee739299183312baee2e1cdeb6e90b4ea2af44f4676da5"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -767,7 +1223,8 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c214077aaa9206958b16411c157961fb7990d4ea628120a78d1a5a28aed24"
 dependencies = [
  "document-features",
 ]
@@ -775,7 +1232,8 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
 
 [[package]]
 name = "embassy-usb"
@@ -877,6 +1335,12 @@ dependencies = [
 
 [[package]]
 name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
@@ -887,7 +1351,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
- "embedded-io",
+ "embedded-io 0.6.1",
 ]
 
 [[package]]
@@ -909,6 +1373,24 @@ dependencies = [
  "embedded-io-async",
  "embedded-nal",
  "no-std-net",
+]
+
+[[package]]
+name = "embedded-nal-coap"
+version = "0.1.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1954b4c5d15dd2db0267ae813883dc679ba9e135d3c16c335e13af0b7d5335e2"
+dependencies = [
+ "coap-handler",
+ "coap-message",
+ "coap-message-implementations",
+ "coap-numbers",
+ "coap-request",
+ "embassy-futures",
+ "embassy-sync 0.3.0",
+ "embedded-nal-async",
+ "heapless 0.7.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -964,13 +1446,13 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cdc46ec28bd728e67540c528013c6a10eb69a02eb31078a1bda695438cbfb8"
+checksum = "c19cbb53d33b57ac4df1f0af6b92c38c107cded663c4aea9fae1189dcfc17cf5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -991,7 +1473,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1001,13 +1483,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "esp-hal"
 version = "0.15.0"
 source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-290224#0377453b0b2a72c0e91244ed1550f21a7a2c4be6"
 dependencies = [
  "basic-toml",
  "bitfield 0.14.0",
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "critical-section",
  "document-features",
@@ -1021,7 +1513,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-nb",
- "embedded-io",
+ "embedded-io 0.6.1",
  "embedded-io-async",
  "enumset",
  "esp-hal-procmacros",
@@ -1060,7 +1552,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1094,7 +1586,7 @@ dependencies = [
  "embassy-futures",
  "embassy-net-driver",
  "embassy-sync 0.5.0",
- "embedded-io",
+ "embedded-io 0.6.1",
  "embedded-io-async",
  "enumset",
  "esp-hal",
@@ -1222,14 +1714,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixed"
-version = "1.26.0"
+name = "fastrand"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4810bcba5534219e7c160473f3a59167e2c98bd7516bc0eec5185848bcd38963"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fixed"
+version = "1.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc715d38bea7b5bf487fcd79bcf8c209f0b58014f3018a7a19c2b855f472048"
 dependencies = [
  "az",
  "bytemuck",
- "half",
+ "half 2.4.1",
  "typenum",
 ]
 
@@ -1241,9 +1749,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "4556222738635b7a3417ae6130d8f52201e45a0c4d1a907f0826383adb5f85e7"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1311,7 +1819,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1372,17 +1880,28 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1392,13 +1911,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "half"
-version = "2.4.0"
+name = "group"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1421,6 +1966,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
@@ -1436,6 +1987,18 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heapless"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+dependencies = [
+ "as-slice 0.1.5",
+ "generic-array 0.13.3",
+ "hash32 0.1.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
@@ -1443,6 +2006,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version 0.4.0",
+ "serde",
  "spin",
  "stable_deref_trait",
 ]
@@ -1475,9 +2039,51 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hexlit"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b6e75c860d4216ac53f9ac88b25c99eaedba075b3a7b2ed31f2adc51a74fffd"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "httparse"
@@ -1493,12 +2099,31 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1507,7 +2132,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys",
 ]
@@ -1523,15 +2148,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "konst"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d712a8c49d4274f8d8a5cf61368cb5f3c143d149882b1a2918129e53395fdb0"
+checksum = "50a0ba6de5f7af397afff922f22c149ff605c766cd3269cf6c1cd5e466dbe3b9"
 dependencies = [
  "const_panic",
  "konst_kernel",
@@ -1540,12 +2165,43 @@ dependencies = [
 
 [[package]]
 name = "konst_kernel"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac6ea8c376b6e208a81cf39b8e82bebf49652454d98a4829e907dac16ef1790"
+checksum = "be0a455a1719220fd6adf756088e1c69a85bf14b6a9e24537a5cc04f503edb2b"
 dependencies = [
  "typewit",
 ]
+
+[[package]]
+name = "lakers"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905e14c2e72626a749cfe6e0b64454ac2e51de3e36cc2ba077b0abc5af5fa535"
+dependencies = [
+ "lakers-shared",
+]
+
+[[package]]
+name = "lakers-crypto-rustcrypto"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6523b65ffa787062edf5907ce9e8500bde82eb3880d3c5d01e2119da12c4653a"
+dependencies = [
+ "aead",
+ "aes",
+ "ccm",
+ "hkdf",
+ "lakers-shared",
+ "p256",
+ "rand_core",
+ "sha2",
+]
+
+[[package]]
+name = "lakers-shared"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ddf0b16bd9c88daa047e2ac190ff90fd685990a14ab8b47dfa6ecc28b43247"
 
 [[package]]
 name = "lalrpop"
@@ -1579,6 +2235,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "ld-memory"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,20 +2265,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "libredox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+name = "liboscore"
+version = "0.1.0"
+source = "git+https://gitlab.com/oscore/liboscore/?rev=e7a4ecd037cbb9c7f085047fec5896f4bdc68d50#e7a4ecd037cbb9c7f085047fec5896f4bdc68d50"
 dependencies = [
- "bitflags 2.4.2",
+ "bindgen",
+ "cbindgen",
+ "cc",
+ "coap-message",
+ "coap-message-implementations",
+ "coap-numbers",
+ "liboscore-cryptobackend",
+ "liboscore-msgbackend",
+ "pretty-hex",
+]
+
+[[package]]
+name = "liboscore-cryptobackend"
+version = "0.1.0"
+source = "git+https://gitlab.com/oscore/liboscore/?rev=e7a4ecd037cbb9c7f085047fec5896f4bdc68d50#e7a4ecd037cbb9c7f085047fec5896f4bdc68d50"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "ccm",
+ "chacha20poly1305",
+ "crypto-common",
+ "heapless 0.7.17",
+ "hkdf",
+ "hmac",
+ "sha2",
+ "typenum",
+]
+
+[[package]]
+name = "liboscore-msgbackend"
+version = "0.1.0"
+source = "git+https://gitlab.com/oscore/liboscore/?rev=e7a4ecd037cbb9c7f085047fec5896f4bdc68d50#e7a4ecd037cbb9c7f085047fec5896f4bdc68d50"
+dependencies = [
+ "coap-message",
+ "coap-message-implementations",
+ "coap-numbers",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
  "libc",
- "redox_syscall",
 ]
 
 [[package]]
@@ -1636,8 +2357,14 @@ checksum = "adf157a4dc5a29b7b464aa8fe7edeff30076e07e13646a1c3874f58477dc99f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "litrs"
@@ -1650,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1672,9 +2399,9 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
@@ -1708,10 +2435,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "minijinja"
-version = "1.0.12"
+name = "minicbor"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe0ff215195a22884d867b547c70a0c4815cbbcc70991f281dca604b20d10ce"
+checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
+
+[[package]]
+name = "minicbor"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ded7eb446d01ad767689ff97ac883a548f6e0d266f20a8cb593b67c9d2590b3"
+
+[[package]]
+name = "minijinja"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e877d961d4f96ce13615862322df7c0b6d169d40cab71a7ef3f9b9e594451e"
 dependencies = [
  "serde",
 ]
@@ -1723,6 +2462,12 @@ dependencies = [
  "riot-rs",
  "riot-rs-boards",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1756,15 +2501,25 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "new_debug_unreachable"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nrf51"
@@ -1973,7 +2728,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2027,6 +2782,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "elliptic-curve",
+ "primeorder",
+]
+
+[[package]]
 name = "panic-semihosting"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2048,15 +2825,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2077,13 +2854,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -2116,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -2167,6 +2950,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,7 +2999,7 @@ checksum = "a33fa6ec7f2047f572d49317cca19c87195de99c6e5b6ee492da701cfe02b053"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2207,6 +3013,21 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -2243,18 +3064,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2305,18 +3126,18 @@ version = "0.1.1"
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
  "libredox",
@@ -2325,14 +3146,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -2343,7 +3164,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -2354,9 +3175,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "ringbuffer"
@@ -2470,7 +3291,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "riot-rs",
- "syn 2.0.52",
+ "syn 2.0.60",
  "trybuild",
 ]
 
@@ -2605,6 +3426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,10 +3450,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
+name = "rustix"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "ruzstd"
@@ -2652,6 +3492,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array 0.14.7",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2674,29 +3527,39 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.197"
+name = "serde_cbor"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.198"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -2713,6 +3576,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,14 +3600,14 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smoltcp"
 version = "0.11.0"
-source = "git+https://github.com/smoltcp-rs/smoltcp.git#125773e282bc2e0c914a49e9c75573926e26e558"
+source = "git+https://github.com/smoltcp-rs/smoltcp.git?rev=125773e282bc2e0c914a49e9c75573926e26e558#125773e282bc2e0c914a49e9c75573926e26e558"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -2760,6 +3640,15 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static-alloc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2975e035ce16539eecee08d7c6e5626ca26f299c6e90af343b302c6dd2e61e"
+dependencies = [
+ "alloc-traits",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2874,8 +3763,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2890,13 +3785,25 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2920,23 +3827,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.58"
+name = "textwrap"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+
+[[package]]
+name = "thiserror"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2958,14 +3871,23 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.11"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.7",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -2978,8 +3900,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.52",
- "toml",
+ "syn 2.0.60",
+ "toml 0.8.12",
 ]
 
 [[package]]
@@ -2997,37 +3919,37 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.7"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow 0.6.6",
 ]
 
 [[package]]
 name = "trybuild"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9d3ba662913483d6722303f619e75ea10b7855b0f8e0d72799cf8621bb488f"
+checksum = "8ad7eb6319ebadebca3dacf1f85a93bc54b73dd81b9036795f73de7ddfe27d5a"
 dependencies = [
- "basic-toml",
  "glob",
  "once_cell",
  "serde",
  "serde_derive",
  "serde_json",
  "termcolor",
+ "toml 0.8.12",
 ]
 
 [[package]]
@@ -3084,6 +4006,16 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "usb-device"
@@ -3160,6 +4092,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,11 +4121,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3191,127 +4135,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windowed-infinity"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9487d1d565a9db59e1fd0b3c2d3f0c277bc375d348a6c46ff2b322917fbc035"
+dependencies = [
+ "ciborium-io",
+ "crc",
+ "digest",
+ "embedded-io 0.4.0",
+ "minicbor 0.19.1",
+ "serde",
+ "serde_cbor",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.4"
+name = "windows_i686_gnullvm"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -3324,9 +4233,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
 dependencies = [
  "memchr",
 ]
@@ -3364,7 +4273,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3384,5 +4293,11 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.60",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,8 +587,7 @@ dependencies = [
 [[package]]
 name = "embassy-net"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cf91dd36dfd623de32242af711fd294d41159f02130052fc93c5c5ba93febe"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
 dependencies = [
  "as-slice 0.2.1",
  "atomic-pool",
@@ -609,8 +608,7 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524eb3c489760508f71360112bca70f6e53173e6fe48fc5f0efd0f5ab217751d"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
 
 [[package]]
 name = "embassy-net-driver-channel"
@@ -740,8 +738,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd938f25c0798db4280fcd8026bf4c2f48789aebf8f77b6e5cf8a7693ba114ec"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -753,8 +750,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c844070d9f80dc66ee739299183312baee2e1cdeb6e90b4ea2af44f4676da5"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -771,8 +767,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c214077aaa9206958b16411c157961fb7990d4ea628120a78d1a5a28aed24"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
 dependencies = [
  "document-features",
 ]
@@ -780,8 +775,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-100424#58d45e9889216bc0e35ef1d580edfba534e5f408"
 
 [[package]]
 name = "embassy-usb"
@@ -2733,8 +2727,7 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 [[package]]
 name = "smoltcp"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1a996951e50b5971a2c8c0fa05a381480d70a933064245c4a223ddc87ccc97"
+source = "git+https://github.com/smoltcp-rs/smoltcp.git#125773e282bc2e0c914a49e9c75573926e26e558"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,8 +89,12 @@ opt-level = 3
 embassy-executor = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-100424" }
 embassy-hal-internal = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-100424" }
 embassy-nrf = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-100424" }
+embassy-net = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-100424" }
 
 usbd-hid-macros = { git = "https://github.com/kaspar030/usbd-hid", branch = "for-riot-rs" }
+
+# version 0.12-to-be
+smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "125773e282bc2e0c914a49e9c75573926e26e558" }
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "warn"

--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "coap"
+version = "0.1.0"
+authors = ["Christian Amsüss <chrysn@fsfe.org>"]
+edition.workspace = true
+publish = false
+
+[dependencies]
+embassy-executor = { workspace = true, default-features = false }
+embassy-net = { workspace = true, features = ["udp"] }
+embassy-time = { workspace = true, default-features = false }
+embedded-io-async = "0.6.1"
+heapless = { workspace = true }
+riot-rs = { path = "../../src/riot-rs", features = [
+  "override-network-config",
+  "random",
+  "csprng",
+] }
+riot-rs-boards = { path = "../../src/riot-rs-boards" }
+
+# for the udp_nal mod
+embedded-nal-async = "0.7"
+# actually patched with https://github.com/smoltcp-rs/smoltcp/pull/904 but
+# patch.crates-io takes care of that
+smoltcp = { version = "0.11", default-features = false }
+embedded-nal-coap = "0.1.0-alpha.2"
+coap-request = "0.2.0-alpha.2"
+coap-message = "0.3.1"
+embassy-futures = "0.1.1"
+coap-message-demos = { version = "0.4.0", default-features = false }
+coap-request-implementations = "0.1.0-alpha.4"
+lakers = { version = "0.5.1", default-features = false }
+lakers-crypto-rustcrypto = "0.5.1"
+coap-handler = "0.2.0"
+coap-message-utils = "0.3.2"
+coap-handler-implementations = "0.5.0"
+hexlit = "0.5.5"
+coap-numbers = "0.2.3"
+minicbor = "0.23.0"
+
+liboscore = { git = "https://gitlab.com/oscore/liboscore/", rev = "e7a4ecd037cbb9c7f085047fec5896f4bdc68d50" }
+liboscore-msgbackend = { git = "https://gitlab.com/oscore/liboscore/", features = [
+  "alloc",
+], rev = "e7a4ecd037cbb9c7f085047fec5896f4bdc68d50" }
+coap-message-implementations = "0.1.1"
+static-alloc = "0.2.5"
+
+[features]
+default = ["proto-ipv4"] # shame
+# actually embedded-nal features, we have to match them here while developing udp_nal in here
+proto-ipv4 = []
+proto-ipv6 = []

--- a/examples/coap/README.md
+++ b/examples/coap/README.md
@@ -1,0 +1,14 @@
+# coap demo
+
+## About
+
+This application is a work in progress demo of running CoAP with OSCORE/EDHOC security on RIOT-rs.
+
+## Roadmap
+
+Eventually, this should be a 20 line demo.
+
+Until the CoAP roadmap is complete,
+this serves as a work bench, test bed, demo zone and playground at the same time.
+This application will grow as parts of the roadmap are added,
+and shrink as they become default or are wrapped into components of RIOT-rs.

--- a/examples/coap/fauxhoc.py
+++ b/examples/coap/fauxhoc.py
@@ -1,0 +1,145 @@
+"""
+fake-it-until-you-make-it wrapper for sending an EDHOC+OSCORE request
+
+Its first stage did roughly
+
+~~~
+$ ./aiocoap-client 'coap://10.42.0.61/.well-known/edhoc' -m POST --content-format application/cbor-seq --payload "[true, 3, 2, h'0000000000000000000000000000000000000000000000000000000000000000', 0]"
+~~~
+
+and the later guessed the C_R and sent a garbled OSCORE request that triggered
+the EDHOC CoAP pathways.
+
+Now it does EDHOC using lakers to a point where the name doesn't fit any more…
+"""
+
+import asyncio
+import cbor2
+from aiocoap import *
+from aiocoap import numbers, oscore
+
+import lakers
+
+# Someone told us that these are the credentials of devices that are our legitimate peers
+eligible_responders_ccs = {
+    bytes.fromhex(
+        "A2026008A101A5010202410A2001215820BBC34960526EA4D32E940CAD2A234148DDC21791A12AFBCBAC93622046DD44F02258204519E257236B2A0CE2023F0931F1F386CA7AFDA64FCDE0108C224C51EABF6072"
+    )
+}
+eligible_responders = {}  # mapping ID_CRED_R to CRED_R
+# when ID_CRED_R is the KID. 8/1/2 is cnf/COSE_Key/kid, IIUC those should be present in suitable CCSs
+eligible_responders |= {
+    parsed[8][1][2]: ccs
+    for (parsed, ccs) in ((cbor2.loads(ccs), ccs) for ccs in eligible_responders_ccs)
+}
+# when ID_CRED_R is CRED_R
+eligible_responders |= {ccs: ccs for ccs in eligible_responders_ccs}
+
+CRED_I = bytes.fromhex(
+    "A2027734322D35302D33312D46462D45462D33372D33322D333908A101A5010202412B2001215820AC75E9ECE3E50BFC8ED60399889522405C47BF16DF96660A41298CB4307F7EB62258206E5DE611388A4B8A8211334AC7D37ECB52A387D257E6DB3C2A93DF21FF3AFFC8"
+)
+I = bytes.fromhex("fb13adeb6518cee5f88417660841142e830a81fe334380a953406a1305e8706b")
+
+
+class EdhocSecurityContext(
+    oscore.CanProtect, oscore.CanUnprotect, oscore.SecurityContextUtils
+):
+    def __init__(self, initiator, c_ours, c_theirs):
+        # initiator could also be responder, and only this line would need to change
+        # FIXME Only ByReference implemented in edhoc.rs so far
+        self.message_3, _i_prk_out = initiator.prepare_message_3(
+            lakers.CredentialTransfer.ByReference, None
+        )
+
+        if initiator.selected_cipher_suite() == 2:
+            self.alg_aead = oscore.algorithms["AES-CCM-16-64-128"]
+            self.hashfun = oscore.hashfunctions["sha256"]
+        else:
+            raise RuntimeError("Unknown suite")
+
+        # we check critical EADs, no out-of-band agreement, so 8 it is
+        oscore_salt_length = 8
+        # I figure that one would be ageed out-of-band as well
+        self.id_context = None
+        self.recipient_replay_window = oscore.ReplayWindow(32, lambda: None)
+
+        master_secret = initiator.edhoc_exporter(0, [], self.alg_aead.key_bytes)
+        master_salt = initiator.edhoc_exporter(1, [], oscore_salt_length)
+        print(f"Derived {master_secret=} {master_salt=}")
+
+        self.sender_id = cbor2.dumps(c_theirs)
+        self.recipient_id = cbor2.dumps(c_ours)
+        if self.sender_id == self.recipient_id:
+            raise ValueError("Bad IDs: identical ones were picked")
+
+        self.derive_keys(master_salt, master_secret)
+
+        self.sender_sequence_number = 0
+        self.recipient_replay_window.initialize_empty()
+
+    def post_seqnoincrease(self):
+        pass
+
+    def protect(self, message, request_id=None, *, kid_context=True):
+        outer_message, request_id = super().protect(
+            message, request_id=request_id, kid_context=kid_context
+        )
+        if self.message_3 is not None:
+            outer_message.opt.edhoc = True
+            outer_message.payload = self.message_3 + outer_message.payload
+            self.message_3 = None
+        return outer_message, request_id
+
+
+async def main():
+    ctx = await Context.create_client_context()
+
+    priv, pub = lakers.p256_generate_key_pair()
+
+    c_i = 0x08
+    initiator = lakers.EdhocInitiator()
+    message_1 = initiator.prepare_message_1(c_i=c_i)
+
+    msg1 = Message(
+        code=POST,
+        uri="coap://10.42.0.61/.well-known/edhoc",
+        payload=cbor2.dumps(True) + message_1,
+        # payload=b"".join(cbor2.dumps(x) for x in [True, 3, 2, b'\0' * 32, 0]),
+    )
+    msg2 = await ctx.request(msg1).response_raising
+
+    (c_r, id_cred_r, ead_2) = initiator.parse_message_2(msg2.payload)
+    # https://github.com/openwsn-berkeley/lakers/issues/256 -- conveniently,
+    # after it is fixed, the line becomes a no-op, so this can stay in until a
+    # Lakers release to PyPI happened.
+    id_cred_r = bytes(id_cred_r)
+
+    print(f"Received MSG2 with {c_r=} {id_cred_r=} {ead_2=}")
+
+    cred_r = eligible_responders[id_cred_r]
+    initiator.verify_message_2(
+        I, CRED_I, cred_r
+    )  # odd that we provide that here rather than in the next function
+
+    oscore_context = EdhocSecurityContext(initiator, c_i, c_r)
+
+    ctx.client_credentials["coap://10.42.0.61/*"] = oscore_context
+
+    msg3 = Message(
+        code=GET,
+        uri="coap://10.42.0.61/.well-known/core",
+    )
+
+    print((await ctx.request(msg3).response_raising).payload)
+
+    normalrequest = Message(
+        code=GET,
+        uri="coap://10.42.0.61/poem",
+    )
+    print((await ctx.request(normalrequest).response).payload)
+
+    await ctx.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/coap/laze.yml
+++ b/examples/coap/laze.yml
@@ -1,0 +1,10 @@
+apps:
+  - name: coap
+    env:
+      global:
+        CARGO_ENV:
+          - CONFIG_ISR_STACKSIZE=16384
+    selects:
+      - ?release
+      - network
+      - random

--- a/examples/coap/src/main.rs
+++ b/examples/coap/src/main.rs
@@ -1,0 +1,138 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::{debug::println, embassy::network};
+
+use embassy_net::udp::{PacketMetadata, UdpSocket};
+
+// Moving work from https://github.com/embassy-rs/embassy/pull/2519 in here for the time being
+mod udp_nal;
+
+mod seccontext;
+
+#[riot_rs::task(autostart)]
+async fn coap_run() {
+    let stack = network::network_stack().await.unwrap();
+
+    // FIXME trim to CoAP requirements
+    let mut rx_meta = [PacketMetadata::EMPTY; 16];
+    let mut rx_buffer = [0; 4096];
+    let mut tx_meta = [PacketMetadata::EMPTY; 16];
+    let mut tx_buffer = [0; 4096];
+
+    let socket = UdpSocket::new(
+        stack,
+        &mut rx_meta,
+        &mut rx_buffer,
+        &mut tx_meta,
+        &mut tx_buffer,
+    );
+
+    println!("Starting up CoAP server");
+
+    // Can't that even bind to the Any address??
+    // let local_any = "0.0.0.0:5683".parse().unwrap(); // shame
+    let local_any = "10.42.0.61:5683".parse().unwrap(); // shame
+    let unconnected = udp_nal::UnconnectedUdp::bind_multiple(socket, local_any)
+        .await
+        .unwrap();
+
+    run(unconnected).await;
+}
+
+// FIXME: So far, this is necessary boiler plate; see ../README.md#networking for details
+#[riot_rs::config(network)]
+fn network_config() -> embassy_net::Config {
+    use embassy_net::Ipv4Address;
+
+    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+        dns_servers: heapless::Vec::new(),
+        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    })
+}
+
+// Rest is from coap-message-demos/examples/std_embedded_nal_coap.rs
+
+/// This function works on *any* UdpFullStack, including embedded ones -- only main() is what makes
+/// this use POSIX sockets. (It does make use of a std based RNG, but that could be passed in just
+/// as well for no_std operation).
+async fn run<S>(mut sock: S)
+where
+    S: embedded_nal_async::UnconnectedUdp,
+{
+    use coap_handler_implementations::HandlerBuilder;
+
+    let log = None;
+
+    let mut secpool: seccontext::SecContextPool = Default::default();
+
+    use hexlit::hex;
+    const R: &[u8] = &hex!("72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac");
+    let own_identity = (
+        &lakers::CredentialRPK::new(lakers::EdhocMessageBuffer::new_from_slice(&hex!("A2026008A101A5010202410A2001215820BBC34960526EA4D32E940CAD2A234148DDC21791A12AFBCBAC93622046DD44F02258204519E257236B2A0CE2023F0931F1F386CA7AFDA64FCDE0108C224C51EABF6072")).expect("Credential should be small enough")).expect("Credential should be processable"),
+        R,
+        );
+
+    let mut handler = coap_message_demos::full_application_tree(log);
+
+    let mut handler = seccontext::OscoreEdhocHandler::new(own_identity, handler);
+
+    println!("Server is ready.");
+
+    let coap = embedded_nal_coap::CoAPShared::<3>::new();
+    let (client, server) = coap.split();
+
+    // going with an embassy_futures join instead of an async_std::task::spawn b/c CoAPShared is not
+    // Sync, and async_std expects to work in multiple threads
+    embassy_futures::join::join(
+        async {
+            server
+                .run(&mut sock, &mut handler, &mut riot_rs::random::fast_rng())
+                .await
+                .expect("UDP error")
+        },
+        run_client_operations(client),
+    )
+    .await;
+}
+
+/// In parallel to server operation, this function performs some operations as a client.
+///
+/// This doubles as an experimentation ground for the client side of embedded_nal_coap and
+/// coap-request in general.
+async fn run_client_operations<const N: usize>(
+    client: embedded_nal_coap::CoAPRuntimeClient<'_, N>,
+) {
+    // shame
+    let demoserver = "10.42.0.1:1234".parse().unwrap();
+
+    use coap_request::Stack;
+    println!("Sending GET to {}...", demoserver);
+    let response = client
+        .to(demoserver)
+        .request(
+            coap_request_implementations::Code::get()
+                .with_path("/other/separate")
+                .processing_response_payload_through(|p| {
+                    println!("Got payload {:?}", p);
+                }),
+        )
+        .await;
+    println!("Response {:?}", response);
+
+    let req = coap_request_implementations::Code::post().with_path("/uppercase");
+
+    println!("Sending POST...");
+    let mut response = client.to(demoserver);
+    let response = response.request(
+        req.with_request_payload_slice(b"Set time to 1955-11-05")
+            .processing_response_payload_through(|p| {
+                println!("Uppercase is {}", core::str::from_utf8(p).unwrap())
+            }),
+    );
+    let response = response.await;
+    println!("Response {:?}", response);
+}

--- a/examples/coap/src/seccontext.rs
+++ b/examples/coap/src/seccontext.rs
@@ -1,0 +1,674 @@
+use coap_message::{
+    error::RenderableOnMinimal, Code, MessageOption, MinimalWritableMessage,
+    MutableWritableMessage, ReadableMessage,
+};
+use coap_message_utils::{Error as CoAPError, OptionsExt as _};
+use core::borrow::Borrow;
+
+extern crate alloc;
+use static_alloc::Bump;
+
+#[global_allocator]
+static A: Bump<[u8; 1 << 16]> = Bump::uninit();
+
+// If this exceeds 47, COwn will need to be extended.
+const MAX_CONTEXTS: usize = 4;
+
+// On the long run, we'll probably provide an own implementation based on crypto primitive
+// implementations that work well for us.
+type LakersCrypto = lakers_crypto_rustcrypto::Crypto<riot_rs::random::CryptoRng>;
+
+/// A pool of security contexts sharable by several users inside a thread.
+///
+/// Access through the inner RefCell always happens with panicking errors, because all accessors
+/// (in this module, given it's a private member) promise to not call code would cause double
+/// locking. (And it's !Sync, so accessors will not be preempted).
+#[derive(Default)]
+pub struct SecContextPool(core::cell::RefCell<[SecContextState; MAX_CONTEXTS]>);
+
+impl SecContextPool {
+    /// Place a non-empty state in a slot and return its index, or return a 5.03 Service
+    /// Unavailable error
+    fn place_in_empty_slot(&self, new: SecContextState) -> Result<usize, CoAPError> {
+        for (index, place) in self.0.borrow_mut().iter_mut().enumerate() {
+            if matches!(place, SecContextState::Empty) {
+                *place = new;
+                return Ok(index);
+            }
+        }
+        for (index, place) in self.0.borrow_mut().iter_mut().enumerate() {
+            // As a possible improvement, define a "keep value" in 0..n, and find the slot withthe
+            // minimum keep value.
+            if place.is_gc_eligible() {
+                *place = new;
+                return Ok(index);
+            }
+        }
+        Err(CoAPError::service_unavailable())
+    }
+}
+
+/// An own identifier for a security context
+///
+/// This is used as C_I when in an initiator role, C_R when in a responder role, and recipient ID
+/// in OSCORE.
+///
+/// This type represents any of the 48 efficient identifiers that use CBOR one-byte integer
+/// encodings (see RFC9528 Section 3.3.2), or equivalently the 1-byte long OSCORE identifiers
+// FIXME Could even limit to positive values if MAX_CONTEXTS < 24
+#[derive(Copy, Clone, PartialEq, Debug)]
+struct COwn(u8);
+
+impl COwn {
+    /// Find a value of self that is not found in the iterator.
+    ///
+    /// This asserts that the iterator is (known to be) short enough that this will always succeed.
+    fn not_in_iter(iterator: impl Iterator<Item = Self>) -> Self {
+        // In theory, this would allow the compiler to see that the unreachable below is indeed
+        // unreachable
+        assert!(
+            iterator.size_hint().1.is_some_and(|v| v < 48),
+            "Too many slots to reliably assign connection identifier"
+        );
+        let mut seen_pos = 0u32;
+        let mut seen_neg = 0u32;
+        for i in iterator {
+            let major = i.0 >> 5;
+            // Let's not make unsafe assumptions on the own value range
+            let target = if major == 0 {
+                &mut seen_pos
+            } else {
+                &mut seen_neg
+            };
+            // Convenienlty, masking to the minor part puts us in the very range that allows u32
+            // shifting
+            *target |= 1 << (i.0 & 0x1f);
+        }
+        // trailing_ones = n implies that bit 1<<n is a zero and thus COwn(n) is free
+        let pos_to = seen_pos.trailing_ones();
+        if pos_to < 24 {
+            return Self(pos_to as u8);
+        }
+        let neg_to = seen_neg.trailing_ones();
+        if neg_to < 24 {
+            return Self(0x20 | neg_to as u8);
+        }
+        unreachable!("Iterator is not long enough ");
+    }
+
+    /// Given an OSCORE Key ID (kid), find the corresponding context identifier value
+    fn from_kid(kid: &[u8]) -> Option<Self> {
+        match kid {
+            [first] if *first <= 0x17 || (*first >= 0x20 && *first <= 0x37) => Some(Self(*first)),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+enum SecContextState {
+    #[default]
+    Empty,
+
+    // if we have time to spare, we can have empty-but-prepared-with-single-use-random-key entries
+    // :-)
+
+    // actionable in response building
+    //
+    // FIXME: The 'static here means that our identity key needs to be 'static -- if identity
+    // roll-over is a topic, that'd be a no-go. An alternative is to both store the message and the
+    // ResponderWaitM3 state -- but that'll make our SecContextPool slots larger; best evaluate
+    // that once the states are ready and we see which ones are the big ones. Possible outcomes are
+    // to just do it, to store the message in the handler's RequestData, or to have one or a few
+    // slots in parallel to this in the SecContextPool.
+    EdhocResponderProcessedM1(lakers::EdhocResponderProcessedM1<'static, LakersCrypto>),
+    //
+    EdhocResponderSentM2 {
+        responder: lakers::EdhocResponderWaitM3<LakersCrypto>,
+        c_r: COwn,
+    },
+
+    // FIXME: Also needs a flag for whether M4 was received; if not, it's GC'able
+    Oscore(liboscore::PrimitiveContext),
+}
+
+impl SecContextState {
+    fn corresponding_cown(&self) -> Option<COwn> {
+        match self {
+            SecContextState::Empty => None,
+            SecContextState::EdhocResponderProcessedM1(_) => None, // yet
+            SecContextState::EdhocResponderSentM2 { c_r, .. } => Some(*c_r),
+            SecContextState::Oscore(ctx) => COwn::from_kid(ctx.recipient_id()),
+        }
+    }
+
+    fn is_gc_eligible(&self) -> bool {
+        match self {
+            SecContextState::Empty => true, // but won't come to it
+            SecContextState::EdhocResponderProcessedM1(_) => {
+                // If this is ever tested, means we're outbound message limited, so let's try to
+                // get one through rather than pointlessly sending errors
+                false
+            }
+            SecContextState::EdhocResponderSentM2 { .. } => {
+                // So far, the peer didn't prove they have anything other than entropy (maybe not
+                // even that)
+                true
+            }
+            SecContextState::Oscore(_) => false,
+        }
+    }
+}
+
+/// A CoAP handler wrapping inner resources, and adding EDHOC and OSCORE support.
+///
+/// While the EDHOC part could be implemented as a handler that is to be added into the tree, the
+/// OSCORE part needs to wrap the inner handler anyway, and EDHOC and OSCORE are intertwined rather
+/// strongly in processing the EDHOC option.
+pub struct OscoreEdhocHandler<'a, H: coap_handler::Handler> {
+    pool: SecContextPool,
+    // FIXME: That 'static is going to bite us -- but EdhocResponderProcessedM1 holds a reference
+    // to it -- see SecContextState::EdhocResponderProcessedM1
+    own_identity: (&'a lakers::CredentialRPK, &'static [u8]),
+
+    // FIXME: This currently bakes in the assumption that there is a single tree both for
+    // unencrypted and encrypted resources. We may later generalize this by making this a factory,
+    // or a single item that has two AsMut<impl Handler> accessors for separate encrypted and
+    // unencrypted tree.
+    inner: H,
+}
+
+impl<'a, H: coap_handler::Handler> OscoreEdhocHandler<'a, H> {
+    pub fn new(own_identity: (&'a lakers::CredentialRPK, &'static [u8]), inner: H) -> Self {
+        Self {
+            pool: Default::default(),
+            own_identity,
+            inner,
+        }
+    }
+}
+
+pub enum EdhocResponse<I> {
+    // Taking a small state here: We already have a slot in the pool, storing the big data there
+    OkSend2(usize),
+    // Could have a state Message3Processed -- but do we really want to implement that? (like, just
+    // use the EDHOC option)
+    OscoreRequest {
+        slot: usize,
+        correlation: liboscore::raw::oscore_requestid_t,
+        extracted: I,
+    },
+}
+
+// FIXME: It'd be tempting to implement Drop for Response to set the slot back to Empty -- but
+// that'd be easier if we could avoid the Drop during enum destructuring, which AIU is currently
+// not supported in match or let destructuring. (But our is_gc_eligible should be good enough
+// anyway).
+
+/// Render a MessageBufferError into the common Error type.
+///
+/// It is yet to be determined whether anything more informative should be returned (likely it
+/// should; maybe Request Entity Too Large or some error code about unusable credential.
+///
+/// Places using this function may be simplified if From/Into is specified (possibly after
+/// enlarging the Error type)
+fn too_small(_e: lakers::MessageBufferError) -> CoAPError {
+    CoAPError::bad_request()
+}
+
+/// Render an EDHOCError into the common Error type.
+///
+/// It is yet to be decided based on the EDHOC specification which EDHOCError values would be
+/// reported with precise data, and which should rather produce a generic response.
+///
+/// Places using this function may be simplified if From/Into is specified (possibly after
+/// enlarging the Error type)
+fn render_error(_e: lakers::EDHOCError) -> CoAPError {
+    CoAPError::bad_request()
+}
+
+#[derive(Debug)]
+pub enum OrInner<O, I> {
+    Own(O),
+    Inner(I),
+}
+
+impl<O, I> From<O> for OrInner<O, I> {
+    fn from(own: O) -> Self {
+        OrInner::Own(own)
+    }
+}
+
+impl<O: RenderableOnMinimal, I: RenderableOnMinimal> RenderableOnMinimal for OrInner<O, I> {
+    type Error<IE> = OrInner<O::Error<IE>, I::Error<IE>> where IE: RenderableOnMinimal, IE: core::fmt::Debug;
+    fn render<M: MinimalWritableMessage>(
+        self,
+        msg: &mut M,
+    ) -> Result<(), Self::Error<M::UnionError>> {
+        match self {
+            OrInner::Own(own) => own.render(msg).map_err(OrInner::Own),
+            OrInner::Inner(inner) => inner.render(msg).map_err(OrInner::Inner),
+        }
+    }
+}
+
+impl<'a, H: coap_handler::Handler> coap_handler::Handler for OscoreEdhocHandler<'a, H> {
+    type RequestData =
+        OrInner<EdhocResponse<Result<H::RequestData, H::ExtractRequestError>>, H::RequestData>;
+
+    type ExtractRequestError = OrInner<CoAPError, H::ExtractRequestError>;
+    type BuildResponseError<M: MinimalWritableMessage> =
+        OrInner<M::UnionError, H::BuildResponseError<M>>;
+
+    fn extract_request_data<M: ReadableMessage>(
+        &mut self,
+        request: &M,
+    ) -> Result<Self::RequestData, Self::ExtractRequestError> {
+        use OrInner::{Inner, Own};
+
+        #[derive(Default, Copy, Clone, Debug)]
+        enum Recognition {
+            #[default]
+            Start,
+            /// Seen an OSCORE option
+            Oscore { kid: u8 },
+            /// Seen an OSCORE option and an EDHOC option
+            Edhoc { kid: u8 },
+            /// Seen path ".well-known" (after not having seen an OSCORE option)
+            WellKnown,
+            /// Seen path ".well-known" and "edhoc"
+            WellKnownEdhoc,
+            /// Seen anything else (where the request handler, or more likely the ACL filter, will
+            /// trip over the critical options)
+            Unencrypted,
+        }
+        use Recognition::*;
+
+        impl Recognition {
+            /// Given a state and an option, produce the next state and whether the option should
+            /// be counted as consumed for the purpose of assessing .well-known/edchoc's
+            /// ignore_elective_others().
+            fn update(self, o: &impl MessageOption) -> (Self, bool) {
+                use coap_numbers::option;
+
+                match (self, o.number(), o.value()) {
+                    // FIXME: Store full value (but a single one is sufficient while we do EDHOC
+                    // extraction)
+                    (Start, option::OSCORE, [.., kid]) => (Oscore { kid: *kid }, false),
+                    (Start, option::URI_PATH, b".well-known") => (WellKnown, false),
+                    (Start, option::URI_PATH, _) => (Unencrypted, true /* doesn't matter */),
+                    (Oscore { kid }, option::EDHOC, b"") => {
+                        (Edhoc { kid }, true /* doesn't matter */)
+                    }
+                    (WellKnown, option::URI_PATH, b"edhoc") => (WellKnownEdhoc, false),
+                    (any, _, _) => (any, true),
+                }
+            }
+        }
+
+        let mut state = Recognition::Start;
+
+        // Some small potential for optimization by cutting iteration short on Edhoc, but probably
+        // not worth it.
+        let extra_options = request
+            .options()
+            .filter(|o| {
+                let (new_state, filter) = state.update(o);
+                state = new_state;
+                filter
+            })
+            // FIXME: This aborts early on critical options, even when the result is later ignored
+            .ignore_elective_others();
+
+        if let (Err(error), WellKnownEdhoc) = (extra_options, state) {
+            // Critical options in all other cases are handled by the Unencrypted or Oscore
+            // handlers
+            return Err(Own(error));
+        }
+
+        match state {
+            Start | WellKnown | Unencrypted => self
+                .inner
+                .extract_request_data(request)
+                .map(Inner)
+                .map_err(Inner),
+            WellKnownEdhoc => {
+                if request.code().into() != coap_numbers::code::POST {
+                    return Err(Own(CoAPError::method_not_allowed()));
+                }
+
+                let first_byte = request
+                    .payload()
+                    .get(0)
+                    .ok_or_else(CoAPError::bad_request)?;
+                let starts_with_true = first_byte == &0xf5;
+
+                if starts_with_true {
+                    let message_1 =
+                        &lakers::EdhocMessageBuffer::new_from_slice(&request.payload()[1..])
+                            .map_err(too_small)?;
+
+                    let (responder, ead_1) = lakers::EdhocResponder::new(
+                        lakers_crypto_rustcrypto::Crypto::new(riot_rs::random::crypto_rng()),
+                        &self.own_identity.1,
+                        self.own_identity.0.clone(),
+                    )
+                    .process_message_1(message_1)
+                    .map_err(render_error)?;
+
+                    if ead_1.is_some_and(|e| e.is_critical) {
+                        // FIXME: send error message
+                        return Err(Own(CoAPError::bad_request()));
+                    }
+
+                    Ok(Own(EdhocResponse::OkSend2(self.pool.place_in_empty_slot(
+                        SecContextState::EdhocResponderProcessedM1(responder),
+                    )?)))
+                } else {
+                    // for the time being we'll only take the EDHOC option
+                    Err(Own(CoAPError::bad_request()))
+                }
+            }
+            Edhoc { kid } | Oscore { kid } => {
+                use crate::println;
+                let payload = request.payload();
+
+                // This whole loop-and-tree could become a single take_responder_wait3 method?
+                let cown = COwn::from_kid(&[kid]);
+                let mut pool_lock = self.pool.0.borrow_mut();
+                let (slot, matched) = pool_lock
+                    .iter_mut()
+                    .enumerate()
+                    .filter(|(slot, c)| c.corresponding_cown() == cown)
+                    .next()
+                    // following RFC8613 Section 8.2 item 2.2
+                    // FIXME unauthorized (unreleased in coap-message-utils)
+                    .ok_or_else(CoAPError::bad_request)?;
+
+                let front_trim_payload = if matches!(state, Edhoc { .. }) {
+                    // We're not supporting block-wise here -- but could later, to the extent we support
+                    // outer block-wise.
+
+                    // Workaround for https://github.com/openwsn-berkeley/lakers/issues/255
+                    let mut decoder = minicbor::decode::Decoder::new(payload);
+                    let _ = decoder
+                        .decode::<&minicbor::bytes::ByteSlice>()
+                        .map_err(|_| Own(CoAPError::bad_request()))?;
+                    let cutoff = decoder.position();
+
+                    // If we don't make progress, we're dropping it altogether. Unless we use the
+                    // responder we might legally continue (because we didn't send data to EDHOC), but
+                    // once we've received something that (as we now know) looks like a message 3 and
+                    // isn't processable, it's unlikely that another one would come up and be.
+                    let mut taken = core::mem::replace(matched, Default::default());
+
+                    if let SecContextState::EdhocResponderSentM2 { responder, c_r } = taken {
+                        let msg_3 = lakers::EdhocMessageBuffer::new_from_slice(&payload[..cutoff])
+                            .map_err(|e| Own(too_small(e)))?;
+
+                        let (responder, id_cred_i, ead_3) =
+                            responder.parse_message_3(&msg_3).map_err(render_error)?;
+
+                        if ead_3.is_some_and(|e| e.is_critical) {
+                            // FIXME: send error message
+                            return Err(Own(CoAPError::bad_request()));
+                        }
+
+                        // FIXME: Right now this can only do credential-by-value
+                        if id_cred_i.reference_only() {
+                            println!("Got reference only, need to upgrade");
+                        } else {
+                            println!("Got full credential, need to evaluate")
+                        }
+
+                        use hexlit::hex;
+                        const CRED_I: &[u8] = &hex!("A2027734322D35302D33312D46462D45462D33372D33322D333908A101A5010202412B2001215820AC75E9ECE3E50BFC8ED60399889522405C47BF16DF96660A41298CB4307F7EB62258206E5DE611388A4B8A8211334AC7D37ECB52A387D257E6DB3C2A93DF21FF3AFFC8");
+                        let cred_i = lakers::CredentialRPK::new(
+                            CRED_I.try_into().expect("Static credential is too large"),
+                        )
+                        .expect("Static credential is not processable");
+
+                        let (mut responder, _prk_out) =
+                            responder.verify_message_3(cred_i).map_err(render_error)?;
+
+                        let oscore_secret = responder.edhoc_exporter(0u8, &[], 16); // label is 0
+                        let oscore_salt = responder.edhoc_exporter(1u8, &[], 8); // label is 1
+                        let oscore_secret = &oscore_secret[..16];
+                        let oscore_salt = &oscore_salt[..8];
+                        println!("OSCORE secret: {:?}...", &oscore_secret[..5]);
+                        println!("OSCORE salt: {:?}", &oscore_salt);
+
+                        let sender_id = 0x08; // FIXME: lakers can't export that?
+                        let recipient_id = kid;
+
+                        // FIXME probe cipher suite
+                        let hkdf = liboscore::HkdfAlg::from_number(5).unwrap();
+                        let aead = liboscore::AeadAlg::from_number(10).unwrap();
+
+                        let immutables = liboscore::PrimitiveImmutables::derive(
+                            hkdf,
+                            &oscore_secret,
+                            &oscore_salt,
+                            None,
+                            aead,
+                            // FIXME need KID form (but for all that's supported that works still)
+                            &[sender_id],
+                            &[recipient_id],
+                        )
+                        // FIXME convert error
+                        .unwrap();
+
+                        let context =
+                            liboscore::PrimitiveContext::new_from_fresh_material(immutables);
+
+                        *matched = SecContextState::Oscore(context);
+                    } else {
+                        // Return the state. Best bet is that it was already advanced to an OSCORE
+                        // state, and the peer sent message 3 with multiple concurrent in-flight
+                        // messages. We're ignoring the EDHOC value and continue with OSCORE
+                        // processing.
+                        *matched = taken;
+                    }
+
+                    cutoff
+                } else {
+                    0
+                };
+
+                let SecContextState::Oscore(oscore_context) = matched else {
+                    // FIXME: How'd we even get there?
+                    return Err(Own(CoAPError::bad_request()));
+                };
+
+                let mut allocated_message = coap_message_implementations::heap::HeapMessage::new();
+                // This works from +WithSortedOptions into MinimalWritableMessage, but not from
+                // ReadableMessage to MutableWritableMessage + allows-random-access:
+                // allocated_message.set_from_message(request);
+                //
+                // The whole workaround is messy; not trying to enhance it b/c the whole alloc mess
+                // is temporary.
+                allocated_message.set_code(request.code().into());
+                let mut oscore_option = None;
+                for opt in request.options() {
+                    if opt.number() == coap_numbers::option::EDHOC {
+                        continue;
+                    }
+                    // it's infallible, but we don't have irrefutable patterns yet
+                    allocated_message
+                        .add_option(opt.number(), opt.value())
+                        .unwrap();
+
+                    if opt.number() == coap_numbers::option::OSCORE {
+                        oscore_option = Some(
+                            heapless::Vec::<_, 16>::try_from(opt.value())
+                                .map_err(|_| CoAPError::bad_option(opt.number()))?,
+                        );
+                    }
+                }
+                // We know this to not fail b/c we only got here due to its presence
+                let oscore_option = oscore_option.unwrap();
+                let oscore_option = liboscore::OscoreOption::parse(&oscore_option)
+                    .map_err(|_| CoAPError::bad_option(coap_numbers::option::OSCORE))?;
+                allocated_message
+                    .set_payload(&payload[front_trim_payload..])
+                    .unwrap();
+
+                let Ok((correlation, extracted)) = liboscore::unprotect_request(
+                    allocated_message,
+                    oscore_option,
+                    oscore_context,
+                    |request| self.inner.extract_request_data(request),
+                ) else {
+                    // FIXME is that the righ tcode?
+                    println!("Decryption failure");
+                    return Err(Own(CoAPError::unauthorized()));
+                };
+
+                Ok(Own(EdhocResponse::OscoreRequest {
+                    slot,
+                    correlation,
+                    extracted,
+                }))
+            }
+        }
+    }
+    fn estimate_length(&mut self, req: &Self::RequestData) -> usize {
+        match req {
+            OrInner::Own(_) => 2 + lakers::MAX_BUFFER_LEN,
+            OrInner::Inner(i) => self.inner.estimate_length(i),
+        }
+    }
+    fn build_response<M: MutableWritableMessage>(
+        &mut self,
+        response: &mut M,
+        req: Self::RequestData,
+    ) -> Result<(), Self::BuildResponseError<M>> {
+        use OrInner::{Inner, Own};
+
+        Ok(match req {
+            Own(EdhocResponse::OkSend2(slot)) => {
+                // FIXME: Why does the From<O> not do the map_err?
+                response.set_code(
+                    M::Code::new(coap_numbers::code::CHANGED).map_err(|x| Own(x.into()))?,
+                );
+
+                let pool = &mut self.pool.0.borrow_mut();
+                let SecContextState::EdhocResponderProcessedM1(responder) =
+                    core::mem::replace(&mut pool[slot], SecContextState::Empty)
+                else {
+                    // FIXME render late error (it'd help if CoAPError also offered a type that unions it
+                    // with an arbitrary other error). As it is, depending on the CoAP stack, there may be
+                    // DoS if a peer can send many requests before the server starts rendering responses.
+                    panic!("State vanished before respone was built.");
+                };
+
+                // We have a lock, let's pick one now
+                let c_r =
+                    COwn::not_in_iter(pool.iter().filter_map(|entry| entry.corresponding_cown()));
+
+                let (responder, message_2) = responder
+                    // We're sending our ID by reference: we have a CCS and don't expect anyone to
+                    // run EDHOC with us who can not verify who we are (and from the CCS there is
+                    // no better way). Also, conveniently, this covers our privacy well.
+                    // (Sending ByValue would still work)
+                    .prepare_message_2(lakers::CredentialTransfer::ByReference, Some(c_r.0), &None)
+                    .unwrap();
+                pool[slot] = SecContextState::EdhocResponderSentM2 { responder, c_r };
+                response
+                    .set_payload(message_2.as_slice())
+                    .map_err(|x| Own(x.into()))?;
+            }
+            Own(EdhocResponse::OscoreRequest {
+                slot,
+                mut correlation,
+                extracted,
+            }) => {
+                response.set_code(
+                    M::Code::new(coap_numbers::code::CHANGED).map_err(|x| Own(x.into()))?,
+                );
+
+                let pool = &mut self.pool.0.borrow_mut();
+                let SecContextState::Oscore(ref mut oscore_context) = &mut pool[slot] else {
+                    // FIXME render late error (it'd help if CoAPError also offered a type that unions it
+                    // with an arbitrary other error). As it is, depending on the CoAP stack, there may be
+                    // DoS if a peer can send many requests before the server starts rendering responses.
+                    panic!("State vanished before respone was built.");
+                };
+
+                // Almost-but-not: This'd require 'static on Message which we can't have b/c the
+                // type may be shortlived for good reason.
+                /*
+                let response: &mut dyn core::any::Any = response;
+                let response: &mut coap_message_implementations::inmemory_write::Message = response.downcast_mut()
+                    .expect("libOSCORE currently only works with CoAP stacks whose response messages are inmemory_write");
+                */
+                // FIXME!
+                let response: &mut M = response;
+                let response: &mut coap_message_implementations::inmemory_write::Message =
+                    unsafe { core::mem::transmute(response) };
+
+                response.set_code(coap_numbers::code::CHANGED);
+
+                use crate::println;
+
+                if liboscore::protect_response(
+                    response,
+                    // SECURITY BIG FIXME: How do we make sure that our correlation is really for
+                    // what we find in the pool and not for what wound up there by the time we send
+                    // the response? (Can't happen with the current stack, but conceptually there
+                    // should be a tie; carry the OSCORE context in an owned way?).
+                    oscore_context,
+                    &mut correlation,
+                    |response| match extracted {
+                        Ok(extracted) => match self.inner.build_response(response, extracted) {
+                            Ok(()) => {
+                                println!("All fine");
+                            },
+                            // One attempt to render rendering errors
+                            // FIXME rewind message
+                            Err(e) => match e.render(response) {
+                                Ok(()) => {
+                                    println!("Rendering error to successful extraction shown");
+                                },
+                                Err(_) => {
+                                    println!("Rendering error to successful extraction failed");
+                                    // FIXME rewind message
+                                    response.set_code(coap_numbers::code::INTERNAL_SERVER_ERROR);
+                                }
+                            },
+                        },
+                        Err(inner_request_error) => {
+                            match inner_request_error.render(response) {
+                                Ok(()) => {
+                                    println!("Extraction failed, inner error rendered successfully");
+                                },
+                                Err(e) => {
+                                    // Two attempts to render extraction errors
+                                    // FIXME rewind message
+                                    match e.render(response) {
+                                        Ok(()) => {
+                                            println!("Extraction failed, inner error rendered through fallback");
+                                        },
+                                        Err(_) => {
+                                            println!("Extraction failed, inner error rendering failed");
+                                            // FIXME rewind message
+                                            response.set_code(
+                                                coap_numbers::code::INTERNAL_SERVER_ERROR,
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                )
+                .is_err()
+                {
+                    println!("Oups, responding with weird state");
+                    // todo!("Thanks to the protect API we've lost access to our response");
+                }
+            }
+            Inner(i) => self.inner.build_response(response, i).map_err(Inner)?,
+        })
+    }
+}

--- a/examples/coap/src/udp_nal/mod.rs
+++ b/examples/coap/src/udp_nal/mod.rs
@@ -1,0 +1,159 @@
+//! UDP sockets usable through [embedded_nal_async]
+//!
+//! The full [embedded_nal_async::UdpStack] is *not* implemented at the moment: As its API allows
+//! arbitrary creation of movable sockets, embassy's [udp::UdpSocket] type could only be crated if
+//! the NAL stack had a pre-allocated pool of sockets with their respective buffers. Nothing rules
+//! out such a type, but at the moment, only the bound or connected socket types are implemented
+//! with their own constructors from an embassy [crate::Stack] -- for many applications, those are
+//! useful enough. (FIXME: Given we construct from Socket, Stack could really be implemented on
+//! `Cell<Option<Socket>>` by `.take()`ing, couldn't it?)
+//!
+//! The constructors of the various socket types mimick the UdpStack's socket creation functions,
+//! but take an owned (uninitialized) Socket instead of a shared stack.
+//!
+//! No `bind_single` style constructor is currently provided. FIXME: Not sure we have all the
+//! information at bind time to specialize a wildcard address into a concrete address and return
+//! it. Should the NAL trait be updated to disallow using wildcard addresses on `bind_single`, and
+//! merely allow unspecified ports to get an ephemeral one?
+
+use core::future::poll_fn;
+
+use embedded_nal_async as nal;
+use smoltcp::wire::{IpAddress, IpEndpoint};
+
+use embassy_net::udp;
+
+mod util;
+pub use util::Error;
+use util::{is_unspec_ip, sockaddr_nal2smol, sockaddr_smol2nal};
+
+pub struct ConnectedUdp<'a> {
+    remote: IpEndpoint,
+    // The local port is stored in the socket, as it gets bound. This value is populated lazily:
+    // embassy only decides at udp::Socket::dispatch time whence to send, and while we could
+    // duplicate the code for the None case of the local_address by calling the right
+    // get_source_address function, we'd still need an interface::Context / an interface to call
+    // this through, and AFAICT we don't get access to that.
+    local: Option<IpAddress>,
+    socket: udp::UdpSocket<'a>,
+}
+
+/// A UDP socket that has been bound locally (either to a unique address or just to a port)
+///
+/// Its operations are accessible through the [nal::UnconnectedUdp] trait.
+pub struct UnconnectedUdp<'a> {
+    socket: udp::UdpSocket<'a>,
+}
+
+impl<'a> ConnectedUdp<'a> {
+    /// Create a ConnectedUdp by assigning it a remote and a concrete local address
+    ///
+    /// ## Prerequisites
+    ///
+    /// The `socket` must be open (in the sense of smoltcp's `.is_open()`) -- unbound and
+    /// unconnected.
+    pub async fn connect_from(
+        mut socket: udp::UdpSocket<'a>,
+        local: nal::SocketAddr,
+        remote: nal::SocketAddr,
+    ) -> Result<Self, Error> {
+        socket.bind(sockaddr_nal2smol(local)?)?;
+
+        Ok(ConnectedUdp {
+            remote: sockaddr_nal2smol(remote)?,
+            // FIXME: We could check if local was fully (or sufficiently, picking the port from the
+            // socket) specified and store if yes -- for a first iteration, leaving that to the
+            // fallback path we need anyway in case local is [::].
+            local: None,
+            socket,
+        })
+    }
+
+    /// Create a ConnectedUdp by assigning it a remote and a local address (the latter may happen
+    /// lazily)
+    ///
+    /// ## Prerequisites
+    ///
+    /// The `socket` must be open (in the sense of smoltcp's `.is_open()`) -- unbound and
+    /// unconnected.
+    pub async fn connect(socket: udp::UdpSocket<'a>, /*, ... */) -> Result<Self, udp::BindError> {
+        // This is really just a copy of the provided `embedded_nal::udp::UdpStack::connect` method
+        todo!()
+    }
+}
+
+impl<'a> UnconnectedUdp<'a> {
+    /// Create an UnconnectedUdp.
+    ///
+    /// The `local` address may be anything from fully specified (address and port) to fully
+    /// unspecified (port 0, all-zeros address).
+    ///
+    /// ## Prerequisites
+    ///
+    /// The `socket` must be open (in the sense of smoltcp's `.is_open()`) -- unbound and
+    /// unconnected.
+    pub async fn bind_multiple(
+        mut socket: udp::UdpSocket<'a>,
+        local: nal::SocketAddr,
+    ) -> Result<Self, Error> {
+        socket.bind(sockaddr_nal2smol(local)?)?;
+
+        Ok(UnconnectedUdp { socket })
+    }
+}
+
+impl<'a> nal::UnconnectedUdp for UnconnectedUdp<'a> {
+    type Error = Error;
+    async fn send(
+        &mut self,
+        local: embedded_nal_async::SocketAddr,
+        remote: embedded_nal_async::SocketAddr,
+        buf: &[u8],
+    ) -> Result<(), Error> {
+        // While the underlying layers probably don't care, we're not passing on the port
+        // information, so the underlying layers won't even have a *chance* to care if we don't
+        // check here.
+        debug_assert!(
+            local.port() == 0 || local.port() == self.socket.with(|s, _| s.endpoint().port),
+            "Port of local address, when given, must match bound port."
+        );
+
+        let remote_endpoint = smoltcp::socket::udp::UdpMetadata {
+            local_address: if is_unspec_ip(local) {
+                None
+            } else {
+                // A conversion of the addr part only might be cheaper, but would also mean we need
+                // two functions
+                Some(sockaddr_nal2smol(local)?.addr)
+            },
+            ..sockaddr_nal2smol(remote)?.into()
+        };
+        poll_fn(move |cx| self.socket.poll_send_to(buf, remote_endpoint, cx)).await?;
+        Ok(())
+    }
+    async fn receive_into(
+        &mut self,
+        buf: &mut [u8],
+    ) -> Result<
+        (
+            usize,
+            embedded_nal_async::SocketAddr,
+            embedded_nal_async::SocketAddr,
+        ),
+        Error,
+    > {
+        // FIXME: The truncation is an issue -- we may need to change poll_recv_from to poll_recv
+        // and copy from the slice ourselves to get the trait's behavior
+        let (size, metadata) = poll_fn(|cx| self.socket.poll_recv_from(buf, cx)).await?;
+        Ok((
+            size,
+            sockaddr_smol2nal(IpEndpoint {
+                addr: metadata
+                    .local_address
+                    .expect("Local address is always populated on receive"),
+                port: self.socket.with(|s, _| s.endpoint().port),
+            }),
+            sockaddr_smol2nal(metadata.endpoint),
+        ))
+    }
+}

--- a/examples/coap/src/udp_nal/util.rs
+++ b/examples/coap/src/udp_nal/util.rs
@@ -1,0 +1,106 @@
+//! Helpers for udp_nal -- conversion and error types
+
+use embassy_net::udp;
+use embedded_nal_async as nal;
+use smoltcp::wire::{IpAddress, IpEndpoint};
+
+pub(super) fn sockaddr_nal2smol(sockaddr: nal::SocketAddr) -> Result<IpEndpoint, Error> {
+    match sockaddr {
+        #[allow(unused)]
+        nal::SocketAddr::V4(sockaddr) => {
+            #[cfg(feature = "proto-ipv4")]
+            return Ok(IpEndpoint {
+                addr: smoltcp::wire::Ipv4Address(sockaddr.ip().octets()).into(),
+                port: sockaddr.port(),
+            });
+            #[cfg(not(feature = "proto-ipv4"))]
+            return Err(Error::AddressFamilyUnavailable);
+        }
+        #[allow(unused)]
+        nal::SocketAddr::V6(sockaddr) => {
+            #[cfg(feature = "proto-ipv6")]
+            return Ok(IpEndpoint {
+                addr: smoltcp::wire::Ipv6Address(sockaddr.ip().octets()).into(),
+                port: sockaddr.port(),
+            });
+            #[cfg(not(feature = "proto-ipv6"))]
+            return Err(Error::AddressFamilyUnavailable);
+        }
+    }
+}
+
+pub(super) fn sockaddr_smol2nal(endpoint: IpEndpoint) -> nal::SocketAddr {
+    match endpoint.addr {
+        // Let's hope those are in sync; what we'll really need to know is whether smoltcp has the
+        // relevant flags set (but we can't query that).
+        #[cfg(feature = "proto-ipv4")]
+        IpAddress::Ipv4(addr) => {
+            embedded_nal_async::SocketAddrV4::new(addr.0.into(), endpoint.port).into()
+        }
+        #[cfg(feature = "proto-ipv6")]
+        IpAddress::Ipv6(addr) => {
+            embedded_nal_async::SocketAddrV6::new(addr.0.into(), endpoint.port).into()
+        }
+    }
+}
+
+/// Is the IP address in this type the unspecified address?
+///
+/// FIXME: What of ::ffff:0.0.0.0? Is that expected to bind to all v4 addresses?
+pub(super) fn is_unspec_ip(addr: nal::SocketAddr) -> bool {
+    match addr {
+        nal::SocketAddr::V4(sockaddr) => sockaddr.ip().octets() == [0; 4],
+        nal::SocketAddr::V6(sockaddr) => sockaddr.ip().octets() == [0; 16],
+    }
+}
+
+/// Unified error type for [embedded_nal_async] operations on UDP sockets
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Error stemming from failure to send
+    RecvError(udp::RecvError),
+    /// Error stemming from failure to send
+    SendError(udp::SendError),
+    /// Error stemming from failure to bind to an address/port
+    BindError(udp::BindError),
+    /// Error stemming from failure to represent the given address family for lack of enabled
+    /// embassy-net features
+    AddressFamilyUnavailable,
+}
+
+impl embedded_io_async::Error for Error {
+    fn kind(&self) -> embedded_io_async::ErrorKind {
+        match self {
+            Self::SendError(udp::SendError::NoRoute) => {
+                embedded_io_async::ErrorKind::AddrNotAvailable
+            }
+            Self::BindError(udp::BindError::NoRoute) => {
+                embedded_io_async::ErrorKind::AddrNotAvailable
+            }
+            Self::AddressFamilyUnavailable => embedded_io_async::ErrorKind::AddrNotAvailable,
+            // These should not happen b/c our sockets are typestated.
+            Self::SendError(udp::SendError::SocketNotBound) => embedded_io_async::ErrorKind::Other,
+            Self::BindError(udp::BindError::InvalidState) => embedded_io_async::ErrorKind::Other,
+            // This should not happen b/c in embedded_nal_async this is not expressed through an
+            // error.
+            // FIXME we're not there in this impl yet.
+            Self::RecvError(udp::RecvError::Truncated) => embedded_io_async::ErrorKind::Other,
+        }
+    }
+}
+impl From<udp::BindError> for Error {
+    fn from(err: udp::BindError) -> Self {
+        Self::BindError(err)
+    }
+}
+impl From<udp::RecvError> for Error {
+    fn from(err: udp::RecvError) -> Self {
+        Self::RecvError(err)
+    }
+}
+impl From<udp::SendError> for Error {
+    fn from(err: udp::SendError) -> Self {
+        Self::SendError(err)
+    }
+}

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -6,6 +6,7 @@ defaults:
 subdirs:
   - benchmark
   - core-sizes
+  - coap
   - embassy
   - embassy-http-server
   - embassy-net-tcp


### PR DESCRIPTION
As part of the [detailed CoAP road map](https://github.com/future-proof-iot/RIOT-rs/issues/226), I'd like to establish an in-tree example of CoAP use.

This is a draft PR until it does anything CoAP related; as soon as that is the case, I'd like to keep it close to main by extending that example continuously through small PRs rather than working on a long-lived branch.

<del>Currently this is based on #224, because that's the hardware I test on.</del>

## Testing

```
$ ./laze build -b particle-xenon -s probe-rs-run --disable silent-panic run &
$ python3 fauxhoc.py
Received MSG2 with c_r=3 id_cred_r=b'\n' ead_2=None
[lib/src/edhoc.rs:644:5] &id_cred_i = [
    161,
    4,
    65,
    43,
]
Derived master_secret=b'gi\x16\x9d\x80j\xf7\xd9\xcehE\x9e\x87\xa0s\xb0' master_salt=b'\x1a\x9a\x0f\x8dv"|\xf2'
b'<>;ct=0;title="Landing page"</time>;ct=0;title="Clock"</poem>;sz=1338</cbor>;ct=60'
b'Aurea prima sata est aetas, quae vindice nullo [...]'
```

(This requires some Python modules to be installed, which are not precisely enumerated.)