### PR TITLE
examples/usb-keyboard: Add nrf5340dk support

### DIFF
--- a/examples/embassy-usb-keyboard/laze.yml
+++ b/examples/embassy-usb-keyboard/laze.yml
@@ -1,5 +1,7 @@
 apps:
   - name: embassy-usb-keyboard
-    context: nrf52840dk
+    context:
+      - nrf52840dk
+      - nrf5340dk
     selects:
       - ?release

--- a/examples/embassy-usb-keyboard/src/pins.rs
+++ b/examples/embassy-usb-keyboard/src/pins.rs
@@ -7,3 +7,11 @@ riot_rs::define_peripherals!(Buttons {
     btn3: P0_24,
     btn4: P0_25,
 });
+
+#[cfg(builder = "nrf5340dk")]
+riot_rs::define_peripherals!(Buttons {
+    btn1: P0_23,
+    btn2: P0_24,
+    btn3: P0_08,
+    btn4: P0_09,
+});


### PR DESCRIPTION
Pinout taken from the board's back side.

---

I appreciate the choice of keystrokes sent. I may submit a patch later to s/t/u/ -- after all, we're in constrained environments here.