### PR TITLE
riot-rs-threads: always set `threads.current_thread` in `sched()`

### DIFF
--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -259,6 +259,7 @@ unsafe fn sched(old_sp: usize) -> usize {
         threads.current_thread = Some(next_pid);
         current_high_regs = threads.threads[current_pid as usize].data.as_ptr();
     } else {
+        threads.current_thread = Some(next_pid);
         current_high_regs = core::ptr::null();
     }
 

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -187,7 +187,6 @@ pub unsafe fn start_threading() {
     let cs = unsafe { CriticalSection::new() };
     let next_sp = THREADS.with_mut_cs(cs, |mut threads| {
         let next_pid = threads.runqueue.get_next().unwrap();
-        threads.current_thread = Some(next_pid);
         threads.threads[next_pid as usize].sp
     });
     Cpu::start_threading(next_sp);


### PR DESCRIPTION
This is taken from #182: 

```
Setting threads.current_id to the very first running thread is now done within sched when the thread actually starts running. Before, this was done already in start_threading, but it caused some problems in the RISC-V implementation because then we couldn't differentiate between the thread running for the first time and current_id == next_id. I've tested on both arch'es and it still works with this change, so I think it should be alright?
```

This changes makes the number of cycles needed for one context switch go up from 254 to 259 (according to tests/benchmarks/bench_sched_yield on nrf52840dk). With the added line in `sched()` *after* the loop (instead of putting it in both cases), it'd go up to 261 cycles.

Fixes #148.