### PR TITLE
ci(rustdoc): lint all crates for rustdoc errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,8 +138,8 @@ jobs:
         with:
           args: --verbose --locked --features no-boards -p riot-rs -p riot-rs-boards -p riot-rs-buildinfo -p riot-rs-chips -p riot-rs-debug -p riot-rs-embassy -p riot-rs-macros -p riot-rs-random -p riot-rs-rt -p riot-rs-utils
 
-      - name: "rustdoc"
-        run: cargo rustdoc -p riot-rs --features no-boards,bench,threading,random,csprng,hwrng -- -D warnings
+      - name: rustdoc
+        run: RUSTDOCFLAGS='-D warnings' cargo doc -p riot-rs --features no-boards,bench,threading,random,csprng,hwrng
 
       - name: rustfmt
         run: cargo fmt --check --all


### PR DESCRIPTION
`cargo rustdoc` only generates docs for the root crate, not its dependencies, `cargo doc` does.

depends on #257