### PR TITLE
feat(arch): re-export Embassy gpio modules

### DIFF
--- a/src/riot-rs-embassy/src/arch/dummy/gpio.rs
+++ b/src/riot-rs-embassy/src/arch/dummy/gpio.rs
@@ -1,0 +1,1 @@
+//! See your architecture's Embassy crate documentation.

--- a/src/riot-rs-embassy/src/arch/dummy/mod.rs
+++ b/src/riot-rs-embassy/src/arch/dummy/mod.rs
@@ -1,6 +1,7 @@
 //! Dummy module used to satisfy platform-independent tooling.
 
 mod executor;
+pub mod gpio;
 
 #[cfg(feature = "hwrng")]
 pub mod hwrng;

--- a/src/riot-rs-embassy/src/arch/esp/gpio.rs
+++ b/src/riot-rs-embassy/src/arch/esp/gpio.rs
@@ -1,0 +1,1 @@
+pub use esp_hal::gpio::*;

--- a/src/riot-rs-embassy/src/arch/esp/mod.rs
+++ b/src/riot-rs-embassy/src/arch/esp/mod.rs
@@ -1,3 +1,5 @@
+pub mod gpio;
+
 use esp_hal::{clock::ClockControl, embassy, prelude::*, timer::TimerGroup};
 
 pub use esp_hal::{

--- a/src/riot-rs-embassy/src/arch/nrf/gpio.rs
+++ b/src/riot-rs-embassy/src/arch/nrf/gpio.rs
@@ -1,0 +1,1 @@
+pub use embassy_nrf::gpio::*;

--- a/src/riot-rs-embassy/src/arch/nrf/mod.rs
+++ b/src/riot-rs-embassy/src/arch/nrf/mod.rs
@@ -1,3 +1,5 @@
+pub mod gpio;
+
 #[cfg(feature = "hwrng")]
 pub mod hwrng;
 

--- a/src/riot-rs-embassy/src/arch/rp2040/gpio.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040/gpio.rs
@@ -1,0 +1,1 @@
+pub use embassy_rp::gpio::*;

--- a/src/riot-rs-embassy/src/arch/rp2040/mod.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040/mod.rs
@@ -1,3 +1,5 @@
+pub mod gpio;
+
 #[cfg(feature = "usb")]
 pub mod usb;
 

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -14,7 +14,7 @@ cfg_if::cfg_if! {
         #[path = "arch/rp2040/mod.rs"]
         pub mod arch;
     } else if #[cfg(context = "esp")] {
-        #[path = "arch/esp.rs"]
+        #[path = "arch/esp/mod.rs"]
         pub mod arch;
     } else if #[cfg(context = "riot-rs")] {
         compile_error!("this architecture is not supported");


### PR DESCRIPTION
The gpio modules need to be re-exported under `arch`, so that we can access the relevant one when codegening sensor initialization.