### PR TITLE
refactor(rng): move hwrng to the nrf arch module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,6 +2444,7 @@ dependencies = [
 name = "riot-rs-embassy"
 version = "0.1.0"
 dependencies = [
+ "cfg-if",
  "critical-section",
  "cyw43",
  "cyw43-pio",

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 critical-section.workspace = true
 linkme.workspace = true
 static_cell.workspace = true
+cfg-if.workspace = true
 
 embassy-executor = { workspace = true, features = ["nightly"] }
 

--- a/src/riot-rs-embassy/src/arch/dummy.rs
+++ b/src/riot-rs-embassy/src/arch/dummy.rs
@@ -195,3 +195,12 @@ pub mod usb {
         }
     }
 }
+
+#[cfg(feature = "hwrng")]
+pub mod hwrng {
+    use super::OptionalPeripherals;
+
+    pub fn construct_rng(_peripherals: &mut OptionalPeripherals) {
+        unimplemented!();
+    }
+}

--- a/src/riot-rs-embassy/src/arch/nrf52.rs
+++ b/src/riot-rs-embassy/src/arch/nrf52.rs
@@ -59,9 +59,32 @@ pub mod usb {
 
 #[cfg(feature = "hwrng")]
 pub mod hwrng {
-    embassy_nrf::bind_interrupts!(pub struct Irqs {
+    use crate::arch;
+
+    embassy_nrf::bind_interrupts!(struct Irqs {
         RNG => embassy_nrf::rng::InterruptHandler<embassy_nrf::peripherals::RNG>;
     });
+
+    pub fn construct_rng(peripherals: &mut arch::OptionalPeripherals) {
+        cfg_if::cfg_if! {
+            // The union of all contexts that wind up in a construct_rng should be synchronized
+            // with laze-project.yml's hwrng module.
+            if #[cfg(any(context = "nrf51", context = "nrf52"))] {
+                let rng = embassy_nrf::rng::Rng::new(
+                    peripherals
+                        .RNG
+                        // We don't even have to take it out, just use it to seed the RNG
+                        .as_mut()
+                        .expect("RNG has not been previously used"),
+                    arch::hwrng::Irqs,
+                );
+
+                riot_rs_random::construct_rng(rng);
+            } else if #[cfg(context = "riot-rs")] {
+                compile_error!("hardware RNG is not supported on this architecture");
+            }
+        }
+    }
 }
 
 pub fn init(config: Config) -> OptionalPeripherals {

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -95,20 +95,7 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
     println!("riot-rs-embassy::init_task()");
 
     #[cfg(feature = "hwrng")]
-    {
-        // The union of all contexts that wind up in a construct_rng should be synchronized with
-        // laze-project.yml's hwrng module.
-        #[cfg(any(context = "nrf51", context = "nrf52"))]
-        let rng = embassy_nrf::rng::Rng::new(
-            peripherals
-                .RNG
-                // We don't even have to take it out, just use it to seed the RNG
-                .as_mut()
-                .expect("RNG has not been previously used"),
-            arch::hwrng::Irqs,
-        );
-        riot_rs_random::construct_rng(rng);
-    }
+    arch::hwrng::construct_rng(&mut peripherals);
     // Clock startup and entropy collection may lend themselves to parallelization, provided that
     // doesn't impact runtime RAM or flash use.
 


### PR DESCRIPTION
This allows to enable doc generation for the `hwrng` Cargo feature, to fix broken links in the docs.

depends on #258