### PR TITLE
laze: change defaults around `run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ example](https://github.com/future-proof-iot/RIOT-rs/tree/main/examples/hello-wo
 
 1. Compile, flash and the hello-world example using `probe-rs run`
 
-        laze -C examples/hello-world build -b nrf52840dk -s probe-rs-run run
+        laze -C examples/hello-world build -b nrf52840dk run
 
 ![Example](./doc/hello-world_render.svg)
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -261,6 +261,8 @@ contexts:
 
   - name: esp
     parent: riot-rs
+    selects:
+      - ?debug-console
     env:
       RUSTFLAGS:
         - --cfg context=\"esp\"

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -157,6 +157,8 @@ contexts:
   - name: nrf
     help: Nordic MCU support (based on embassy-nrf)
     parent: riot-rs
+    selects:
+      - ?probe-rs
     env:
       RUSTFLAGS:
         - --cfg context=\"nrf\"
@@ -202,7 +204,6 @@ contexts:
     parent: nrf
     selects:
       - thumbv8m.main-none-eabi # actually eabihf, but riot-rs doesn't support hard float yet
-      - probe-rs-run
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
       RUSTFLAGS:
@@ -243,6 +244,8 @@ contexts:
 
   - name: rp2040
     parent: rp
+    selects:
+      - ?probe-rs
     env:
       RUSTFLAGS:
         - --cfg context=\"rp2040\"
@@ -358,7 +361,6 @@ modules:
 
   - name: release
     selects:
-      - ?silent-panic
       - ?lto
 
   - name: debug-console
@@ -458,12 +460,18 @@ modules:
           - NRF52840_FLASH_SLOT_OFFSET=${FLASH_SLOT_OFFSET}
           - NRF52840_FLASH_SLOT=0
 
-  - name: probe-rs-run
+  - name: probe-rs
+    help: use probe-rs as runner
     selects:
       - ?debug-console
     env:
       global:
         CARGO_RUNNER: "'probe-rs run --chip ${PROBE_RS_CHIP}'"
+
+  - name: probe-rs-run
+    help: "deprecated alias for `probe-rs`"
+    selects:
+      - probe-rs
 
   - name: network
     selects:

--- a/tests/benchmarks/bench_sched_yield/README.md
+++ b/tests/benchmarks/bench_sched_yield/README.md
@@ -8,4 +8,4 @@ This benchmark tests basic context switch performance.
 
 In this folder, run
 
-    laze build -b nrf52840dk -s probe-rs-run run
+    laze build -b nrf52840dk run


### PR DESCRIPTION
This PR intents to unify `laze run` across our devices.

it:

- removes the `silent-panic` dep from `release` (so panics are now shown by default)
- makes nrf & rp select `?probe-rs-run` (making it the default)
- renames `probe-rs-run` to just `probe-rs`, keeping an alias to `probe-rs-run`
- updates the docs to drop `-s probe-rs-run`
- *edit* also default to using the debug-console on esp32

*edit* I expect this to get another overhaul when [laze supports tasks defined by modules](https://github.com/kaspar030/laze/issues/420).

Fixes #200.
