### PR TITLE
ci: build and publish rustdoc

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,67 @@
+name: Deploy rustdoc
+
+# GitHub Action workflow documentation:
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+# This workflow is based on
+# https://github.com/actions/starter-workflows/blob/main/pages/mdbook.yml
+
+on:
+  push:
+    branches: [$default-branch]
+    paths:
+      - src/**
+      - Cargo.toml
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.repository == 'future-proof-iot/RIOT-rs'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - id: get_toolchain
+        run: echo "toolchain=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
+
+      - name: Build rustdoc docs
+        run:
+          - cargo rustdoc -p riot-rs --features no-boards,bench -- -D warnings
+          - echo "<meta http-equiv=\"refresh\" content=\"0; url=riot_rs\">" > target/doc/index.html
+          - mkdir -p ./dev/docs/api && mv target/doc/* ./dev/docs/api
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dev/docs/api
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
As GitHub Pages now support [deploying from Actions](https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/), this uses the [deploy-pages](https://github.com/actions/deploy-pages) Action instead of the strategy currently used for the book.