### PR TITLE
deps: switch to the upstream usbd-hid repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "usbd-hid-descriptors"
 version = "0.1.2"
-source = "git+https://github.com/kaspar030/usbd-hid?branch=for-riot-rs#1dfc36bf4241e1088a29ebae308868d271ad70be"
+source = "git+https://github.com/twitchyliquid64/usbd-hid?rev=76bea16537e1a347df2ebced5b9e1d48f71c9859#76bea16537e1a347df2ebced5b9e1d48f71c9859"
 dependencies = [
  "bitfield 0.14.0",
 ]
@@ -4054,7 +4054,7 @@ dependencies = [
 [[package]]
 name = "usbd-hid-macros"
 version = "0.6.0"
-source = "git+https://github.com/kaspar030/usbd-hid?branch=for-riot-rs#1dfc36bf4241e1088a29ebae308868d271ad70be"
+source = "git+https://github.com/twitchyliquid64/usbd-hid?rev=76bea16537e1a347df2ebced5b9e1d48f71c9859#76bea16537e1a347df2ebced5b9e1d48f71c9859"
 dependencies = [
  "byteorder",
  "hashbrown 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ embassy-hal-internal = { git = "https://github.com/kaspar030/embassy", branch = 
 embassy-nrf = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-300424" }
 embassy-net = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-300424" }
 
-usbd-hid-macros = { git = "https://github.com/kaspar030/usbd-hid", branch = "for-riot-rs" }
+usbd-hid-macros = { git = "https://github.com/twitchyliquid64/usbd-hid", rev = "76bea16537e1a347df2ebced5b9e1d48f71c9859" }
 
 # version 0.12-to-be
 smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "125773e282bc2e0c914a49e9c75573926e26e558" }


### PR DESCRIPTION
The upstream usbd-hid repo is now depending on byteorder 1.5.0, but has not released a release yet.