### PR TITLE
docs(riot-rs): show the `thread` module in docs

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Build rustdoc docs
         run: |
-          cargo doc -p riot-rs --features no-boards,bench
+          cargo doc -p riot-rs --features no-boards,bench,threading
           echo "<meta http-equiv=\"refresh\" content=\"0; url=riot_rs\">" > target/doc/index.html
           mkdir -p ./_site/dev/docs/api && mv target/doc/* ./_site/dev/docs/api
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,9 +138,8 @@ jobs:
         with:
           args: --verbose --locked --features no-boards -p riot-rs -p riot-rs-boards -p riot-rs-buildinfo -p riot-rs-chips -p riot-rs-debug -p riot-rs-embassy -p riot-rs-macros -p riot-rs-rt -p riot-rs-utils
 
-      # TODO: we'll eventually want to enable relevant features
       - name: "rustdoc"
-        run: cargo rustdoc -p riot-rs --features no-boards,bench -- -D warnings
+        run: cargo rustdoc -p riot-rs --features no-boards,bench,threading -- -D warnings
 
       - name: rustfmt
         run: cargo fmt --check --all

--- a/src/riot-rs/src/lib.rs
+++ b/src/riot-rs/src/lib.rs
@@ -5,10 +5,9 @@
 //! # Cargo features
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![no_std]
-#![feature(doc_cfg)]
+#![feature(doc_auto_cfg)]
 
 #[cfg(feature = "bench")]
-#[doc(cfg(feature = "bench"))]
 #[doc(inline)]
 pub use riot_rs_bench as bench;
 #[doc(inline)]
@@ -20,17 +19,16 @@ pub use riot_rs_embassy as embassy;
 pub use riot_rs_embassy::{define_peripherals, group_peripherals};
 #[doc(inline)]
 pub use riot_rs_rt as rt;
+#[cfg(feature = "threading")]
+#[doc(inline)]
+pub use riot_rs_threads as thread;
 
 // Attribute macros
 pub use riot_rs_macros::config;
 pub use riot_rs_macros::spawner;
 pub use riot_rs_macros::task;
 #[cfg(any(feature = "threading", doc))]
-#[doc(cfg(feature = "threading"))]
 pub use riot_rs_macros::thread;
-
-#[cfg(feature = "threading")]
-pub use riot_rs_threads as thread;
 
 // These are used by proc-macros we provide
 pub use linkme;


### PR DESCRIPTION
Fixes #230