### PR TITLE
stdio/rtt: Don't silently drop println statements

### DIFF
--- a/src/riot-rs-debug/src/lib.rs
+++ b/src/riot-rs-debug/src/lib.rs
@@ -30,7 +30,7 @@ mod backend {
     pub use rtt_target::rprint as print;
     pub use rtt_target::rprintln as println;
     pub fn init() {
-        rtt_target::rtt_init_print!();
+        rtt_target::rtt_init_print!(NoBlockTrim);
     }
 }
 


### PR DESCRIPTION
This still silently truncates prints, but during printf debugging, those are still understood more easily than skipped lines.

---

We're probably migrating to something more defmt anyway, but this fixes a repeated issue I've been running into when I thought my code is in weird branches just because the printf("Stage 1 {:?}", ...) silently didn't do anything at all.

(At some point we'll probably have similar high-level stdio discussions as in riot-c regarding whether to block and what to do in ISRs, but this is just a small step here and shouldn't touch the controversial topics).