### PR TITLE
riot-rs-embassy: move `Config` handling into arch modules

### DIFF
--- a/src/riot-rs-embassy/src/arch/dummy/mod.rs
+++ b/src/riot-rs-embassy/src/arch/dummy/mod.rs
@@ -25,10 +25,7 @@ impl From<Peripherals> for OptionalPeripherals {
     }
 }
 
-#[derive(Default)]
-pub struct Config;
-
-pub fn init(_config: Config) -> OptionalPeripherals {
+pub fn init() -> OptionalPeripherals {
     unimplemented!();
 }
 

--- a/src/riot-rs-embassy/src/arch/esp/mod.rs
+++ b/src/riot-rs-embassy/src/arch/esp/mod.rs
@@ -7,10 +7,7 @@ pub use esp_hal::{
     peripherals::{OptionalPeripherals, Peripherals},
 };
 
-#[derive(Default)]
-pub struct Config {}
-
-pub fn init(_config: Config) -> OptionalPeripherals {
+pub fn init() -> OptionalPeripherals {
     let mut peripherals = OptionalPeripherals::from(Peripherals::take());
     let system = peripherals.SYSTEM.take().unwrap().split();
     let clocks = ClockControl::max(system.clock_control).freeze();

--- a/src/riot-rs-embassy/src/arch/nrf/mod.rs
+++ b/src/riot-rs-embassy/src/arch/nrf/mod.rs
@@ -14,9 +14,11 @@ crate::executor_swi!(SWI0_EGU0);
 #[cfg(context = "nrf5340")]
 crate::executor_swi!(EGU0);
 
-pub use embassy_nrf::{config::Config, interrupt, peripherals, OptionalPeripherals};
+use embassy_nrf::config::Config;
 
-pub fn init(config: Config) -> OptionalPeripherals {
-    let peripherals = embassy_nrf::init(config);
+pub use embassy_nrf::{interrupt, peripherals, OptionalPeripherals};
+
+pub fn init() -> OptionalPeripherals {
+    let peripherals = embassy_nrf::init(Config::default());
     OptionalPeripherals::from(peripherals)
 }

--- a/src/riot-rs-embassy/src/arch/rp2040/mod.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040/mod.rs
@@ -3,17 +3,19 @@ pub mod gpio;
 #[cfg(feature = "usb")]
 pub mod usb;
 
+use embassy_rp::config::Config;
+
 pub(crate) use embassy_executor::InterruptExecutor as Executor;
 pub use embassy_rp::interrupt;
-pub use embassy_rp::{config::Config, peripherals, OptionalPeripherals};
+pub use embassy_rp::{peripherals, OptionalPeripherals};
 
 crate::executor_swi!(SWI_IRQ_1);
 
-pub fn init(config: Config) -> OptionalPeripherals {
+pub fn init() -> OptionalPeripherals {
     // SWI & DMA priority need to match. DMA is hard-coded to P3 by upstream.
     use embassy_rp::interrupt::{InterruptExt, Priority};
     SWI.set_priority(Priority::P3);
 
-    let peripherals = embassy_rp::init(config);
+    let peripherals = embassy_rp::init(Config::default());
     OptionalPeripherals::from(peripherals)
 }

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -78,7 +78,7 @@ pub static EXECUTOR: arch::Executor = arch::Executor::new();
 #[distributed_slice(riot_rs_rt::INIT_FUNCS)]
 pub(crate) fn init() {
     println!("riot-rs-embassy::init()");
-    let p = arch::init(Default::default());
+    let p = arch::init();
 
     #[cfg(any(context = "nrf", context = "rp2040"))]
     {
@@ -94,7 +94,7 @@ pub(crate) fn init() {
 #[export_name = "riot_rs_embassy_init"]
 fn init() -> ! {
     println!("riot-rs-embassy::init()");
-    let p = arch::init(Default::default());
+    let p = arch::init();
 
     println!("riot-rs-embassy::init() done");
 


### PR DESCRIPTION
This PR drops the `config` argument from the architecture's `init()` function, and moves it in there where needed.

The reason is that we passed `default()` anyways, esp doesn't use it at all, (dummy neither), and [stm32](#237) will actually need per-MCU Config handling.
