### PR TITLE
Add random number generator infrastructure

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build rustdoc docs
         run: |
-          cargo doc -p riot-rs --features no-boards,bench,threading
+          cargo doc -p riot-rs --features no-boards,bench,threading,random
           echo "<meta http-equiv=\"refresh\" content=\"0; url=riot_rs\">" > target/doc/index.html
           mkdir -p ./_site/dev/docs/api && mv target/doc/* ./_site/dev/docs/api
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,7 @@ jobs:
           args: --verbose --locked --features no-boards -p riot-rs -p riot-rs-boards -p riot-rs-buildinfo -p riot-rs-chips -p riot-rs-debug -p riot-rs-embassy -p riot-rs-macros -p riot-rs-rt -p riot-rs-utils
 
       - name: "rustdoc"
-        run: cargo rustdoc -p riot-rs --features no-boards,bench,threading -- -D warnings
+        run: cargo rustdoc -p riot-rs --features no-boards,bench,threading,random -- -D warnings
 
       - name: rustfmt
         run: cargo fmt --check --all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,6 +2194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,10 +2263,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "random"
+version = "0.1.0"
+dependencies = [
+ "rand",
+ "riot-rs",
+ "riot-rs-boards",
+ "riot-rs-random",
+]
 
 [[package]]
 name = "rbi"
@@ -2417,6 +2452,7 @@ dependencies = [
  "linkme",
  "once_cell",
  "riot-rs-debug",
+ "riot-rs-random",
  "riot-rs-rt",
  "riot-rs-threads",
  "riot-rs-utils",
@@ -2436,6 +2472,15 @@ dependencies = [
  "riot-rs",
  "syn 2.0.52",
  "trybuild",
+]
+
+[[package]]
+name = "riot-rs-random"
+version = "0.1.0"
+dependencies = [
+ "embassy-sync 0.5.0",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,6 +2375,7 @@ dependencies = [
  "riot-rs-debug",
  "riot-rs-embassy",
  "riot-rs-macros",
+ "riot-rs-random",
  "riot-rs-rt",
  "riot-rs-threads",
  "static_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,6 +1211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-random"
+version = "0.1.0"
+dependencies = [
+ "rand",
+ "riot-rs",
+ "riot-rs-boards",
+]
+
+[[package]]
 name = "expressif-esp32-c6-devkitc-1"
 version = "0.1.0"
 dependencies = [
@@ -2288,13 +2297,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
-name = "random"
-version = "0.1.0"
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand",
- "riot-rs",
- "riot-rs-boards",
- "riot-rs-random",
+ "rand_core",
 ]
 
 [[package]]
@@ -2482,6 +2490,7 @@ dependencies = [
  "embassy-sync 0.5.0",
  "rand_chacha",
  "rand_core",
+ "rand_pcg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "src/riot-rs-chips",
   "src/riot-rs-debug",
   "src/riot-rs-macros",
+  "src/riot-rs-random",
   "tests/benchmarks/bench_sched_yield",
 ]
 

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -13,4 +13,5 @@ subdirs:
   - embassy-usb-keyboard
   - hello-world
   - minimal
+  - random
   - threading

--- a/examples/random/Cargo.toml
+++ b/examples/random/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
-name = "random"
+name = "example-random"
 version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 publish = false
 
 [dependencies]
-# not enabling riot-rs/hwrng even though it's currently needed -- laze takes
-# care of that.
-riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+# Enabling the feature "random" is somewhat redundant with laze.yml's selects:
+# random, but helps with interactive tools.
+riot-rs = { path = "../../src/riot-rs", features = ["threading", "random"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }
 
-riot-rs-random = { version = "0.1.0", path = "../../src/riot-rs-random" }
 rand = { version = "0.8.5", default-features = false }

--- a/examples/random/Cargo.toml
+++ b/examples/random/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "random"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+# not enabling riot-rs/hwrng even though it's currently needed -- laze takes
+# care of that.
+riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs-boards = { path = "../../src/riot-rs-boards" }
+
+riot-rs-random = { version = "0.1.0", path = "../../src/riot-rs-random" }
+rand = { version = "0.8.5", default-features = false }

--- a/examples/random/README.md
+++ b/examples/random/README.md
@@ -1,0 +1,17 @@
+# random
+
+## About
+
+This application performs a very important role in physical computing:
+It produces randomness in the form of a dice roll (values 1 to 6, inclusive).
+It prints out a single random value via the debug console.
+
+## How to run
+
+In this folder, run
+
+    laze build -b nrf52840dk run
+
+This will print different values most of the time on all boards it can be built
+on. If there is no way to get startup entropy on a board, the example can not
+be built.

--- a/examples/random/laze.yml
+++ b/examples/random/laze.yml
@@ -1,0 +1,5 @@
+apps:
+  - name: random
+    selects:
+      - ?release
+      - rng

--- a/examples/random/laze.yml
+++ b/examples/random/laze.yml
@@ -1,5 +1,5 @@
 apps:
-  - name: random
+  - name: example-random
     selects:
       - ?release
-      - rng
+      - random

--- a/examples/random/src/main.rs
+++ b/examples/random/src/main.rs
@@ -8,7 +8,7 @@ use riot_rs::debug::println;
 #[riot_rs::thread(autostart)]
 fn main() {
     use rand::Rng as _;
-    let mut rng = riot_rs::random::get_rng();
+    let mut rng = riot_rs::random::fast_rng();
 
     let value = rng.gen_range(1..=6);
 

--- a/examples/random/src/main.rs
+++ b/examples/random/src/main.rs
@@ -1,0 +1,16 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::debug::println;
+
+#[riot_rs::thread(autostart)]
+fn main() {
+    use rand::Rng as _;
+    let mut rng = riot_rs_random::get_rng();
+
+    let value = rng.gen_range(1..=6);
+
+    println!("The random value of this round is {}.", value);
+}

--- a/examples/random/src/main.rs
+++ b/examples/random/src/main.rs
@@ -8,7 +8,7 @@ use riot_rs::debug::println;
 #[riot_rs::thread(autostart)]
 fn main() {
     use rand::Rng as _;
-    let mut rng = riot_rs_random::get_rng();
+    let mut rng = riot_rs::random::get_rng();
 
     let value = rng.gen_range(1..=6);
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -507,7 +507,8 @@ modules:
       # these are precisely those for which the hwrng feature of
       # riot-rs-embassy builds, which would fail if the big if(context=...)
       # doesn't have an entry in the cfg(feature = "hwrng") part of init_task
-      - nrf
+      - nrf51
+      - nrf52
     env:
       global:
         FEATURES:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -501,6 +501,24 @@ modules:
         RUSTFLAGS:
           - --cfg capability=\"hw/usb-device-port\"
 
+  - name: hwrng
+    help: The board's peripherals are suitable for passing into riot_rs_random::construct_rng.
+    context:
+      # these are precisely those for which the hwrng feature of
+      # riot-rs-embassy builds, which would fail if the big if(context=...)
+      # doesn't have an entry in the cfg(feature = "hwrng") part of init_task
+      - nrf
+    env:
+      global:
+        FEATURES:
+          - riot-rs/hwrng
+
+  - name: rng
+    help: A system-wide RNG is available
+    depends:
+      # could later alternatively depend on mutable config storage
+      - hwrng
+
   - name: sw/benchmark
     help: provided if a target supports `benchmark()`
     # Currently there's only one implementation based on Systick, so Cortex-M only.

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -514,11 +514,18 @@ modules:
         FEATURES:
           - riot-rs/hwrng
 
-  - name: rng
-    help: A system-wide RNG is available
+  - name: random
+    help: A system-wide RNG is available (through the riot_rs::random module).
+
+      As the riot_rs::random module will refuse operation at run time if not
+      properly initialized, this depends on sources of original entropy.
     depends:
       # could later alternatively depend on mutable config storage
       - hwrng
+    env:
+      global:
+        FEATURES:
+          - riot-rs/random
 
   - name: sw/benchmark
     help: provided if a target supports `benchmark()`

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -26,6 +26,7 @@ riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 riot-rs-debug = { workspace = true }
 riot-rs-rt = { path = "../riot-rs-rt" }
 riot-rs-utils = { path = "../riot-rs-utils" }
+riot-rs-random = { path = "../riot-rs-random", optional = true }
 
 heapless = "0.8.0"
 once_cell = { version = "1.19.0", default-features = false, features = [
@@ -96,6 +97,8 @@ usb = ["dep:embassy-usb"]
 # embassy-net requires embassy-time and support for timeouts in the executor
 net = ["dep:embassy-net", "time"]
 usb-ethernet = ["usb", "net"]
+## Use a hardware RNG to seed into the riot-rs-random system-wide RNG
+hwrng = ["dep:riot-rs-random"]
 
 wifi = []
 wifi-cyw43 = [

--- a/src/riot-rs-embassy/src/arch/nrf52.rs
+++ b/src/riot-rs-embassy/src/arch/nrf52.rs
@@ -57,6 +57,13 @@ pub mod usb {
     }
 }
 
+#[cfg(feature = "hwrng")]
+pub mod hwrng {
+    embassy_nrf::bind_interrupts!(pub struct Irqs {
+        RNG => embassy_nrf::rng::InterruptHandler<embassy_nrf::peripherals::RNG>;
+    });
+}
+
 pub fn init(config: Config) -> OptionalPeripherals {
     let peripherals = embassy_nrf::init(config);
     OptionalPeripherals::from(peripherals)

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -96,7 +96,9 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
 
     #[cfg(feature = "hwrng")]
     {
-        #[cfg(context = "nrf")]
+        // The union of all contexts that wind up in a construct_rng should be synchronized with
+        // laze-project.yml's hwrng module.
+        #[cfg(any(context = "nrf51", context = "nrf52"))]
         let rng = embassy_nrf::rng::Rng::new(
             peripherals
                 .RNG

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -94,6 +94,22 @@ fn init() -> ! {
 async fn init_task(mut peripherals: arch::OptionalPeripherals) {
     println!("riot-rs-embassy::init_task()");
 
+    #[cfg(feature = "hwrng")]
+    {
+        #[cfg(context = "nrf")]
+        let rng = embassy_nrf::rng::Rng::new(
+            peripherals
+                .RNG
+                // We don't even have to take it out, just use it to seed the RNG
+                .as_mut()
+                .expect("RNG has not been previously used"),
+            arch::hwrng::Irqs,
+        );
+        riot_rs_random::construct_rng(rng);
+    }
+    // Clock startup and entropy collection may lend themselves to parallelization, provided that
+    // doesn't impact runtime RAM or flash use.
+
     #[cfg(all(context = "nrf", feature = "usb"))]
     {
         // nrf52840

--- a/src/riot-rs-random/Cargo.toml
+++ b/src/riot-rs-random/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "riot-rs-random"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[dependencies]
+rand_core = "0.6.4"
+# Not making it optional during development b/c we don't have a small or fast one
+rand_chacha = { version = "0.3.1", default-features = false }
+embassy-sync.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+## If set, the provided main RNG is also a cryptographically secure pseudo
+## random number generator (CSPRNG) and thusly annotated by the
+## rand_core::CryptoRngCore trait.
+main-is-csprng = []

--- a/src/riot-rs-random/Cargo.toml
+++ b/src/riot-rs-random/Cargo.toml
@@ -7,15 +7,16 @@ repository.workspace = true
 
 [dependencies]
 rand_core = "0.6.4"
-# Not making it optional during development b/c we don't have a small or fast one
-rand_chacha = { version = "0.3.1", default-features = false }
+
 embassy-sync.workspace = true
+
+rand_pcg = "0.3.1"
+rand_chacha = { version = "0.3.1", default-features = false, optional = true }
 
 [lints]
 workspace = true
 
 [features]
-## If set, the provided main RNG is also a cryptographically secure pseudo
-## random number generator (CSPRNG) and thusly annotated by the
-## rand_core::CryptoRngCore trait.
-main-is-csprng = []
+## If set, the one global RNG is also a cryptographically secure pseudo
+## random number generator (CSPRNG), and thus, a `CryptoRng` can be produced.
+csprng = ["dep:rand_chacha"]

--- a/src/riot-rs-random/src/lib.rs
+++ b/src/riot-rs-random/src/lib.rs
@@ -52,7 +52,10 @@ pub(crate) type SelectedRng = rand_chacha::ChaCha20Rng;
 /// depend on a known fast RNG and seed it from the OS's RNG, but preferably there should be a
 /// single configured implementation used across applications for ROM optimization, even if it
 /// turns out to be beneficial to have a thread or task local RNG around in RAM for speed).
-pub struct Rng;
+pub struct Rng {
+    // Make the type not Send
+    _private: core::marker::PhantomData<*const ()>,
+}
 
 impl Rng {
     fn with<R>(&mut self, action: impl FnOnce(&mut SelectedRng) -> R) -> R {
@@ -112,5 +115,7 @@ pub fn construct_rng(hwrng: impl RngCore) {
 /// macros.
 #[inline]
 pub fn get_rng() -> Rng {
-    Rng
+    Rng {
+        _private: Default::default(),
+    }
 }

--- a/src/riot-rs-random/src/lib.rs
+++ b/src/riot-rs-random/src/lib.rs
@@ -1,0 +1,116 @@
+//! Provides a seeded random number generator depending on RIOT-rs's configuration.
+//!
+//! The module provides a single function for use by applications, [`get_rng()`], produces an owned
+//! RNG of type [`Rng`] to the application.
+//!
+//! The crate abstracts over multiple aspects of RNGs:
+//! * Where do we take a valid seed for the RNG from?
+//! * What's the type of RNG that we take along?
+//! * Can some of those be shared?
+//!   (This may need an API change, but non-Send tasks could very well use an executor-local RNG
+//!   behind a shared reference to not all carry a full RNG state for each user)
+//!
+//! No matter the choices taken (eventually through the application's setup), all is hidden behind
+//! a main [`Rng`] type, which depending on the feature `main-is-csprng` also implements
+//! [`rand_core::CryptoRng`]
+//!
+//! Before accessing the RNG, it needs to be initialized through the [`construct_rng()`'] function.
+//! This is taken care of by the `riot-rs-embassy` initialization functions. Applications can
+//! ensure that this has happened by depending on the laze feature `rng`.
+//!
+//! ---
+//!
+//! Currently, this provides very little choice, and little fanciness: It (more or less
+//! arbitrarily) uses the [rand_chacha::ChaCha20Rng] generator, seeds uses different copies of that
+//! RNG for all callers fo [`get_rng()`]. Later, it may offer a wider range of choices and
+//! trade-offs between flash size, speed and security. (See [Rng] for its properties).
+#![no_std]
+
+use rand_core::{RngCore, SeedableRng};
+
+// The Mutex<RefCell> can probably be simplified
+static RNG: embassy_sync::blocking_mutex::Mutex<
+    embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
+    core::cell::RefCell<Option<Rng>>,
+> = embassy_sync::blocking_mutex::Mutex::new(core::cell::RefCell::new(None));
+
+// This is one of the points where we can tune easily. If calls to `get_rng()` are rare, it may
+// even make sense to move the HWRNG in here to get a global ZST.
+// #[cfg(feature = "main-is-csprng")]
+pub(crate) type SelectedRng = rand_chacha::ChaCha20Rng;
+
+/// The OS provided random number generator.
+///
+/// This may be small, fast and/or secure, but will sacrifice the earlier properties if the later
+/// are needed by any system component.
+///
+/// Such an RNG can be requested by any component, and will always be seeded appropriately.
+///
+/// There is no point in requesting a "small" RNG (if a fast RNG is built in, that will do just as
+/// well). There may be a point in requesting a "fast" RNG, which it may make sense to introduce a
+/// FastRng that particular components can request. (Until that is available, an application can
+/// depend on a known fast RNG and seed it from the OS's RNG, but preferably there should be a
+/// single configured implementation used across applications for ROM optimization, even if it
+/// turns out to be beneficial to have a thread or task local RNG around in RAM for speed).
+pub struct Rng {
+    inner: SelectedRng,
+}
+
+impl Rng {
+    // Create a per-thread/per-task copy of the RNG. Not sure whether we'll need that all the time,
+    // and/or whether these should all have the same types, but for the first iteration
+    // everything-is-of-type-Rng is good enough
+    fn split(&mut self) -> Self {
+        Self { inner: SelectedRng::from_rng(self).expect("Main RNG is infallible") }
+    }
+}
+
+// Re-implementing the trait rather than Deref'ing into inner: This avoids leaking implementation
+// details to users who might otherwise come to depend on platform specifics of the Rng.
+impl RngCore for Rng {
+    fn next_u32(&mut self) -> u32 {
+        self.inner.next_u32()
+    }
+    fn next_u64(&mut self) -> u64 {
+        self.inner.next_u64()
+    }
+    fn fill_bytes(&mut self, buf: &mut [u8]) {
+        self.inner.fill_bytes(buf)
+    }
+    fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.inner.try_fill_bytes(buf)
+    }
+}
+
+#[cfg(feature = "main-is-csprng")]
+mod main_is_csprng {
+    impl rand_core::CryptoRng for super::Rng {}
+
+    /// Asserts that SelectedRng is CryptoRng, justifying the implementation above.
+    fn static_assert_is_cryptorng() -> impl rand_core::CryptoRng {
+        let result: super::SelectedRng = unreachable!("This function is for type checking only");
+        result
+    }
+}
+
+/// Populates the RNG from a seed value.
+///
+/// This is called by RIOT-rs's initialization functions.
+pub fn construct_rng(hwrng: impl RngCore) {
+    RNG.lock(|r| {
+        r.replace(Some(Rng {
+            inner: SelectedRng::from_rng(hwrng).expect("Hardware RNG failed to provide entropy"),
+        }))
+    });
+}
+
+/// Obtains a suitably initialized random number generator.
+///
+/// This may be used by threads or tasks. To avoid synchronizion overhead, in the future,
+/// dependency injection for task and thread generation might be provided through the riot-rs
+/// macros.
+#[inline]
+pub fn get_rng() -> Rng {
+    RNG.lock(|r| r.borrow_mut().as_mut().map(|main| main.split()))
+        .expect("Initialization should have populated the RNG")
+}

--- a/src/riot-rs-random/src/lib.rs
+++ b/src/riot-rs-random/src/lib.rs
@@ -1,94 +1,128 @@
 //! Provides a seeded random number generator depending on RIOT-rs's configuration.
 //!
-//! The module provides a single function for use by applications, [`get_rng()`], produces an owned
-//! RNG of type [`Rng`] to the application.
+//! The module provides functions for use by applications, [`fast_rng()`] and [`crypto_rng()`],
+//! which produce owned types that provide the [`rand_core::RngCore`] and
+//! [`rand_core::CryptoRng`'] traits, respectively.
 //!
 //! The crate abstracts over multiple aspects of RNGs:
 //! * Where do we take a valid seed for the RNG from?
 //! * What's the type of RNG that we take along?
-//! * Can some of those be shared?
-//!   (Currently, Rng is a zero-sized type shared across all users, and locks on each access.
-//!   That behavior may still change).
+//! * Is RNG state shared across cores, threads, tasks or not at all?
 //!
 //! No matter the choices taken (eventually through the application's setup), all is hidden behind
-//! a main [`Rng`] type, which depending on the feature `main-is-csprng` also implements
-//! [`rand_core::CryptoRng`]
+//! the [`FastRng`] and [`CryptoRng`] types.
 //!
 //! Before accessing the RNG, it needs to be initialized through the [`construct_rng()`'] function.
 //! This is taken care of by the `riot-rs-embassy` initialization functions. Applications can
-//! ensure that this has happened by depending on the laze feature `rng`.
+//! ensure that this has happened by depending on the laze feature `random`.
 //!
 //! ---
 //!
 //! Currently, this provides very little choice, and little fanciness: It (more or less
-//! arbitrarily) uses the [rand_chacha::ChaCha20Rng] generator, and the zero-sized wrapper Rng
-//! around it locks the global state on demand. Neither the algorithm nor the size of Rng is
-//! guaranteed.
+//! arbitrarily) uses the [rand_chacha::ChaCha20Rng] generator as a shared global RNG, and
+//! [rand_pcg::Pcg32] is decided yet for the fast one. Neither the algorithm nor the size of
+//! FastRng or CryptoRng is guaranteed.
 #![no_std]
 
 use rand_core::{RngCore, SeedableRng};
 
+/// A global RNG.
 // The Mutex<RefCell> can probably be simplified
 static RNG: embassy_sync::blocking_mutex::Mutex<
     embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
     core::cell::RefCell<Option<SelectedRng>>,
 > = embassy_sync::blocking_mutex::Mutex::new(core::cell::RefCell::new(None));
 
-// This is one of the points where we can tune easily. If calls to `get_rng()` are rare, it may
-// even make sense to move the HWRNG in here to get a global ZST.
-// #[cfg(feature = "main-is-csprng")]
+/// Type of the global RNG when needing the ability to produce cryptographially secure random
+/// numbers.
+///
+/// If calls to [`rng()`] are rare, it may even make sense to move the HWRNG in here to get a
+/// ZST global.
+#[cfg(feature = "csprng")]
 pub(crate) type SelectedRng = rand_chacha::ChaCha20Rng;
 
-/// The OS provided random number generator.
+/// Type of the global RNG when cryptographically secure random numbers are not needed.
+#[cfg(not(feature = "csprng"))]
+pub(crate) type SelectedRng = rand_pcg::Pcg32;
+
+/// Locks the global RNG for a single operation.
 ///
-/// This may be small, fast and/or secure, but will sacrifice the earlier properties if the later
-/// are needed by any system component.
+/// ## Panics
+///
+/// … if initialization did not happen.
+///
+/// ## Deadlocks
+///
+/// … if the action attempts to lock RNG.
+fn with_global<R>(action: impl FnOnce(&mut SelectedRng) -> R) -> R {
+    RNG.lock(|i| {
+        action(
+            i.borrow_mut()
+                .as_mut()
+                .expect("Initialization should have populated RNG"),
+        )
+    })
+}
+
+/// The OS provided fast random number generator.
+///
+/// This will generally be faster to produce random numbers than [`CryptoRng`].
 ///
 /// Such an RNG can be requested by any component, and will always be seeded appropriately.
-///
-/// There is no point in requesting a "small" RNG (if a fast RNG is built in, that will do just as
-/// well). There may be a point in requesting a "fast" RNG, which it may make sense to introduce a
-/// FastRng that particular components can request. (Until that is available, an application can
-/// depend on a known fast RNG and seed it from the OS's RNG, but preferably there should be a
-/// single configured implementation used across applications for ROM optimization, even if it
-/// turns out to be beneficial to have a thread or task local RNG around in RAM for speed).
-pub struct Rng {
-    // Make the type not Send
+pub struct FastRng {
+    inner: rand_pcg::Pcg32,
+    // Make the type not Send to later allow using thread-locals
     _private: core::marker::PhantomData<*const ()>,
 }
 
-impl Rng {
-    fn with<R>(&mut self, action: impl FnOnce(&mut SelectedRng) -> R) -> R {
-        RNG.lock(|i| {
-            action(
-                i.borrow_mut()
-                    .as_mut()
-                    .expect("Initialization should have populated RNG"),
-            )
-        })
-    }
-}
-
 // Re-implementing the trait rather than Deref'ing into inner: This avoids leaking implementation
-// details to users who might otherwise come to depend on platform specifics of the Rng.
-impl RngCore for Rng {
+// details to users who might otherwise come to depend on platform specifics of the FastRng.
+impl RngCore for FastRng {
     fn next_u32(&mut self) -> u32 {
-        self.with(|i| i.next_u32())
+        self.inner.next_u32()
     }
     fn next_u64(&mut self) -> u64 {
-        self.with(|i| i.next_u64())
+        self.inner.next_u64()
     }
     fn fill_bytes(&mut self, buf: &mut [u8]) {
-        self.with(|i| i.fill_bytes(buf))
+        self.inner.fill_bytes(buf)
     }
     fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), rand_core::Error> {
-        self.with(|i| i.try_fill_bytes(buf))
+        self.inner.try_fill_bytes(buf)
     }
 }
 
-#[cfg(feature = "main-is-csprng")]
-mod main_is_csprng {
-    impl rand_core::CryptoRng for super::Rng {}
+/// The OS provided cryptographically secure random number generator.
+///
+/// Such an RNG can be requested by any component, and will always be seeded appropriately.
+#[cfg(feature = "csprng")]
+pub struct CryptoRng {
+    // Make the type not Send to later allow using thread-locals
+    pub(crate) _private: core::marker::PhantomData<*const ()>,
+}
+
+#[cfg(feature = "csprng")]
+mod csprng {
+    use super::*;
+
+    // Re-implementing the trait rather than Deref'ing into inner: This avoids leaking implementation
+    // details to users who might otherwise come to depend on platform specifics of the CryptoRng.
+    impl RngCore for CryptoRng {
+        fn next_u32(&mut self) -> u32 {
+            with_global(|i| i.next_u32())
+        }
+        fn next_u64(&mut self) -> u64 {
+            with_global(|i| i.next_u64())
+        }
+        fn fill_bytes(&mut self, buf: &mut [u8]) {
+            with_global(|i| i.fill_bytes(buf))
+        }
+        fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), rand_core::Error> {
+            with_global(|i| i.try_fill_bytes(buf))
+        }
+    }
+
+    impl rand_core::CryptoRng for super::CryptoRng {}
 
     /// Asserts that SelectedRng is CryptoRng, justifying the implementation above.
     fn static_assert_is_cryptorng() -> impl rand_core::CryptoRng {
@@ -97,7 +131,7 @@ mod main_is_csprng {
     }
 }
 
-/// Populates the RNG from a seed value.
+/// Populates the global RNG from a seed value.
 ///
 /// This is called by RIOT-rs's initialization functions.
 pub fn construct_rng(hwrng: impl RngCore) {
@@ -108,14 +142,20 @@ pub fn construct_rng(hwrng: impl RngCore) {
     });
 }
 
-/// Obtains a suitably initialized random number generator.
-///
-/// This may be used by threads or tasks. To avoid synchronizion overhead, in the future,
-/// dependency injection for task and thread generation might be provided through the riot-rs
-/// macros.
+/// Obtains a suitably initialized fast random number generator.
 #[inline]
-pub fn get_rng() -> Rng {
-    Rng {
+pub fn fast_rng() -> FastRng {
+    FastRng {
+        inner: with_global(|i| rand_pcg::Pcg32::from_rng(i).expect("Global RNG is infallible")),
+        _private: Default::default(),
+    }
+}
+
+/// Obtains a suitably initialized cryptographically secure random number generator.
+#[inline]
+#[cfg(feature = "csprng")]
+pub fn crypto_rng() -> CryptoRng {
+    CryptoRng {
         _private: Default::default(),
     }
 }

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -16,6 +16,7 @@ riot-rs-buildinfo = { path = "../riot-rs-buildinfo" }
 riot-rs-debug = { workspace = true }
 riot-rs-embassy = { path = "../riot-rs-embassy" }
 riot-rs-macros = { path = "../riot-rs-macros" }
+riot-rs-random = { path = "../riot-rs-random", optional = true }
 riot-rs-rt = { path = "../riot-rs-rt" }
 riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 static_cell = { workspace = true }
@@ -44,6 +45,8 @@ threading = [
 ## Enables support for timeouts in the internal executor---required to use
 ## `embassy_time::Timer`.
 time = ["riot-rs-embassy/time"]
+## Enables the [`riot-rs::random`] module.
+random = ["riot-rs-random"]
 ## Enables seeding the random number generator from hardware.
 hwrng = ["riot-rs-embassy/hwrng"]
 

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -45,8 +45,10 @@ threading = [
 ## Enables support for timeouts in the internal executor---required to use
 ## `embassy_time::Timer`.
 time = ["riot-rs-embassy/time"]
-## Enables the [`riot-rs::random`] module.
+## Enables the `random` module.
 random = ["riot-rs-random"]
+## Enables a cryptographically seucre random number generator in the `random` module.
+csprng = ["riot-rs-random/csprng"]
 ## Enables seeding the random number generator from hardware.
 hwrng = ["riot-rs-embassy/hwrng"]
 

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -44,6 +44,8 @@ threading = [
 ## Enables support for timeouts in the internal executor---required to use
 ## `embassy_time::Timer`.
 time = ["riot-rs-embassy/time"]
+## Enables seeding the random number generator from hardware.
+hwrng = ["riot-rs-embassy/hwrng"]
 
 #! ## Wired communication
 ## Enables USB support.

--- a/src/riot-rs/src/lib.rs
+++ b/src/riot-rs/src/lib.rs
@@ -17,6 +17,9 @@ pub use riot_rs_debug as debug;
 #[doc(inline)]
 pub use riot_rs_embassy as embassy;
 pub use riot_rs_embassy::{define_peripherals, group_peripherals};
+#[cfg(feature = "random")]
+#[doc(inline)]
+pub use riot_rs_random as random;
 #[doc(inline)]
 pub use riot_rs_rt as rt;
 #[cfg(feature = "threading")]


### PR DESCRIPTION
This is <del>a first jab at</del> supporting OS level RNG, <del>based on the CoAP branch</del> because that needs it.

<del>For a first coarse review please consider the latest two commits; if that first stage is passed, I'll rebase it to be usable without CoAP.</del>

Closes: https://github.com/future-proof-iot/RIOT-rs/issues/231