### PR TITLE
(WIP) threads: multicore support for RP2040

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,6 +2907,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "threading-multicore"
+version = "0.1.0"
+dependencies = [
+ "riot-rs",
+ "riot-rs-boards",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,6 +2445,7 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "cortex-m-rt",
+ "embassy-rp",
  "esp-hal",
  "linkme",
  "portable-atomic",
@@ -2468,9 +2469,12 @@ dependencies = [
  "cortex-m-rt",
  "cortex-m-semihosting",
  "critical-section",
+ "embassy-rp",
  "linkme",
  "panic-semihosting",
  "riot-rs-runqueue",
+ "rp-pac",
+ "static_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ embassy-sync = { version = "0.5", default-features = false }
 embassy-time = { version = "0.3", default-features = false }
 embassy-usb = { version = "0.1", default-features = false }
 
+rp-pac = { version = "6.0", default-features = false }
+
 esp-hal = { version = "0.15", git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-290224", default-features = false }
 esp-println = { version = "0.9.0" }
 esp-wifi = { git = "https://github.com/kaspar030/esp-wifi", branch = "update-esp-hal" }

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -14,3 +14,4 @@ subdirs:
   - hello-world
   - minimal
   - threading
+  - threading-multicore

--- a/examples/threading-multicore/Cargo.toml
+++ b/examples/threading-multicore/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "threading-multicore"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/threading-multicore/README.md
+++ b/examples/threading-multicore/README.md
@@ -1,0 +1,13 @@
+# threading multicore
+
+## About
+
+This application demonstrates basic threading on multicore.
+
+## How to run
+
+In this folder, run
+
+    laze build -b rpi-pico-w run
+
+The application will start two threads that run on different cores and print a message from each thread.

--- a/examples/threading-multicore/laze.yml
+++ b/examples/threading-multicore/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: threading-multicore
+    selects:
+      - ?release

--- a/examples/threading-multicore/src/main.rs
+++ b/examples/threading-multicore/src/main.rs
@@ -1,0 +1,22 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::debug::println;
+
+#[riot_rs::thread(autostart)]
+fn thread0() {
+    let cpu = riot_rs::thread::cpuid();
+    // let thread_id = riot_rs::thread::current_pid().unwrap();
+    println!("Hello from thread {} on CPU {}", 0, cpu);
+    loop {}
+}
+
+#[riot_rs::thread(autostart)]
+fn thread1() {
+    let cpu = riot_rs::thread::cpuid();
+    // let thread_id = riot_rs::thread::current_pid().unwrap();
+    println!("Hello from thread {} on CPU {}", 1, cpu);
+    loop {}
+}

--- a/src/riot-rs-debug/Cargo.toml
+++ b/src/riot-rs-debug/Cargo.toml
@@ -13,7 +13,8 @@ workspace = true
 [dependencies]
 
 [target.'cfg(context = "cortex-m")'.dependencies]
-cortex-m = { workspace = true, features = ["critical-section-single-core"] }
+cortex-m = { workspace = true }
+# cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 cortex-m-semihosting = { workspace = true, optional = true }
 rtt-target = { version = "0.4.0", optional = true }
 

--- a/src/riot-rs-rt/Cargo.toml
+++ b/src/riot-rs-rt/Cargo.toml
@@ -16,7 +16,7 @@ riot-rs-utils = { path = "../riot-rs-utils" }
 rtt-target = { version = "0.4.0", optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
-cortex-m = { workspace = true, features = ["critical-section-single-core"] }
+cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 portable-atomic = { version = "1.6.0", features = ["critical-section"] }
 
@@ -25,6 +25,12 @@ esp-hal = { workspace = true, default-features = false }
 portable-atomic = { version = "1.6.0", default-features = false, features = [
   "require-cas",
 ] }
+
+[target.'cfg(context = "rp2040")'.dependencies]
+embassy-rp = { workspace = true, features = ["critical-section-impl"] }
+
+[target.'cfg(context = "nrf")'.dependencies]
+cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 
 [features]
 #default = ["threading"]

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -22,3 +22,9 @@ cortex-m.workspace = true
 cortex-m-rt.workspace = true
 cortex-m-semihosting.workspace = true
 panic-semihosting = { version = "0.6.0", features = ["exit"] }
+
+[target.'cfg(context = "rp2040")'.dependencies]
+static_cell.workspace = true
+rp-pac.workspace = true
+embassy-rp.workspace = true
+

--- a/src/riot-rs-threads/src/smp/mod.rs
+++ b/src/riot-rs-threads/src/smp/mod.rs
@@ -1,0 +1,26 @@
+pub trait Multicore {
+    const CORES: u32;
+
+    fn cpuid() -> u32;
+
+    fn startup_cores();
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(context = "rp2040")] {
+        mod rp2040;
+        pub use rp2040::Chip;
+    }
+    else {
+        pub struct Chip;
+        impl Multicore for Chip {
+            const CORES: u32 = 1;
+
+            fn cpuid() -> u32 {
+                0
+            }
+
+            fn startup_cores() { }
+        }
+    }
+}

--- a/src/riot-rs-threads/src/smp/rp2040.rs
+++ b/src/riot-rs-threads/src/smp/rp2040.rs
@@ -1,0 +1,41 @@
+use crate::{
+    arch::{Arch, Cpu},
+    THREADS,
+};
+
+use super::Multicore;
+use critical_section::CriticalSection;
+use embassy_rp::{
+    multicore::{spawn_core1, Stack},
+    peripherals::CORE1,
+};
+use rp_pac::SIO;
+
+pub struct Chip;
+
+impl Multicore for Chip {
+    const CORES: u32 = 2;
+
+    fn cpuid() -> u32 {
+        SIO.cpuid().read()
+    }
+
+    fn startup_cores() {
+        let stack: &'static mut Stack<4096> = static_cell::make_static!(Stack::new());
+        let start_threading = move || {
+            let cpuid = Self::cpuid();
+            let cs = unsafe { CriticalSection::new() };
+            let next_sp = THREADS.with_mut_cs(cs, |mut threads| {
+                // FIXME: this is a hack!
+                let next_pid = threads.runqueue.get_next().unwrap() + (cpuid as u8);
+                threads.current_threads[cpuid as usize] = Some(next_pid);
+                threads.threads[next_pid as usize].sp
+            });
+            Cpu::start_threading(next_sp);
+            loop {}
+        };
+        unsafe {
+            spawn_core1(CORE1::steal(), stack, start_threading);
+        }
+    }
+}

--- a/src/riot-rs-threads/src/threadlist.rs
+++ b/src/riot-rs-threads/src/threadlist.rs
@@ -1,6 +1,6 @@
 use critical_section::CriticalSection;
 
-use crate::{ThreadId, ThreadState, THREADS};
+use crate::{cpuid, ThreadId, ThreadState, THREADS};
 
 /// Manages blocked [`super::Thread`]s for a resource, and triggering the scheduler when needed.
 #[derive(Debug, Default)]
@@ -18,7 +18,7 @@ impl ThreadList {
     /// Puts the current (blocked) thread into this [`ThreadList`] and triggers the scheduler.
     pub fn put_current(&mut self, cs: CriticalSection, state: ThreadState) {
         THREADS.with_mut_cs(cs, |mut threads| {
-            let thread_id = threads.current_thread.unwrap();
+            let thread_id = threads.current_threads[cpuid()].unwrap();
             threads.thread_blocklist[thread_id as usize] = self.head;
             self.head = Some(thread_id);
             threads.set_state(thread_id, state);


### PR DESCRIPTION
First PoC that implements multicore support for the Raspberry RP2040. 

It introduces a small abstraction layer for SMP (symmetric multiprocessing) support and mostly relies on embassy to implement it for the RP2040.
A first example `threads-multicore` runs, but a lot of this is quite hacky.

Concretely, what definitely needs to be fixed is:
- `riot-rs-runqueue` support for more than one currently running thread (right now I am doing a *very* hacky workaround that just works for this example)
- locking of critical sections and shared resources
- ... (probably a lot more once I dig more into the details)

I'll write a proper issue for this and do separate PRs for the subtasks. 
Just thought it would be nice to already open this PR show how easy a first implementation is thanks to embassy :slightly_smiling_face:.