### PR TITLE
feat: riot-rs-storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1455,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version 0.4.0",
+ "serde",
  "spin",
  "stable_deref_trait",
 ]
@@ -2203,6 +2210,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "heapless 0.7.17",
+ "postcard-derive",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4b01218787dd4420daf63875163a787a78294ad48a24e9f6fa8c6507759a79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,6 +2415,7 @@ dependencies = [
  "riot-rs-macros",
  "riot-rs-random",
  "riot-rs-rt",
+ "riot-rs-storage",
  "riot-rs-threads",
  "static_cell",
 ]
@@ -2514,6 +2545,19 @@ dependencies = [
 [[package]]
 name = "riot-rs-runqueue"
 version = "0.1.2"
+
+[[package]]
+name = "riot-rs-storage"
+version = "0.1.0"
+dependencies = [
+ "arrayvec",
+ "embassy-embedded-hal",
+ "embedded-storage-async",
+ "postcard",
+ "riot-rs-debug",
+ "sequential-storage",
+ "serde",
+]
 
 [[package]]
 name = "riot-rs-threads"
@@ -2683,19 +2727,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "sequential-storage"
+version = "2.0.0"
+source = "git+https://github.com/tweedegolf/sequential-storage#5f4fa19b8d366565aaadc1a8308d8901cbbf837e"
+dependencies = [
+ "arrayvec",
+ "embedded-storage-async",
+]
+
+[[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2826,6 +2879,20 @@ dependencies = [
  "rtcc",
  "stm32f4",
  "void",
+]
+
+[[package]]
+name = "storage"
+version = "0.1.0"
+dependencies = [
+ "arrayvec",
+ "embassy-embedded-hal",
+ "embassy-executor",
+ "embassy-nrf",
+ "heapless 0.8.0",
+ "riot-rs",
+ "riot-rs-boards",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ cortex-m-semihosting = { version = "0.5" }
 critical-section = { version = "1.1.2" }
 
 embassy-executor = { version = "0.5", default-features = false }
+embassy-embedded-hal = { version = "0.1.0", default-features = false }
 embassy-net = { version = "0.4", default-features = false }
 embassy-net-driver-channel = { version = "0.2.0", default-features = false }
 embassy-nrf = { version = "0.1", default-features = false }

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -14,4 +14,5 @@ subdirs:
   - hello-world
   - minimal
   - random
+  - storage
   - threading

--- a/examples/storage/Cargo.toml
+++ b/examples/storage/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "storage"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+riot-rs = { path = "../../src/riot-rs", features = ["storage"] }
+riot-rs-boards = { path = "../../src/riot-rs-boards" }
+embassy-executor = { workspace = true, default-features = false }
+embassy-embedded-hal = { workspace = true }
+embassy-nrf = { workspace = true }
+arrayvec = { version = "0.7.4", default-features = false }
+heapless = { workspace = true, features = ["serde"] }
+serde = { version = "1.0.199", default-features = false }

--- a/examples/storage/README.md
+++ b/examples/storage/README.md
@@ -1,0 +1,13 @@
+# storage
+
+## About
+
+This application demonstrates use of the riot-rs-storage API.
+
+## How to run
+
+In this folder, run
+
+    laze build -b nrf52840dk run
+
+The application will store and read back a value to the flash.

--- a/examples/storage/laze.yml
+++ b/examples/storage/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: storage
+    selects:
+      - ?release

--- a/examples/storage/src/main.rs
+++ b/examples/storage/src/main.rs
@@ -1,0 +1,51 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::debug::println;
+
+//#[cfg(builder = "nrf5340dk")]
+use riot_rs::arch::peripherals;
+
+#[cfg(builder = "nrf52840dk")]
+riot_rs::define_peripherals!(MyPeripherals { nvmc: NVMC });
+
+use riot_rs::storage::Storage;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct MyConfig {
+    val_uno: heapless::String<64>,
+    val_dos: u64,
+}
+
+#[riot_rs::task(autostart, peripherals)]
+async fn main(p: MyPeripherals) {
+    println!("Hello from storage test!");
+
+    let flash = embassy_nrf::nvmc::Nvmc::new(p.nvmc);
+    let flash = embassy_embedded_hal::adapter::BlockingAsync::new(flash);
+    let mut storage = Storage::new(flash).await;
+
+    let value: Option<u32> = storage.get("counter").await.unwrap();
+    let value = if let Some(value) = value {
+        println!("got value {}", value);
+        value
+    } else {
+        0
+    };
+
+    let cfg = MyConfig {
+        val_uno: heapless::String::<64>::try_from("mybarrocks").unwrap(),
+        val_dos: 99,
+    };
+    storage.put("counter", value + 1).await.unwrap();
+    storage.put("my_config", cfg).await.unwrap();
+
+    let cfg: Option<MyConfig> = storage.get("my_config").await.unwrap();
+    if let Some(value) = cfg {
+        println!("got value {:?}", value);
+    }
+}

--- a/src/riot-rs-storage/.gitignore
+++ b/src/riot-rs-storage/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/src/riot-rs-storage/Cargo.toml
+++ b/src/riot-rs-storage/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "riot-rs-storage"
+version = "0.1.0"
+authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
+edition = "2021"
+description = "RIOT-rs storage API"
+license = "Apache-2.0 / MIT"
+
+[lints]
+workspace = true
+
+[dependencies]
+riot-rs-debug = { workspace = true }
+arrayvec = { version = "0.7.4", default-features = false }
+embassy-embedded-hal = { workspace = true }
+embedded-storage-async = "0.4.1"
+sequential-storage = { version = "2.0.0", git = "https://github.com/tweedegolf/sequential-storage", features = [
+  "arrayvec",
+], rev = "5f4fa19b8d366565aaadc1a8308d8901cbbf837e" }
+serde = { version = "1.0.197", default-features = false }
+postcard = { version = "1.0.8", features = ["postcard-derive"] }

--- a/src/riot-rs-storage/README.md
+++ b/src/riot-rs-storage/README.md
@@ -1,0 +1,4 @@
+# riot-rs-storage
+
+This crate provides a storage API for RIOT-rs.
+It is currently an opinionated wrapper over [sequential-storage][https://github.com/tweedegolf/sequential-storage].

--- a/src/riot-rs-storage/src/lib.rs
+++ b/src/riot-rs-storage/src/lib.rs
@@ -1,0 +1,140 @@
+#![cfg_attr(not(test), no_std)]
+
+use core::ops::Range;
+
+use arrayvec::ArrayString;
+use embedded_storage_async::nor_flash::ErrorType;
+use embedded_storage_async::nor_flash::NorFlash;
+use serde::{Deserialize, Serialize};
+
+use sequential_storage::{
+    cache::NoCache,
+    map::{fetch_item, store_item, SerializationError, Value},
+};
+
+pub const MAX_KEY_LEN: usize = 64usize;
+pub const DATA_BUFFER_SIZE: usize = 128usize;
+
+pub struct Storage<F> {
+    flash: F,
+    storage_range: Range<u32>,
+}
+
+pub struct StringValue {
+    pub inner: ArrayString<MAX_KEY_LEN>,
+}
+
+impl StringValue {
+    pub fn from(string: &str) -> Self {
+        Self {
+            inner: ArrayString::<MAX_KEY_LEN>::from(string).unwrap(),
+        }
+    }
+}
+
+impl<'d> Value<'d> for StringValue {
+    fn serialize_into(
+        &self,
+        buffer: &mut [u8],
+    ) -> Result<usize, sequential_storage::map::SerializationError> {
+        buffer[0..self.inner.len()].copy_from_slice(self.inner.as_bytes());
+        Ok(self.inner.len())
+    }
+    fn deserialize_from(
+        buffer: &'d [u8],
+    ) -> Result<Self, sequential_storage::map::SerializationError> {
+        let mut output = ArrayString::<MAX_KEY_LEN>::new();
+        output
+            .try_push_str(
+                core::str::from_utf8(buffer).map_err(|_| SerializationError::InvalidFormat)?,
+            )
+            .map_err(|_| SerializationError::InvalidFormat)?;
+
+        Ok(Self { inner: output })
+    }
+}
+
+mod postcard_value;
+
+pub use postcard_value::PostcardValue;
+
+impl<F: NorFlash> Storage<F> {
+    pub async fn new(flash: F) -> Storage<F> {
+        const NUM_SECTORS: u32 = 2u32;
+
+        let storage_range = (flash.capacity() - NUM_SECTORS as usize * F::ERASE_SIZE) as u32
+            ..flash.capacity() as u32;
+
+        Self {
+            flash,
+            storage_range,
+        }
+    }
+
+    pub async fn get_raw<V: for<'d> Value<'d>>(
+        &mut self,
+        key: &str,
+    ) -> Result<Option<V>, sequential_storage::Error<<F as ErrorType>::Error>> {
+        let key = ArrayString::<MAX_KEY_LEN>::from(key).unwrap();
+        let mut data_buffer = [0; DATA_BUFFER_SIZE];
+
+        fetch_item::<_, V, _>(
+            &mut self.flash,
+            self.storage_range.clone(),
+            &mut NoCache::new(),
+            &mut data_buffer,
+            key,
+        )
+        .await
+    }
+
+    pub async fn put_raw<'d, V: Value<'d>>(
+        &mut self,
+        key: &str,
+        value: V,
+    ) -> Result<(), sequential_storage::Error<<F as ErrorType>::Error>> {
+        let key = ArrayString::<MAX_KEY_LEN>::from(key).unwrap();
+        let mut data_buffer = [0; DATA_BUFFER_SIZE];
+        store_item(
+            &mut self.flash,
+            self.storage_range.clone(),
+            &mut NoCache::new(),
+            &mut data_buffer,
+            key,
+            &value,
+        )
+        .await
+    }
+
+    pub async fn put<'d, V>(
+        &mut self,
+        key: &str,
+        value: V,
+    ) -> Result<(), sequential_storage::Error<<F as ErrorType>::Error>>
+    where
+        V: Serialize + Deserialize<'d> + Into<PostcardValue<V>>,
+    {
+        self.put_raw(key, value.into()).await
+    }
+
+    pub async fn get<V>(
+        &mut self,
+        key: &str,
+    ) -> Result<Option<V>, sequential_storage::Error<<F as ErrorType>::Error>>
+    where
+        V: Serialize + for<'d> Deserialize<'d> + Into<PostcardValue<V>>,
+    {
+        let key = ArrayString::<MAX_KEY_LEN>::from(key).unwrap();
+        let mut data_buffer = [0; DATA_BUFFER_SIZE];
+
+        let postcard_value = fetch_item::<_, PostcardValue<V>, _>(
+            &mut self.flash,
+            self.storage_range.clone(),
+            &mut NoCache::new(),
+            &mut data_buffer,
+            key,
+        )
+        .await?;
+        Ok(postcard_value.map(|v| v.into_inner()))
+    }
+}

--- a/src/riot-rs-storage/src/postcard_value.rs
+++ b/src/riot-rs-storage/src/postcard_value.rs
@@ -1,0 +1,54 @@
+use core::ops::Deref;
+
+use postcard::{from_bytes, to_slice};
+use serde::{Deserialize, Serialize};
+
+use sequential_storage::map::{SerializationError, Value};
+
+#[derive(Debug)]
+pub struct PostcardValue<T> {
+    value: T,
+}
+
+impl<'d, T: Serialize + Deserialize<'d>> PostcardValue<T> {
+    pub const fn from(value: T) -> Self {
+        Self { value }
+    }
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+}
+
+impl<'d, T: Serialize + Deserialize<'d>> From<T> for PostcardValue<T> {
+    fn from(other: T) -> PostcardValue<T> {
+        PostcardValue::from(other)
+    }
+}
+
+impl<T> Deref for PostcardValue<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<'d, T: Serialize + Deserialize<'d>> Value<'d> for PostcardValue<T> {
+    fn serialize_into(&self, buffer: &mut [u8]) -> Result<usize, SerializationError> {
+        let used = to_slice(&self.value, buffer).map_err(|e| match e {
+            postcard::Error::SerializeBufferFull => SerializationError::BufferTooSmall,
+            _ => SerializationError::Custom(0),
+        })?;
+
+        Ok(used.len())
+    }
+
+    fn deserialize_from(buffer: &'d [u8]) -> Result<Self, SerializationError> {
+        let value = from_bytes(buffer).map_err(|e| match e {
+            postcard::Error::DeserializeUnexpectedEnd => SerializationError::InvalidData,
+            _ => SerializationError::Custom(0),
+        })?;
+
+        Ok(Self { value })
+    }
+}

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -18,6 +18,7 @@ riot-rs-embassy = { path = "../riot-rs-embassy" }
 riot-rs-macros = { path = "../riot-rs-macros" }
 riot-rs-random = { path = "../riot-rs-random", optional = true }
 riot-rs-rt = { path = "../riot-rs-rt" }
+riot-rs-storage = { path = "../riot-rs-storage", optional = true }
 riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 static_cell = { workspace = true }
 
@@ -36,6 +37,10 @@ riot-rs-rt = { path = "../riot-rs-rt", features = ["executor-single-thread"] }
 default = ["riot-rs-rt/_panic-handler"]
 
 #! ## System functionality
+## Enables storage support.
+storage = [
+  "dep:riot-rs-storage",
+]
 ## Enables threading support, see the [`macro@thread`] attribute macro.
 threading = [
   "dep:riot-rs-threads",

--- a/src/riot-rs/src/lib.rs
+++ b/src/riot-rs/src/lib.rs
@@ -16,12 +16,15 @@ pub use riot_rs_buildinfo as buildinfo;
 pub use riot_rs_debug as debug;
 #[doc(inline)]
 pub use riot_rs_embassy as embassy;
-pub use riot_rs_embassy::{define_peripherals, group_peripherals};
+pub use riot_rs_embassy::{arch, define_peripherals, group_peripherals};
 #[cfg(feature = "random")]
 #[doc(inline)]
 pub use riot_rs_random as random;
 #[doc(inline)]
 pub use riot_rs_rt as rt;
+#[cfg(feature = "storage")]
+#[doc(inline)]
+pub use riot_rs_storage as storage;
 #[cfg(feature = "threading")]
 #[doc(inline)]
 pub use riot_rs_threads as thread;


### PR DESCRIPTION
This PR adds a simple (to use) storage module based on [sequential-storage](https://github.com/tweedegolf/sequential-storage) and postcard/serde.

It's WIP.

Todos:

- [ ] iron out API
- [ ] where to allocate storage from?
- [ ] docs & tests
- [ ] ...