### PR TITLE
docs(threads): document threading-relating panics

### DIFF
--- a/src/riot-rs-runqueue/src/runqueue.rs
+++ b/src/riot-rs-runqueue/src/runqueue.rs
@@ -1,3 +1,6 @@
+// Disable indexing lints for now
+#![allow(clippy::indexing_slicing)]
+
 use core::mem;
 
 use self::clist::CList;

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -2,6 +2,9 @@
 #![feature(inline_const)]
 #![feature(naked_functions)]
 #![feature(used_with_arg)]
+// Disable indexing lints for now, possible panics are documented or rely on internally-enforced
+// invariants
+#![allow(clippy::indexing_slicing)]
 
 use critical_section::CriticalSection;
 
@@ -140,6 +143,10 @@ impl Threads {
     ///
     /// This function handles adding/ removing the thread to the Runqueue depending
     /// on its previous or new state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `pid` is >= [`THREADS_NUMOF`].
     pub(crate) fn set_state(&mut self, pid: ThreadId, state: ThreadState) -> ThreadState {
         let thread = &mut self.threads[pid as usize];
         let old_state = thread.state;
@@ -153,6 +160,7 @@ impl Threads {
         old_state
     }
 
+    /// Returns the state of a thread.
     pub fn get_state(&self, thread_id: ThreadId) -> Option<ThreadState> {
         if self.is_valid_pid(thread_id) {
             Some(self.threads[thread_id as usize].state)

--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -18,7 +18,7 @@ pub enum WaitMode {
 ///
 /// # Panics
 ///
-/// Panics if no valid thread for `thread_id` exists.
+/// Panics if `thread_id` is >= [`THREADS_NUMOF`](crate::THREADS_NUMOF).
 pub fn set(thread_id: ThreadId, mask: ThreadFlags) {
     THREADS.with_mut(|mut threads| threads.flag_set(thread_id, mask))
 }


### PR DESCRIPTION
Document possible panics related to invalid `ThreadId`s provided from outside the crate.
Disable indexing lints in `riot-rs-runqueue` and `riot-rs-threads` to reduce noise and because panic-freedom is expected to be proven by hax or possible panics are documented.

depends on #219