### PR TITLE
riot-rs-embassy: improve `SWI` selection

### DIFF
--- a/src/riot-rs-embassy/build.rs
+++ b/src/riot-rs-embassy/build.rs
@@ -1,0 +1,27 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+
+    // handle CONFIG_SWI
+    {
+        let dest_path = Path::new(&out_dir).join("swi.rs");
+        if let Ok(var) = env::var("CONFIG_SWI") {
+            fs::write(
+                &dest_path,
+                format!("crate::executor_swi!({});\n", var).as_bytes(),
+            )
+            .expect("write failed");
+        } else {
+            fs::write(
+                &dest_path,
+                b"compile_error!(\"swi.rs included but CONFIG_SWI not set!\");\n",
+            )
+            .expect("write failed");
+        }
+
+        println!("cargo::rerun-if-env-changed=CONFIG_SWI");
+    }
+}

--- a/src/riot-rs-embassy/src/arch/nrf/mod.rs
+++ b/src/riot-rs-embassy/src/arch/nrf/mod.rs
@@ -9,28 +9,12 @@ pub mod usb;
 pub(crate) use embassy_executor::InterruptExecutor as Executor;
 
 #[cfg(context = "nrf52")]
-pub use embassy_nrf::interrupt::SWI0_EGU0 as SWI;
+crate::executor_swi!(SWI0_EGU0);
 
 #[cfg(context = "nrf5340")]
-pub use embassy_nrf::interrupt::EGU0 as SWI;
+crate::executor_swi!(EGU0);
 
 pub use embassy_nrf::{config::Config, interrupt, peripherals, OptionalPeripherals};
-
-#[cfg(context = "nrf52")]
-#[interrupt]
-unsafe fn SWI0_EGU0() {
-    // SAFETY:
-    // - called from ISR
-    // - not called before `start()`, as the interrupt is enabled by `start()`
-    //   itself
-    unsafe { crate::EXECUTOR.on_interrupt() }
-}
-
-#[cfg(context = "nrf5340")]
-#[interrupt]
-unsafe fn EGU0() {
-    unsafe { crate::EXECUTOR.on_interrupt() }
-}
 
 pub fn init(config: Config) -> OptionalPeripherals {
     let peripherals = embassy_nrf::init(config);

--- a/src/riot-rs-embassy/src/arch/rp2040/mod.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040/mod.rs
@@ -5,17 +5,9 @@ pub mod usb;
 
 pub(crate) use embassy_executor::InterruptExecutor as Executor;
 pub use embassy_rp::interrupt;
-pub use embassy_rp::interrupt::SWI_IRQ_1 as SWI;
 pub use embassy_rp::{config::Config, peripherals, OptionalPeripherals};
 
-#[interrupt]
-unsafe fn SWI_IRQ_1() {
-    // SAFETY:
-    // - called from ISR
-    // - not called before `start()`, as the interrupt is enabled by `start()`
-    //   itself
-    unsafe { crate::EXECUTOR.on_interrupt() }
-}
+crate::executor_swi!(SWI_IRQ_1);
 
 pub fn init(config: Config) -> OptionalPeripherals {
     // SWI & DMA priority need to match. DMA is hard-coded to P3 by upstream.

--- a/src/riot-rs-embassy/src/executor_swi.rs
+++ b/src/riot-rs-embassy/src/executor_swi.rs
@@ -1,0 +1,42 @@
+//! Use and create executor ISR from string name.
+//!
+//! This module provides [`executor_swi`], a macro that generates the interrupt
+//! that polls the executor.
+//!
+
+/// Create swi interrupt routine and import from string interrupt name.
+///
+/// The macro turns this:
+///
+/// ```Rust
+/// executor_swi!(SWI_IRQ_1);
+/// ```
+///
+/// into this:
+///
+/// ```Rust
+/// pub use interrupt::SWI_IRQ_1 as SWI;
+/// #[interrupt]
+/// unsafe fn SWI_IRQ_1() {
+///     unsafe { crate::EXECUTOR.on_interrupt() }
+/// }
+/// ```
+///
+/// Note: this expects the `interrupt` to be present (e.g., "used") and that it contains the ISR
+/// type.
+#[macro_export]
+macro_rules! executor_swi {
+    ($swi:ident) => {
+        pub use interrupt::$swi as SWI;
+        #[interrupt]
+        unsafe fn $swi() {
+            // SAFETY:
+            // - As required, it is called from an ISR
+            // - The interrupt is enabled by start(), thus this is not called before start.
+            //   (This macro just adds "only enable it after starting the executor" to the
+            //   requirements of the unsafe interrupt starting; the safe start() function
+            //    trusts the user to pass the right number.)
+            unsafe { crate::EXECUTOR.on_interrupt() }
+        }
+    };
+}

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -6,6 +6,9 @@
 
 pub mod define_peripherals;
 
+#[cfg(context = "cortex-m")]
+pub mod executor_swi;
+
 cfg_if::cfg_if! {
     if #[cfg(context = "nrf")] {
         #[path = "arch/nrf/mod.rs"]


### PR DESCRIPTION
This PR tries to make the incoming wave of different SWI choices more managable.

- add `executor_swi!(NAME)`-macro (reduces code duplication, see e.g., `arch/nrf/mod.rs`)

- adds logic to `build.rs` that, if set, generates a `swi.rs` that basically just contains `executor_swi!(NAME)` with `NAME` taken from the env variable `CONFIG_SWI`. This will be used in #237.
