### PR TITLE
runqueue: allocate threads to >= 1 cores

### DIFF
--- a/src/riot-rs-runqueue/src/lib.rs
+++ b/src/riot-rs-runqueue/src/lib.rs
@@ -95,4 +95,135 @@ mod tests {
         runqueue.advance(0);
         assert_eq!(runqueue.get_next(), Some(0));
     }
+
+    #[test]
+    fn multicore_basic() {
+        let mut runqueue: RunQueue<8, 32, 4> = RunQueue::new();
+
+        // First thread should get allocated to core 0.
+        assert_eq!(runqueue.add(0, 0), Some(0));
+        // Second thread should get allocated to core 1.
+        assert_eq!(runqueue.add(1, 0), Some(1));
+
+        assert_eq!(runqueue.get_next_for_core(0), Some(0));
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert!(runqueue.get_next_for_core(2).is_none());
+
+        // Advancing a runqueue shouldn't change any allocations
+        // if all threads in the queue are already running.
+        assert_eq!(runqueue.advance(0), None);
+        assert_eq!(runqueue.get_next_for_core(0), Some(0));
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert!(runqueue.get_next_for_core(2).is_none());
+
+        // Restores original order.
+        assert_eq!(runqueue.advance(0), None);
+
+        // Add more threads, which should be allocated to free
+        // cores.
+        assert_eq!(runqueue.add(2, 0), Some(2));
+        assert_eq!(runqueue.add(3, 0), Some(3));
+        assert_eq!(runqueue.add(4, 0), None);
+        assert_eq!(runqueue.get_next_for_core(0), Some(0));
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert_eq!(runqueue.get_next_for_core(2), Some(2));
+        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+
+        // Advancing the runqueue now should change the mapping
+        // on core 0, since the previous head was running there.
+        assert_eq!(runqueue.advance(0), Some(0));
+        assert_eq!(runqueue.get_next_for_core(0), Some(4));
+        // Other allocations shouldn't change.
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert_eq!(runqueue.get_next_for_core(2), Some(2));
+        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+
+        // Adding or deleting waiting threads shouldn't change
+        // any allocations.
+        assert_eq!(runqueue.del(0, 0), None);
+        assert_eq!(runqueue.add(5, 0), None);
+
+        // Deleting a running thread should allocate the waiting
+        // thread to the now free core.
+        assert_eq!(runqueue.del(2, 0), Some(2));
+        assert_eq!(runqueue.get_next_for_core(2), Some(5));
+        // Other allocations shouldn't change.
+        assert_eq!(runqueue.get_next_for_core(0), Some(4));
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+    }
+
+    #[test]
+    fn multicore_multiqueue() {
+        let mut runqueue: RunQueue<8, 32, 4> = RunQueue::new();
+
+        assert_eq!(runqueue.add(0, 2), Some(0));
+        assert_eq!(runqueue.add(1, 2), Some(1));
+        assert_eq!(runqueue.add(2, 1), Some(2));
+        assert_eq!(runqueue.add(3, 0), Some(3));
+        assert_eq!(runqueue.add(4, 0), None);
+
+        assert_eq!(runqueue.get_next_for_core(0), Some(0));
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert_eq!(runqueue.get_next_for_core(2), Some(2));
+        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+
+        // Advancing highest priority queue shouldn't change anything
+        // because there are more cores than threads in this priority's queue.
+        assert_eq!(runqueue.advance(2), None);
+        assert_eq!(runqueue.get_next_for_core(0), Some(0));
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert_eq!(runqueue.get_next_for_core(2), Some(2));
+        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+
+        // Advancing lowest priority queue should change allocations
+        // since there are two threads in this priority's queue,
+        // but only one available core for them.
+
+        // Core 3 was newly allocated.
+        assert_eq!(runqueue.advance(0), Some(3));
+        assert_eq!(runqueue.get_next_for_core(3), Some(4));
+        // Other allocations didn't change.
+        assert_eq!(runqueue.get_next_for_core(0), Some(0));
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert_eq!(runqueue.get_next_for_core(2), Some(2));
+
+        // Restores original order.
+        runqueue.advance(0);
+
+        // Delete one high-priority thread.
+        // The waiting low-priority thread should be allocated
+        // to the newly freed core.
+
+        // Core 0 was newly allocated.
+        assert_eq!(runqueue.del(0, 2), Some(0));
+        assert_eq!(runqueue.get_next_for_core(0), Some(4));
+        // Other allocations didn't change.
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert_eq!(runqueue.get_next_for_core(2), Some(2));
+        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+
+        // Add one medium-priority thread.
+        // The low-priority thread furthest back in its priority queue
+        // should be preempted.
+
+        // Core 0 was newly allocated.
+        assert_eq!(runqueue.add(5, 1), Some(0));
+        assert_eq!(runqueue.get_next_for_core(0), Some(5));
+        // Other allocations didn't change.
+        assert_eq!(runqueue.get_next_for_core(1), Some(1));
+        assert_eq!(runqueue.get_next_for_core(2), Some(2));
+        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+    }
+
+    #[test]
+    fn multicore_invalid_core() {
+        let mut runqueue: RunQueue<8, 32, 1> = RunQueue::new();
+        assert_eq!(runqueue.add(0, 2), Some(0));
+        assert_eq!(runqueue.add(1, 2), None);
+        assert_eq!(runqueue.get_next(), Some(0));
+        assert_eq!(runqueue.get_next_for_core(0), Some(0));
+        // Querying for n > `N_CORES` shouldn't cause a panic.
+        assert_eq!(runqueue.get_next_for_core(1), None)
+    }
 }

--- a/src/riot-rs-runqueue/src/lib.rs
+++ b/src/riot-rs-runqueue/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(test), no_std)]
 
 mod runqueue;
-pub use runqueue::{RunQueue, RunqueueId, ThreadId};
+pub use runqueue::{CoreId, RunQueue, RunqueueId, ThreadId};
 
 #[cfg(test)]
 mod tests {

--- a/src/riot-rs-runqueue/src/lib.rs
+++ b/src/riot-rs-runqueue/src/lib.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(not(test), no_std)]
+#![feature(min_specialization)]
 
 mod runqueue;
-pub use runqueue::{CoreId, RunQueue, RunqueueId, ThreadId};
+pub use runqueue::{CoreId, GlobalRunqueue, RunQueue, RunqueueId, ThreadId};
 
 #[cfg(test)]
 mod tests {
@@ -15,24 +16,24 @@ mod tests {
         runqueue.add(1, 0);
         runqueue.add(2, 0);
 
-        assert_eq!(runqueue.get_next(), Some(0));
+        assert_eq!(runqueue.get_next(0), Some(0));
 
-        runqueue.advance(0);
+        runqueue.advance(0, 0);
 
-        assert_eq!(runqueue.get_next(), Some(1));
-        runqueue.advance(0);
+        assert_eq!(runqueue.get_next(0), Some(1));
+        runqueue.advance(0, 0);
 
-        assert_eq!(runqueue.get_next(), Some(2));
-        assert_eq!(runqueue.get_next(), Some(2));
+        assert_eq!(runqueue.get_next(0), Some(2));
+        assert_eq!(runqueue.get_next(0), Some(2));
 
-        runqueue.advance(0);
-        assert_eq!(runqueue.get_next(), Some(0));
+        runqueue.advance(0, 0);
+        assert_eq!(runqueue.get_next(0), Some(0));
 
-        runqueue.advance(0);
-        assert_eq!(runqueue.get_next(), Some(1));
+        runqueue.advance(0, 0);
+        assert_eq!(runqueue.get_next(0), Some(1));
 
-        runqueue.advance(0);
-        assert_eq!(runqueue.get_next(), Some(2));
+        runqueue.advance(0, 0);
+        assert_eq!(runqueue.get_next(0), Some(2));
     }
 
     #[test]
@@ -44,13 +45,13 @@ mod tests {
         }
 
         for i in 0..=31 {
-            assert_eq!(runqueue.get_next(), Some(i));
-            runqueue.advance(0);
+            assert_eq!(runqueue.get_next(0), Some(i));
+            runqueue.advance(0, 0);
         }
 
         for i in 0..=31 {
-            assert_eq!(runqueue.get_next(), Some(i));
-            runqueue.advance(0);
+            assert_eq!(runqueue.get_next(0), Some(i));
+            runqueue.advance(0, 0);
         }
     }
 
@@ -65,17 +66,17 @@ mod tests {
         runqueue.add(2, 1);
         runqueue.add(4, 1);
 
-        assert_eq!(runqueue.get_next(), Some(2));
+        assert_eq!(runqueue.get_next(0), Some(2));
         runqueue.del(2, 1);
-        assert_eq!(runqueue.get_next(), Some(4));
+        assert_eq!(runqueue.get_next(0), Some(4));
         runqueue.del(4, 1);
-        assert_eq!(runqueue.get_next(), Some(0));
+        assert_eq!(runqueue.get_next(0), Some(0));
         runqueue.del(0, 0);
-        assert_eq!(runqueue.get_next(), Some(1));
+        assert_eq!(runqueue.get_next(0), Some(1));
         runqueue.del(1, 0);
-        assert_eq!(runqueue.get_next(), Some(3));
+        assert_eq!(runqueue.get_next(0), Some(3));
         runqueue.del(3, 0);
-        assert_eq!(runqueue.get_next(), None);
+        assert_eq!(runqueue.get_next(0), None);
     }
     #[test]
     fn test_push_twice() {
@@ -84,16 +85,16 @@ mod tests {
         runqueue.add(0, 0);
         runqueue.add(1, 0);
 
-        assert_eq!(runqueue.get_next(), Some(0));
+        assert_eq!(runqueue.get_next(0), Some(0));
         runqueue.del(0, 0);
-        assert_eq!(runqueue.get_next(), Some(1));
+        assert_eq!(runqueue.get_next(0), Some(1));
 
         runqueue.add(0, 0);
 
-        assert_eq!(runqueue.get_next(), Some(1));
+        assert_eq!(runqueue.get_next(0), Some(1));
 
-        runqueue.advance(0);
-        assert_eq!(runqueue.get_next(), Some(0));
+        runqueue.advance(0, 0);
+        assert_eq!(runqueue.get_next(0), Some(0));
     }
 
     #[test]
@@ -105,38 +106,38 @@ mod tests {
         // Second thread should get allocated to core 1.
         assert_eq!(runqueue.add(1, 0), Some(1));
 
-        assert_eq!(runqueue.get_next_for_core(0), Some(0));
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert!(runqueue.get_next_for_core(2).is_none());
+        assert_eq!(runqueue.get_next(0), Some(0));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert!(runqueue.get_next(2).is_none());
 
         // Advancing a runqueue shouldn't change any allocations
         // if all threads in the queue are already running.
-        assert_eq!(runqueue.advance_from(0, 0), None);
-        assert_eq!(runqueue.get_next_for_core(0), Some(0));
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert!(runqueue.get_next_for_core(2).is_none());
+        assert_eq!(runqueue.advance(0, 0), None);
+        assert_eq!(runqueue.get_next(0), Some(0));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert!(runqueue.get_next(2).is_none());
 
         // Restores original order.
-        assert_eq!(runqueue.advance_from(1, 0), None);
+        assert_eq!(runqueue.advance(1, 0), None);
 
         // Add more threads, which should be allocated to free
         // cores.
         assert_eq!(runqueue.add(2, 0), Some(2));
         assert_eq!(runqueue.add(3, 0), Some(3));
         assert_eq!(runqueue.add(4, 0), None);
-        assert_eq!(runqueue.get_next_for_core(0), Some(0));
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(2), Some(2));
-        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+        assert_eq!(runqueue.get_next(0), Some(0));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(2), Some(2));
+        assert_eq!(runqueue.get_next(3), Some(3));
 
         // Advancing the runqueue now should change the mapping
         // on core 0, since the previous head was running there.
-        assert_eq!(runqueue.advance_from(0, 0), Some(0));
-        assert_eq!(runqueue.get_next_for_core(0), Some(4));
+        assert_eq!(runqueue.advance(0, 0), Some(0));
+        assert_eq!(runqueue.get_next(0), Some(4));
         // Other allocations shouldn't change.
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(2), Some(2));
-        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(2), Some(2));
+        assert_eq!(runqueue.get_next(3), Some(3));
 
         // Adding or deleting waiting threads shouldn't change
         // any allocations.
@@ -146,11 +147,11 @@ mod tests {
         // Deleting a running thread should allocate the waiting
         // thread to the now free core.
         assert_eq!(runqueue.del(2, 0), Some(2));
-        assert_eq!(runqueue.get_next_for_core(2), Some(5));
+        assert_eq!(runqueue.get_next(2), Some(5));
         // Other allocations shouldn't change.
-        assert_eq!(runqueue.get_next_for_core(0), Some(4));
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+        assert_eq!(runqueue.get_next(0), Some(4));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(3), Some(3));
     }
 
     #[test]
@@ -163,33 +164,33 @@ mod tests {
         assert_eq!(runqueue.add(3, 0), Some(3));
         assert_eq!(runqueue.add(4, 0), None);
 
-        assert_eq!(runqueue.get_next_for_core(0), Some(0));
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(2), Some(2));
-        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+        assert_eq!(runqueue.get_next(0), Some(0));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(2), Some(2));
+        assert_eq!(runqueue.get_next(3), Some(3));
 
         // Advancing highest priority queue shouldn't change anything
         // because there are more cores than threads in this priority's queue.
-        assert_eq!(runqueue.advance_from(0, 2), None);
-        assert_eq!(runqueue.get_next_for_core(0), Some(0));
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(2), Some(2));
-        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+        assert_eq!(runqueue.advance(0, 2), None);
+        assert_eq!(runqueue.get_next(0), Some(0));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(2), Some(2));
+        assert_eq!(runqueue.get_next(3), Some(3));
 
         // Advancing lowest priority queue should change allocations
         // since there are two threads in this priority's queue,
         // but only one available core for them.
 
         // Core 3 was newly allocated.
-        assert_eq!(runqueue.advance_from(3, 0), Some(3));
-        assert_eq!(runqueue.get_next_for_core(3), Some(4));
+        assert_eq!(runqueue.advance(3, 0), Some(3));
+        assert_eq!(runqueue.get_next(3), Some(4));
         // Other allocations didn't change.
-        assert_eq!(runqueue.get_next_for_core(0), Some(0));
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(2), Some(2));
+        assert_eq!(runqueue.get_next(0), Some(0));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(2), Some(2));
 
         // Restores original order.
-        runqueue.advance_from(4, 0);
+        runqueue.advance(4, 0);
 
         // Delete one high-priority thread.
         // The waiting low-priority thread should be allocated
@@ -197,11 +198,11 @@ mod tests {
 
         // Core 0 was newly allocated.
         assert_eq!(runqueue.del(0, 2), Some(0));
-        assert_eq!(runqueue.get_next_for_core(0), Some(4));
+        assert_eq!(runqueue.get_next(0), Some(4));
         // Other allocations didn't change.
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(2), Some(2));
-        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(2), Some(2));
+        assert_eq!(runqueue.get_next(3), Some(3));
 
         // Add one medium-priority thread.
         // The low-priority thread furthest back in its priority queue
@@ -209,11 +210,11 @@ mod tests {
 
         // Core 0 was newly allocated.
         assert_eq!(runqueue.add(5, 1), Some(0));
-        assert_eq!(runqueue.get_next_for_core(0), Some(5));
+        assert_eq!(runqueue.get_next(0), Some(5));
         // Other allocations didn't change.
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(2), Some(2));
-        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(2), Some(2));
+        assert_eq!(runqueue.get_next(3), Some(3));
     }
 
     #[test]
@@ -221,10 +222,10 @@ mod tests {
         let mut runqueue: RunQueue<8, 32, 1> = RunQueue::new();
         assert_eq!(runqueue.add(0, 2), Some(0));
         assert_eq!(runqueue.add(1, 2), None);
-        assert_eq!(runqueue.get_next(), Some(0));
-        assert_eq!(runqueue.get_next_for_core(0), Some(0));
+        assert_eq!(runqueue.get_next(0), Some(0));
+        assert_eq!(runqueue.get_next(0), Some(0));
         // Querying for n > `N_CORES` shouldn't cause a panic.
-        assert_eq!(runqueue.get_next_for_core(1), None)
+        assert_eq!(runqueue.get_next(1), None)
     }
 
     #[test]
@@ -238,19 +239,19 @@ mod tests {
         assert_eq!(runqueue.add(5, 0), None);
 
         // Advance head.
-        assert_eq!(runqueue.advance_from(0, 0), Some(0));
-        assert_eq!(runqueue.get_next_for_core(0), Some(4));
+        assert_eq!(runqueue.advance(0, 0), Some(0));
+        assert_eq!(runqueue.get_next(0), Some(4));
         // Other allocations didn't change.
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(2), Some(2));
-        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(2), Some(2));
+        assert_eq!(runqueue.get_next(3), Some(3));
 
         // Advance from a thread that is not head.
-        assert_eq!(runqueue.advance_from(2, 0), Some(2));
-        assert_eq!(runqueue.get_next_for_core(2), Some(5));
+        assert_eq!(runqueue.advance(2, 0), Some(2));
+        assert_eq!(runqueue.get_next(2), Some(5));
         // Other allocations didn't change.
-        assert_eq!(runqueue.get_next_for_core(0), Some(4));
-        assert_eq!(runqueue.get_next_for_core(1), Some(1));
-        assert_eq!(runqueue.get_next_for_core(3), Some(3));
+        assert_eq!(runqueue.get_next(0), Some(4));
+        assert_eq!(runqueue.get_next(1), Some(1));
+        assert_eq!(runqueue.get_next(3), Some(3));
     }
 }

--- a/src/riot-rs-runqueue/src/runqueue.rs
+++ b/src/riot-rs-runqueue/src/runqueue.rs
@@ -283,7 +283,7 @@ mod clist {
                 let prev = self
                     .next_idxs
                     .iter()
-                    .position(|n| *n == next)
+                    .position(|next_idx| *next_idx == n)
                     .expect("List is circular.");
                 self.next_idxs[prev] = next as ThreadId;
 

--- a/src/riot-rs-runqueue/src/runqueue.rs
+++ b/src/riot-rs-runqueue/src/runqueue.rs
@@ -126,12 +126,6 @@ impl<const N_QUEUES: usize, const N_THREADS: usize, const N_CORES: usize>
         self.reallocate()
     }
 
-    pub fn advance_head(&mut self, rq: RunqueueId) -> Option<CoreId> {
-        debug_assert!((rq as usize) < N_QUEUES);
-        self.queues.advance(rq);
-        self.reallocate()
-    }
-
     /// Update `self.next` so that the highest `N_CORES` threads
     /// are allocated.
     ///
@@ -230,6 +224,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<N_QUEUES, N_THREADS
     ///
     /// Returns a [`CoreId`] if the allocation for this core changed.
     pub fn advance(&mut self, rq: RunqueueId) -> Option<ThreadId> {
+        debug_assert!((rq as usize) < N_QUEUES);
         self.queues.advance(rq);
         self.reallocate()
     }

--- a/src/riot-rs-runqueue/src/runqueue.rs
+++ b/src/riot-rs-runqueue/src/runqueue.rs
@@ -20,7 +20,7 @@ impl FromBitmap for u8 {
         if bitmap == 0 {
             return None;
         }
-        Some(ffs(bitmap) as ThreadId - 1)
+        Some(ffs(bitmap) as u8 - 1)
     }
 }
 
@@ -61,130 +61,22 @@ impl<const N_QUEUES: usize, const N_THREADS: usize, const N_CORES: usize>
         }
     }
 
-    /// Adds thread with pid `n` to runqueue number `rq`.
-    ///
-    /// Returns a [`CoreId`] if the allocation for this core changed.
-    ///
-    pub fn add(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId> {
-        debug_assert!((n as usize) < N_THREADS);
-        debug_assert!((rq as usize) < N_QUEUES);
-        self.bitcache |= 1 << rq;
-        self.queues.push(n, rq);
-        self.reallocate()
-    }
-
-    /// Removes thread with pid `n` from runqueue number `rq`.
-    ///
-    /// Returns a [`CoreId`] if the allocation for this core changed.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `n` is not the queue's head.
-    /// This is fine, RIOT-rs only ever calls `del()` for the current thread.
-    pub fn del(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId> {
-        debug_assert!((n as usize) < N_THREADS);
-        debug_assert!((rq as usize) < N_QUEUES);
-
-        if N_CORES == 1 {
-            let popped = self.queues.pop_head(rq);
-            assert_eq!(popped, Some(n));
-        } else {
-            if self.queues.peek_head(rq) == Some(n) {
-                let popped = self.queues.pop_head(rq);
-                assert_eq!(popped, Some(n));
-            } else {
-                self.queues.del(n, rq);
-            }
-        }
-
-        if self.queues.is_empty(rq) {
-            self.bitcache &= !(1 << rq);
-        }
-        self.reallocate()
-    }
-
     /// Returns the next thread that should run on this core.
-    pub fn get_next_for_core(&self, core: CoreId) -> Option<ThreadId> {
+    pub fn get_next(&self, core: CoreId) -> Option<ThreadId> {
         if core as usize >= N_CORES {
             return None;
         }
         self.next[core as usize]
     }
 
-    /// Advances from thread `n` in runqueue number `rq`.
-    ///
-    /// This is used to "yield" to another thread of *the same* priority.
-    /// Compared to [`RunQueue::advance`], this method allows to advance from a thread that
-    /// is not necessarily the head of the runqueue.
-    ///
-    /// Returns a [`CoreId`] if the allocation for this core changed.
-    ///
-    /// **Warning: This changes the order of the runqueue because the thread is moved to the
-    /// tail of the queue.**
-    pub fn advance_from(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId> {
-        debug_assert!((rq as usize) < N_QUEUES);
-        if Some(n) == self.queues.peek_head(rq) {
-            self.queues.advance(rq);
-        } else {
-            // If the thread is not the head remove it
-            // from queue and re-insert it at tail.
-            self.queues.del(n, rq);
-            self.queues.push(n, rq);
-        }
-        self.reallocate()
-    }
-
-    /// Update `self.next` so that the highest `N_CORES` threads
-    /// are allocated.
-    ///
-    /// This only changes allocations if a thread was previously allocated
-    /// and is now not part of the new list anymore, or the other way around.
-    /// It assumes that there was maximum one change in the runqueue since the
-    /// last reallocation (only one add/ delete or a runqueue advancement)!
-    ///
-    /// Returns a [`CoreId`] if the allocation for this core changed.
-    ///
-    /// The complexity of this call is O(n).
-    fn reallocate(&mut self) -> Option<CoreId> {
-        if N_CORES == 1 {
-            let next = self.peek_head(self.bitcache);
-            if next == self.next[0] {
-                return None;
-            }
-            self.next[0] = next;
-            return Some(0);
-        }
-        let next = self.get_next_n();
-        let mut bitmap_next = 0;
-        let mut bitmap_allocated = 0;
-        for i in 0..N_CORES {
-            if let Some(id) = next[i] {
-                bitmap_next |= 1 << id
-            }
-            if let Some(id) = self.next[i] {
-                bitmap_allocated |= 1 << id
-            }
-        }
-        if bitmap_next == bitmap_allocated {
-            return None;
-        }
-        let diff = bitmap_next ^ bitmap_allocated;
-        let prev_allocated = ThreadId::from_bitmap(bitmap_allocated & diff);
-        let new_allocated = ThreadId::from_bitmap(bitmap_next & diff);
-
-        let changed_core = self.next.iter().position(|i| *i == prev_allocated).unwrap();
-        self.next[changed_core] = new_allocated;
-        return Some(changed_core as CoreId);
-    }
-
-    /// Returns the `n` highest priority threads in the [`Runqueue`].
+    /// Returns the `n` highest priority threads in the [`RunQueue`].
     ///
     /// This iterates through all non-empty runqueues with descending
     /// priority, until `N_CORES` threads have been found or all
     /// queues have been checked.
     ///
     /// Complexity is O(n).
-    pub fn get_next_n(&self) -> [Option<ThreadId>; N_CORES] {
+    fn get_next_n(&self) -> [Option<ThreadId>; N_CORES] {
         let mut next_list = [None; N_CORES];
         let mut bitcache = self.bitcache;
         // Get head from highest priority queue.
@@ -214,6 +106,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize, const N_CORES: usize>
         next_list
     }
 
+    #[inline]
     fn peek_head(&self, bitcache: usize) -> Option<ThreadId> {
         // Switch to highest priority runqueue remaining
         // in the bitcache.
@@ -225,23 +118,188 @@ impl<const N_QUEUES: usize, const N_THREADS: usize, const N_CORES: usize>
     }
 }
 
-impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<N_QUEUES, N_THREADS> {
-    /// Returns the pid that should run next.
+pub trait GlobalRunqueue<const N_QUEUES: usize, const N_THREADS: usize, const N_CORES: usize> {
+    /// Adds thread with pid `n` to runqueue number `rq`.
     ///
-    /// Returns the next runnable thread of
-    /// the runqueue with the highest index.
-    pub fn get_next(&self) -> Option<ThreadId> {
-        self.get_next_for_core(0)
+    /// Returns a [`CoreId`] if the allocation for this core changed.
+    ///
+    fn add(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId>;
+
+    /// Removes thread with pid `n` from runqueue number `rq`.
+    ///
+    /// Returns a [`CoreId`] if the allocation for this core changed.
+    ///
+    /// # Panics
+    ///
+    /// Panics for `N_CORES == 1`` if `n` is not the queue's head.
+    /// This is fine, RIOT-rs only ever calls `del()` for the current thread.
+    fn del(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId>;
+
+    /// Advances from thread `n` in runqueue number `rq`.
+    ///
+    /// This is used to "yield" to another thread of *the same* priority.
+    ///
+    /// Returns a [`CoreId`] if the allocation for this core changed.
+    ///
+    /// **Warning: If `n` it not head if the run queue, this changes
+    /// the order of the queue because the thread is moved to the
+    /// tail.**
+    fn advance(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId>;
+
+    /// Update `self.next` so that the highest `N_CORES` threads
+    /// are allocated.
+    ///
+    /// This only changes allocations if a thread was previously allocated
+    /// and is now not part of the new list anymore, or the other way around.
+    /// It assumes that there was maximum one change in the runqueue since the
+    /// last reallocation (only one add/ delete or a runqueue advancement)!
+    ///
+    /// Returns a [`CoreId`] if the allocation for this core changed.
+    fn reallocate(&mut self) -> Option<CoreId>;
+}
+
+impl<const N_QUEUES: usize, const N_THREADS: usize, const N_CORES: usize>
+    GlobalRunqueue<N_QUEUES, N_THREADS, N_CORES> for RunQueue<N_QUEUES, N_THREADS, N_CORES>
+{
+    default fn add(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId> {
+        debug_assert!((n as usize) < N_THREADS);
+        debug_assert!((rq as usize) < N_QUEUES);
+        self.bitcache |= 1 << rq;
+        self.queues.push(n, rq);
+        self.reallocate()
     }
 
+    default fn del(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId> {
+        debug_assert!((n as usize) < N_THREADS);
+        debug_assert!((rq as usize) < N_QUEUES);
+
+        if self.queues.peek_head(rq) == Some(n) {
+            let popped = self.queues.pop_head(rq);
+            assert_eq!(popped, Some(n));
+        } else {
+            self.queues.del(n, rq);
+        }
+
+        if self.queues.is_empty(rq) {
+            self.bitcache &= !(1 << rq);
+        }
+        self.reallocate()
+    }
+
+    default fn advance(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId> {
+        debug_assert!((rq as usize) < N_QUEUES);
+        if Some(n) == self.queues.peek_head(rq) {
+            self.queues.advance(rq);
+        } else {
+            // If the thread is not the head remove it
+            // from queue and re-insert it at tail.
+            self.queues.del(n, rq);
+            self.queues.push(n, rq);
+        }
+        self.reallocate()
+    }
+
+    default fn reallocate(&mut self) -> Option<CoreId> {
+        let next = self.get_next_n();
+        let mut bitmap_next = 0;
+        let mut bitmap_allocated = 0;
+        for i in 0..N_CORES {
+            if let Some(id) = next[i] {
+                bitmap_next |= 1 << id
+            }
+            if let Some(id) = self.next[i] {
+                bitmap_allocated |= 1 << id
+            }
+        }
+        if bitmap_next == bitmap_allocated {
+            return None;
+        }
+        let diff = bitmap_next ^ bitmap_allocated;
+        let prev_allocated = ThreadId::from_bitmap(bitmap_allocated & diff);
+        let new_allocated = ThreadId::from_bitmap(bitmap_next & diff);
+
+        let changed_core = self.next.iter().position(|i| *i == prev_allocated).unwrap();
+        self.next[changed_core] = new_allocated;
+        return Some(changed_core as CoreId);
+    }
+}
+
+impl<const N_QUEUES: usize, const N_THREADS: usize> GlobalRunqueue<N_QUEUES, N_THREADS, 1>
+    for RunQueue<N_QUEUES, N_THREADS>
+{
     /// Advances runqueue number `rq`.
     ///
     /// This is used to "yield" to another thread of *the same* priority.
     ///
     /// Returns a [`CoreId`] if the allocation for this core changed.
-    pub fn advance(&mut self, rq: RunqueueId) -> Option<ThreadId> {
+    fn advance(&mut self, _: ThreadId, rq: RunqueueId) -> Option<CoreId> {
         debug_assert!((rq as usize) < N_QUEUES);
         self.queues.advance(rq);
+        self.reallocate()
+    }
+
+    #[inline]
+    fn del(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId> {
+        debug_assert!((n as usize) < N_THREADS);
+        debug_assert!((rq as usize) < N_QUEUES);
+        let popped = self.queues.pop_head(rq);
+        assert_eq!(popped, Some(n));
+        if self.queues.is_empty(rq) {
+            self.bitcache &= !(1 << rq);
+        }
+        self.reallocate()
+    }
+
+    #[inline]
+    fn reallocate(&mut self) -> Option<CoreId> {
+        let next = self.peek_head(self.bitcache);
+        if next == self.next[0] {
+            return None;
+        }
+        self.next[0] = next;
+        return Some(0);
+    }
+}
+
+impl<const N_QUEUES: usize, const N_THREADS: usize> GlobalRunqueue<N_QUEUES, N_THREADS, 2>
+    for RunQueue<N_QUEUES, N_THREADS, 2>
+{
+    fn reallocate(&mut self) -> Option<CoreId> {
+        let next = self.get_next_n();
+
+        if self.next[0] == next[0] {
+            if self.next[1] == next[1] {
+                return None;
+            }
+            self.next[1] = next[1];
+            return Some(1);
+        }
+        if self.next[1] == next[0] {
+            if self.next[0] == next[1] {
+                return None;
+            }
+            self.next[0] = next[1];
+            return Some(0);
+        }
+        if self.next[1] == next[1] {
+            self.next[0] = next[0];
+            return Some(0);
+        } else {
+            self.next[1] = next[0];
+            Some(1)
+        }
+    }
+
+    fn advance(&mut self, n: ThreadId, rq: RunqueueId) -> Option<CoreId> {
+        debug_assert!((rq as usize) < N_QUEUES);
+        if Some(n) == self.queues.peek_head(rq) {
+            self.queues.advance(rq);
+        } else {
+            // If the thread is not the head remove it
+            // from queue and re-insert it at tail.
+            self.queues.pop_next(rq);
+            self.queues.push(n, rq);
+        }
         self.reallocate()
     }
 }
@@ -359,6 +417,7 @@ mod clist {
             }
         }
 
+        #[inline]
         pub fn peek_head(&self, rq: RunqueueId) -> Option<ThreadId> {
             if self.tail[rq as usize] == Self::sentinel() {
                 None
@@ -375,6 +434,18 @@ mod clist {
 
         pub fn peek_next(&self, curr: ThreadId) -> ThreadId {
             self.next_idxs[curr as usize]
+        }
+
+        /// Remove next thread after head in runqueue.
+        pub fn pop_next(&mut self, rq: RunqueueId) -> Option<ThreadId> {
+            let head = self.peek_head(rq)?;
+            let next = self.peek_next(head);
+            if next == head {
+                return None;
+            }
+            self.next_idxs[head as usize] = self.next_idxs[next as usize];
+            self.next_idxs[next as usize] = Self::sentinel();
+            Some(next)
         }
     }
 

--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -175,7 +175,7 @@ unsafe fn sched() -> usize {
 
     loop {
         {
-            if let Some(pid) = (unsafe { &*THREADS.as_ptr(cs) }).runqueue.get_next() {
+            if let Some(pid) = (unsafe { &*THREADS.as_ptr(cs) }).runqueue.get_next(0) {
                 next_pid = pid;
                 break;
             }

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -6,7 +6,7 @@
 // invariants
 #![allow(clippy::indexing_slicing)]
 
-use riot_rs_runqueue::RunQueue;
+use riot_rs_runqueue::{GlobalRunqueue, RunQueue};
 pub use riot_rs_runqueue::{RunqueueId, ThreadId};
 
 mod arch;
@@ -287,8 +287,10 @@ fn cleanup() -> ! {
 /// "Yields" to another thread with the same priority.
 pub fn yield_same() {
     THREADS.with_mut(|mut threads| {
-        let runqueue = threads.current().unwrap().prio;
-        threads.runqueue.advance(runqueue);
+        let thread = threads.current().unwrap();
+        let runqueue = thread.prio;
+        let pid = thread.pid;
+        threads.runqueue.advance(pid, runqueue);
         schedule();
     })
 }


### PR DESCRIPTION
See #244.

Add support for multicore to the runqueue.

The current allocation for each core is stored in a new array so that any call to `get_next_for_core`  remains minimal effort.

The allocation is updated after each change in the runqueue. The reallocation currently has complexity O(n) because we a) need to get _n_ threads for the _n_ cores and b) need to iterate through the lists of new and old allocations to compare what has changed.  Given that we have a very low number of cores I'd say this is okay. Wdyt?

I also had to add a new method `del` to the `CList` because with multiple running threads we can't assume that the deleted thread is always the head.