### PR TITLE
refactor(random): rewrite a static assert checking for an impl

### DIFF
--- a/src/riot-rs-random/src/lib.rs
+++ b/src/riot-rs-random/src/lib.rs
@@ -125,10 +125,8 @@ mod csprng {
     impl rand_core::CryptoRng for super::CryptoRng {}
 
     /// Asserts that SelectedRng is CryptoRng, justifying the implementation above.
-    fn static_assert_is_cryptorng() -> impl rand_core::CryptoRng {
-        let result: super::SelectedRng = unreachable!("This function is for type checking only");
-        result
-    }
+    trait _AssertCryptoRng: rand_core::CryptoRng {}
+    impl _AssertCryptoRng for SelectedRng {}
 }
 
 /// Populates the global RNG from a seed value.


### PR DESCRIPTION
This verifies that `SelectedRng` is indeed a CSRNG using a shorter, arguably easier to read construct. It is also easier to make clippy happy about it.