### PR TITLE
riot-rs-threads: cortex-m: make `sched()` deal with no previous thread

### DIFF
--- a/src/riot-rs-threads/src/arch/mod.rs
+++ b/src/riot-rs-threads/src/arch/mod.rs
@@ -19,7 +19,7 @@ pub trait Arch {
     fn schedule();
 
     /// Setup and initiate the first context switch.
-    fn start_threading(next_sp: usize);
+    fn start_threading();
 }
 
 cfg_if::cfg_if! {
@@ -36,7 +36,7 @@ cfg_if::cfg_if! {
             fn setup_stack(_: &mut [u8], _: usize, _: usize) -> usize {
                 unimplemented!()
             }
-            fn start_threading(_: usize) {
+            fn start_threading() {
                 unimplemented!()
             }
             fn schedule() {

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -6,8 +6,6 @@
 // invariants
 #![allow(clippy::indexing_slicing)]
 
-use critical_section::CriticalSection;
-
 use riot_rs_runqueue::RunQueue;
 pub use riot_rs_runqueue::{RunqueueId, ThreadId};
 
@@ -176,20 +174,13 @@ impl Threads {
 ///
 /// # Safety
 ///
-/// This may only be called once.
+/// This function is crafted to be called at a specific point in the RIOT-rs
+/// initialization, by `riot-rs-rt`. Don't call this unless you know you need to.
 ///
-/// # Panics
-///
-/// Panics if no thread exists.
+/// Currently it expects at least:
+/// - Cortex-M: to be called from the reset handler while MSP is active
 pub unsafe fn start_threading() {
-    // faking a critical section to get THREADS
-    // SAFETY: caller ensures invariants
-    let cs = unsafe { CriticalSection::new() };
-    let next_sp = THREADS.with_mut_cs(cs, |mut threads| {
-        let next_pid = threads.runqueue.get_next().unwrap();
-        threads.threads[next_pid as usize].sp
-    });
-    Cpu::start_threading(next_sp);
+    Cpu::start_threading();
 }
 
 /// Trait for types that fit into a single register.


### PR DESCRIPTION
This PR moves reading of PSP into `sched()`, and drops the need for the SVCall dance for `start_threading()`.
PendSV / sched now just handle the no-thread case properly.

This change seems a bit more intrusive ... It does, for some reason, reduce cycle count for `bench_sched_yield` (on nrf52840dk) from 259 to 229 (and from 90 to 75 in if there's only one thread).

Fixes #148. (next try. :) )