### PR TITLE
fix(floats): disable hard floats on thumbv7m-none-eabi

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -317,7 +317,6 @@ modules:
         RUSTC_TARGET: thumbv7em-none-eabi
         CARGO_TARGET_PREFIX: CARGO_TARGET_THUMBV7EM_NONE_EABI
         RUSTFLAGS:
-          - "-Ctarget-cpu=cortex-m4"
           - --cfg armv7m
 
   - name: thumbv7m-none-eabi


### PR DESCRIPTION
`-Ctarget-cpu=cortex-m4` actually enables hard floats [1], which should not be enabled on the `thumbv7m-none-eabi` target.

[1]: https://github.com/rust-lang/rust/blob/6acb9e75ebc936df737381a9d0b7a7bccd6f0b2f/compiler/rustc_target/src/spec/targets/thumbv7em_none_eabi.rs#L9

---

Tested only on nRF52840, not sure whether we should replace this with something else.