### PR TITLE
feat(laze): expose `builder` as cfg context

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -12,6 +12,7 @@ contexts:
         - "-Clink-arg=--nmagic"
         - "-Clink-arg=${LINK_ARG_PREFIX}--no-eh-frame-hdr"
         - --cfg builder=\"${builder}\"
+        - --cfg context=\"${builder}\"
         - --cfg context=\"riot-rs\"
       FEATURES:
         - riot-rs-boards/${BOARD}


### PR DESCRIPTION
As builders are contexts, it makes sense to expose them as such as well.

We'll need this for the board setup file, so we don't have to treat the builder (i.e., the board name) separately.