### PR TITLE
add defmt support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "byteorder"
@@ -803,7 +803,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -814,7 +814,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -830,6 +830,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
+name = "defmt"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9f309eff1f79b3ebdf252954d90ae440599c26c2c553fe87a2d17195f2dcb"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.67",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "defmt-rtt-target"
+version = "0.3.0"
+source = "git+https://github.com/kaspar030/defmt-rtt-target?rev=5668c92ac5a0689b165a6a07bb14e173fc47cd34#5668c92ac5a0689b165a6a07bb14e173fc47cd34"
+dependencies = [
+ "cortex-m",
+ "critical-section",
+ "defmt",
+ "rtt-target 0.5.0",
+]
+
+[[package]]
 name = "delegate"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,7 +880,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -852,13 +895,13 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -961,6 +1004,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca4a9380d03e61063067b8239f67d2fa9f108ede7c46b4273804f6b79e59a1d"
 dependencies = [
+ "defmt",
  "embassy-futures",
  "embassy-sync 0.5.0",
  "embassy-time",
@@ -994,7 +1038,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1002,6 +1046,9 @@ name = "embassy-futures"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+dependencies = [
+ "defmt",
+]
 
 [[package]]
 name = "embassy-hal-internal"
@@ -1010,6 +1057,7 @@ source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-240605#584
 dependencies = [
  "cortex-m",
  "critical-section",
+ "defmt",
  "num-traits",
 ]
 
@@ -1037,6 +1085,7 @@ name = "embassy-net"
 version = "0.4.0"
 source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-240605#584940fc7ea02fe184f3ae346ecaa3d00008c95e"
 dependencies = [
+ "defmt",
  "document-features",
  "embassy-net-driver",
  "embassy-sync 0.6.0",
@@ -1052,6 +1101,9 @@ dependencies = [
 name = "embassy-net-driver"
 version = "0.2.0"
 source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-240605#584940fc7ea02fe184f3ae346ecaa3d00008c95e"
+dependencies = [
+ "defmt",
+]
 
 [[package]]
 name = "embassy-net-driver-channel"
@@ -1099,6 +1151,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
+ "defmt",
  "document-features",
  "embassy-embedded-hal",
  "embassy-hal-internal",
@@ -1196,6 +1249,7 @@ checksum = "b3e0c49ff02ebe324faf3a8653ba91582e2d0a7fdef5bc88f449d5aa1bfcc05c"
 dependencies = [
  "cfg-if",
  "critical-section",
+ "defmt",
  "embedded-io-async",
  "futures-util",
  "heapless 0.8.0",
@@ -1209,6 +1263,7 @@ checksum = "274c019608a9004aed3cafc871e2a3c87ce9351d537dcaab4cc5db184d4a04b1"
 dependencies = [
  "cfg-if",
  "critical-section",
+ "defmt",
  "document-features",
  "embassy-time-driver",
  "embassy-time-queue-driver",
@@ -1238,6 +1293,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1587e58ed8f7e0215246e6bb8d7ef4837db682e209e5ef7410a81c500dc949e5"
 dependencies = [
+ "defmt",
  "embassy-futures",
  "embassy-net-driver-channel",
  "embassy-sync 0.5.0",
@@ -1251,6 +1307,9 @@ dependencies = [
 name = "embassy-usb-driver"
 version = "0.1.0"
 source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-240605#584940fc7ea02fe184f3ae346ecaa3d00008c95e"
+dependencies = [
+ "defmt",
+]
 
 [[package]]
 name = "embassy-usb-keyboard"
@@ -1320,6 +1379,9 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+dependencies = [
+ "defmt",
+]
 
 [[package]]
 name = "embedded-hal-async"
@@ -1351,6 +1413,9 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+dependencies = [
+ "defmt",
+]
 
 [[package]]
 name = "embedded-io-async"
@@ -1358,6 +1423,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
 dependencies = [
+ "defmt",
  "embedded-io 0.6.1",
 ]
 
@@ -1459,7 +1525,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1480,7 +1546,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1505,7 +1571,7 @@ version = "0.1.0"
 source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#abacafb069aac19dfc1c995f58189a3a3aeef411"
 dependencies = [
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
  "termcolor",
 ]
 
@@ -1519,6 +1585,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
  "critical-section",
+ "defmt",
  "delegate",
  "document-features",
  "embassy-futures",
@@ -1537,10 +1604,14 @@ dependencies = [
  "esp-hal-procmacros",
  "esp-metadata",
  "esp-riscv-rt",
+ "esp32",
+ "esp32c2",
  "esp32c3",
  "esp32c6",
+ "esp32h2",
+ "esp32s2",
+ "esp32s3",
  "fugit",
- "log",
  "nb 1.1.0",
  "paste",
  "portable-atomic",
@@ -1581,7 +1652,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1602,6 +1673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98f0f58453dd2ce08d99228fc8757fad39d05dfd26643665d1093b8844f42cc"
 dependencies = [
  "critical-section",
+ "defmt",
  "log",
 ]
 
@@ -1623,6 +1695,7 @@ dependencies = [
  "atomic-waker",
  "cfg-if",
  "critical-section",
+ "defmt",
  "embassy-futures",
  "embassy-net-driver",
  "embassy-sync 0.6.0",
@@ -1638,12 +1711,12 @@ dependencies = [
  "heapless 0.8.0",
  "libm",
  "linked_list_allocator",
- "log",
  "no-std-net",
  "num-derive",
  "num-traits",
  "portable-atomic",
  "portable_atomic_enum",
+ "smoltcp",
  "toml-cfg",
 ]
 
@@ -1657,11 +1730,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp32"
+version = "0.31.0"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=a7c72f7#a7c72f72c4cc50d1595a0d5a395250306d741fed"
+dependencies = [
+ "critical-section",
+ "defmt",
+ "vcell",
+ "xtensa-lx",
+]
+
+[[package]]
+name = "esp32c2"
+version = "0.20.0"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=a7c72f7#a7c72f72c4cc50d1595a0d5a395250306d741fed"
+dependencies = [
+ "critical-section",
+ "defmt",
+ "vcell",
+]
+
+[[package]]
 name = "esp32c3"
 version = "0.23.0"
 source = "git+https://github.com/esp-rs/esp-pacs?rev=a7c72f7#a7c72f72c4cc50d1595a0d5a395250306d741fed"
 dependencies = [
  "critical-section",
+ "defmt",
  "vcell",
 ]
 
@@ -1671,7 +1766,40 @@ version = "0.14.0"
 source = "git+https://github.com/esp-rs/esp-pacs?rev=a7c72f7#a7c72f72c4cc50d1595a0d5a395250306d741fed"
 dependencies = [
  "critical-section",
+ "defmt",
  "vcell",
+]
+
+[[package]]
+name = "esp32h2"
+version = "0.10.0"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=a7c72f7#a7c72f72c4cc50d1595a0d5a395250306d741fed"
+dependencies = [
+ "critical-section",
+ "defmt",
+ "vcell",
+]
+
+[[package]]
+name = "esp32s2"
+version = "0.22.0"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=a7c72f7#a7c72f72c4cc50d1595a0d5a395250306d741fed"
+dependencies = [
+ "critical-section",
+ "defmt",
+ "vcell",
+ "xtensa-lx",
+]
+
+[[package]]
+name = "esp32s3"
+version = "0.26.0"
+source = "git+https://github.com/esp-rs/esp-pacs?rev=a7c72f7#a7c72f72c4cc50d1595a0d5a395250306d741fed"
+dependencies = [
+ "critical-section",
+ "defmt",
+ "vcell",
+ "xtensa-lx",
 ]
 
 [[package]]
@@ -1797,7 +1925,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1995,6 +2123,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
+ "defmt",
  "hash32 0.3.1",
  "portable-atomic",
  "serde",
@@ -2080,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "ident_case"
@@ -2350,7 +2479,7 @@ checksum = "f8dccda732e04fa3baf2e17cf835bfe2601c7c2edafd64417c627dabae3a8cda"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2464,12 +2593,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
+
+[[package]]
+name = "mutex-trait"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4bb1638d419e12f8b1c43d9e639abd0d1424285bdea2f76aa231e233c63cd3a"
 
 [[package]]
 name = "nb"
@@ -2715,7 +2850,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2986,7 +3121,7 @@ checksum = "a33fa6ec7f2047f572d49317cca19c87195de99c6e5b6ee492da701cfe02b053"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3051,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -3233,9 +3368,11 @@ version = "0.1.0"
 dependencies = [
  "cortex-m",
  "cortex-m-semihosting",
+ "defmt",
+ "defmt-rtt-target",
  "esp-println",
  "log",
- "rtt-target",
+ "rtt-target 0.5.0",
 ]
 
 [[package]]
@@ -3280,7 +3417,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "riot-rs",
- "syn 2.0.66",
+ "syn 2.0.67",
  "trybuild",
 ]
 
@@ -3308,7 +3445,7 @@ dependencies = [
  "riot-rs-debug",
  "riot-rs-threads",
  "riot-rs-utils",
- "rtt-target",
+ "rtt-target 0.4.0",
 ]
 
 [[package]]
@@ -3412,6 +3549,16 @@ name = "rtt-target"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3afa12c77ba1b9bf560e4039a9b9a08bb9cde0e9e6923955eeb917dd8d5cf303"
+dependencies = [
+ "critical-section",
+ "ufmt-write",
+]
+
+[[package]]
+name = "rtt-target"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b34c9e6832388e45f3c01f1bb60a016384a0a4ad80cdd7d34913bed25037f0"
 dependencies = [
  "critical-section",
  "ufmt-write",
@@ -3544,7 +3691,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3604,6 +3751,7 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
+ "defmt",
  "heapless 0.8.0",
  "managed",
 ]
@@ -3761,14 +3909,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"
@@ -3783,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3847,7 +3995,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3906,7 +4054,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.66",
+ "syn 2.0.67",
  "toml 0.8.14",
 ]
 
@@ -4246,6 +4394,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtensa-lx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e758f94e1a1f71758f94052a2766dcb12604998eb372b8b2e30576e3ab1ba1e6"
+dependencies = [
+ "bare-metal 1.0.0",
+ "mutex-trait",
+ "spin",
+]
+
+[[package]]
 name = "xtensa-lx-rt"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,7 +4426,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -4287,7 +4446,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ embassy-usb = { version = "0.1", default-features = false }
 esp-hal = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-06-14", default-features = false }
 esp-hal-embassy = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-06-14", default-features = false }
 esp-println = { version = "0.9.0" }
-esp-wifi = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-06-14" }
+esp-wifi = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-06-14", default-features = false }
 
 linkme = { version = "0.3.21", features = ["used_linker"] }
 
@@ -62,6 +62,7 @@ riot-rs-runqueue = { path = "src/riot-rs-runqueue" }
 riot-rs-utils = { path = "src/riot-rs-utils", default-features = false }
 
 const_panic = { version = "0.2.8", default-features = false }
+defmt = { version = "0.3.7" }
 document-features = "0.2.8"
 heapless = { version = "0.8.0", default-features = false }
 konst = { version = "0.3.8", default-features = false }

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -7,6 +7,9 @@
 
 # User Guide
 
+- [Tooling](./tooling/index.md)
+  - [defmt](./tooling/defmt.md)
+
 # Developer Guide
 
 - [Appendices](./appendices.md)

--- a/book/src/tooling/defmt.md
+++ b/book/src/tooling/defmt.md
@@ -1,0 +1,33 @@
+# defmt
+
+RIOT-rs supports [defmt] on all platforms.
+To enable it, enable the laze module `defmt`, either on the laze command line or
+in a laze file. Don't forget to set the `DEFMT_LOG` variable, it defaults to `error`.
+See the [defmt documentation] for general info on `defmt`.
+
+Example:
+
+```shell
+# DEFMT_LOG=info laze -C examples/hello-world-async --board nrf52840dk --select defmt run
+```
+
+Then within Rust code, import `riot_rs::debug::log` items, then use `defmt` log
+macros [as usual][defmt-macros]:
+
+```rust
+use riot_rs::debug::log::*;
+
+#[riot_rs::task(autostart)]
+async fn main() {
+    info!("Hello!");
+}
+```
+
+If the `defmt` laze module is not selected, all log statements become no-ops.
+
+Note: On Cortex-M devices, the order of `riot_rs::debug::println!()` output and
+      `defmt` log output is not deterministic.
+
+[defmt]: https://github.com/knurling-rs/defmt
+[defmt documentation]: https://defmt.ferrous-systems.com/
+[defmt-macros]: https://defmt.ferrous-systems.com/macros

--- a/book/src/tooling/index.md
+++ b/book/src/tooling/index.md
@@ -1,0 +1,3 @@
+# Tooling
+
+This chapter contains documentation on tooling that RIOT-rs provides or integrates.

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -276,7 +276,7 @@ contexts:
         #- -C force-frame-pointers
       CARGO_ARGS:
         - -Zbuild-std=core
-      CARGO_RUNNER: '"espflash flash --monitor"'
+      CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
 
   - name: esp32c3
     parent: esp
@@ -373,6 +373,21 @@ modules:
       global:
         FEATURES:
           - riot-rs/debug-console
+
+  - name: defmt
+    help: Enable use of defmt
+    context: riot-rs
+    env:
+      global:
+        FEATURES:
+          - riot-rs/defmt
+        RUSTFLAGS:
+          - -Clink-arg=-Tdefmt.x
+        ESPFLASH_LOG_FORMAT: '--log-format defmt'
+        CARGO_ENV:
+          # For some reason, `sccache` makes the build not realize changes to
+          # `DEFMT_LOG`. Painful as it is, hard-disable `sccache` here.
+          - RUSTC_WRAPPER=""
 
   - name: silent-panic
     context: riot-rs

--- a/src/riot-rs-debug/Cargo.toml
+++ b/src/riot-rs-debug/Cargo.toml
@@ -11,11 +11,16 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+defmt = { workspace = true, optional = true }
+
+# listed here so they can enable its features conditionally
+esp-println = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 cortex-m-semihosting = { workspace = true, optional = true }
-rtt-target = { version = "0.4.0", optional = true }
+rtt-target = { version = "0.5.0", optional = true }
+defmt-rtt-target = { git = "https://github.com/kaspar030/defmt-rtt-target", rev = "5668c92ac5a0689b165a6a07bb14e173fc47cd34" }
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-println = { workspace = true, features = ["log"] }
@@ -29,3 +34,4 @@ esp-println = { workspace = true, features = ["esp32c6"] }
 
 [features]
 debug-console = []
+defmt = ["dep:defmt", "esp-println?/defmt-espflash"]

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -43,6 +43,7 @@ cyw43-pio = { version = "0.1.0", features = ["overclock"], optional = true }
 embassy-nrf = { workspace = true, default-features = false, optional = true }
 esp-hal = { workspace = true, default-features = false, optional = true }
 esp-hal-embassy = { workspace = true, default-features = false, optional = true }
+esp-wifi = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 embassy-executor = { workspace = true, default-features = false, features = [
@@ -79,7 +80,7 @@ esp-hal = { workspace = true, features = [] }
 esp-hal-embassy = { workspace = true, default-features = false, features = [
   "time-timg0",
 ] }
-esp-wifi = { workspace = true, features = [
+esp-wifi = { workspace = true, default-features = false, features = [
   "async",
   "embassy-net",
   "wifi",
@@ -90,14 +91,18 @@ esp-hal = { workspace = true, features = ["esp32c3"] }
 esp-hal-embassy = { workspace = true, default-features = false, features = [
   "esp32c3",
 ] }
-esp-wifi = { workspace = true, features = ["esp32c3"], optional = true }
+esp-wifi = { workspace = true, default-features = false, features = [
+  "esp32c3",
+], optional = true }
 
 [target.'cfg(context = "esp32c6")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c6"] }
 esp-hal-embassy = { workspace = true, default-features = false, features = [
   "esp32c6",
 ] }
-esp-wifi = { workspace = true, features = ["esp32c6"], optional = true }
+esp-wifi = { workspace = true, default-features = false, features = [
+  "esp32c6",
+], optional = true }
 
 [features]
 time = ["dep:embassy-time", "embassy-executor/integrated-timers"]
@@ -129,3 +134,11 @@ executor-single-thread = [
 executor-interrupt = ["embassy-executor/executor-interrupt"]
 executor-thread = ["threading"]
 executor-none = []
+
+defmt = [
+  "embassy-net?/defmt",
+  "embassy-nrf?/defmt",
+  "embassy-time?/defmt",
+  "embassy-usb?/defmt",
+  "esp-wifi?/defmt",
+]

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -71,6 +71,8 @@ wifi-esp = ["riot-rs-embassy/wifi-esp"]
 ## Enables the debug console, required to use
 ## [`println!`](riot_rs_debug::println).
 debug-console = ["riot-rs-rt/debug-console"]
+## Enables logging support through `defmt`.
+defmt = ["riot-rs-debug/defmt", "riot-rs-embassy/defmt"]
 ## Enables benchmarking facilities.
 bench = ["dep:riot-rs-bench"]
 ## Prints nothing in case of panics (may help reduce binary size).


### PR DESCRIPTION
This PR adds initial defmt support.

On Cortex-M, this currently co-exists with `rtt-target` through `defmt-rtt-target`. Output is line-wise intermingled, seems like probe-rs gets data from the buffers in practically arbitrary order.

Depends on #294.

TODO:

- [x] make `rtt-target` and `defmt` coexist => use (updated) `defmt-rtt-target`
- [x] figure out why `DEFMT_LOG` changes don't propagate => `sccache` seems to be the issue
- [x] add example (in book)
- [x] wire up defmt (or log macros) for esp
- [x] add some documentation (in book)

~~This is in *very* early stages.~~

~~Currently, I'm trying to figure out if the previous `println!()` can be supported together with defmt, as defmt-rtt conflicts with rtt-target.~~