### PR TITLE
ci(docs): fix the workflow trigger conditions

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -8,10 +8,12 @@ name: Deploy docs
 
 on:
   push:
-    branches: [$default-branch]
+    branches: main
     paths:
+      - book/**
       - src/**
       - Cargo.toml
+      - rust-toolchain
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
`$default-branch` can only be used in workflow templates, not in workflows, see
https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization