### PR TITLE
riot-rs-embassy: introduce thread mode executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "ccm"
@@ -1502,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "esp-build"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#f612c820265fe8cee2a9693ec8c2032143ca1403"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#abacafb069aac19dfc1c995f58189a3a3aeef411"
 dependencies = [
  "quote",
  "syn 2.0.66",
@@ -1512,7 +1512,7 @@ dependencies = [
 [[package]]
 name = "esp-hal"
 version = "0.18.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#f612c820265fe8cee2a9693ec8c2032143ca1403"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#abacafb069aac19dfc1c995f58189a3a3aeef411"
 dependencies = [
  "basic-toml",
  "bitfield 0.15.0",
@@ -1555,7 +1555,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-embassy"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#f612c820265fe8cee2a9693ec8c2032143ca1403"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#abacafb069aac19dfc1c995f58189a3a3aeef411"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.11.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#f612c820265fe8cee2a9693ec8c2032143ca1403"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#abacafb069aac19dfc1c995f58189a3a3aeef411"
 dependencies = [
  "darling",
  "document-features",
@@ -1587,7 +1587,7 @@ dependencies = [
 [[package]]
 name = "esp-metadata"
 version = "0.1.1"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#f612c820265fe8cee2a9693ec8c2032143ca1403"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#abacafb069aac19dfc1c995f58189a3a3aeef411"
 dependencies = [
  "basic-toml",
  "lazy_static",
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "esp-riscv-rt"
 version = "0.8.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#f612c820265fe8cee2a9693ec8c2032143ca1403"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#abacafb069aac19dfc1c995f58189a3a3aeef411"
 dependencies = [
  "document-features",
  "riscv",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "esp-wifi"
 version = "0.6.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#f612c820265fe8cee2a9693ec8c2032143ca1403"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-06-14#abacafb069aac19dfc1c995f58189a3a3aeef411"
 dependencies = [
  "atomic-waker",
  "cfg-if",
@@ -2080,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "d0e7a4dd27b9476dc40cb050d3632d3bba3a70ddbff012285f7f8559a1e7e545"
 
 [[package]]
 name = "ident_case"
@@ -2392,9 +2392,9 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -3113,9 +3113,9 @@ version = "0.1.1"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -3133,25 +3133,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -3162,9 +3162,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ringbuffer"
@@ -3261,6 +3261,7 @@ dependencies = [
  "linkme",
  "once_cell",
  "riot-rs-debug",
+ "riot-rs-macros",
  "riot-rs-random",
  "riot-rs-rt",
  "riot-rs-threads",
@@ -3939,7 +3940,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.11",
+ "winnow 0.6.13",
 ]
 
 [[package]]
@@ -4237,9 +4238,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c52728401e1dc672a56e81e593e912aa54c78f40246869f78359a2bf24d29d"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]

--- a/examples/benchmark/laze.yml
+++ b/examples/benchmark/laze.yml
@@ -3,3 +3,4 @@ apps:
     depends:
       - ?release
       - sw/benchmark
+      - sw/threading

--- a/examples/core-sizes/laze.yml
+++ b/examples/core-sizes/laze.yml
@@ -2,3 +2,4 @@ apps:
   - name: core-sizes
     selects:
       - debug-console
+      - sw/threading

--- a/examples/embassy/laze.yml
+++ b/examples/embassy/laze.yml
@@ -5,3 +5,4 @@ apps:
       - rp
     selects:
       - ?release
+      - sw/threading

--- a/examples/hello-world/laze.yml
+++ b/examples/hello-world/laze.yml
@@ -2,3 +2,4 @@ apps:
   - name: hello-world
     selects:
       - ?release
+      - sw/threading

--- a/examples/random/laze.yml
+++ b/examples/random/laze.yml
@@ -3,3 +3,4 @@ apps:
     selects:
       - ?release
       - random
+      - sw/threading

--- a/examples/threading-channel/laze.yml
+++ b/examples/threading-channel/laze.yml
@@ -2,3 +2,4 @@ apps:
   - name: threading-channel
     selects:
       - ?release
+      - sw/threading

--- a/examples/threading/laze.yml
+++ b/examples/threading/laze.yml
@@ -2,3 +2,4 @@ apps:
   - name: threading
     selects:
       - ?release
+      - sw/threading

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -481,6 +481,10 @@ modules:
     selects:
       - network_device
 
+  - name: sw/threading
+    conflicts:
+      - executor-single-thread
+
   - name: wifi-cyw43
     context:
       - rpi-pico-w

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -7,6 +7,8 @@ contexts:
   # base context for all RIOT-rs applications
   - name: riot-rs
     parent: default
+    selects:
+      - executor-default
     env:
       RUSTFLAGS:
         - "-Clink-arg=--nmagic"
@@ -557,6 +559,48 @@ modules:
         FEATURES:
           - riot-rs/wifi-esp
 
+  - name: executor-thread
+    help: use embassy executor within riot-rs-threads thread
+    provides_unique:
+      - executor
+    env:
+      global:
+        FEATURES:
+          - riot-rs/executor-thread
+
+  - name: executor-single-thread
+    help: use Embassy executor within single "thread mode" thread
+    context:
+      - esp
+    provides_unique:
+      - executor
+    env:
+      global:
+        FEATURES:
+          - riot-rs/executor-single-thread
+
+  - name: executor-interrupt
+    help: use the Embassy interrupt executor
+    context:
+      - nrf
+      - rp
+    provides_unique:
+      - executor
+    env:
+      global:
+        FEATURES:
+          - riot-rs/executor-interrupt
+
+  - name: executor-default
+    help: executor preference
+    selects:
+      # This is order dependent.
+      # Unless otherwise selected (by application, context, on cli, or by other
+      # dependencies), the interrupt executor is preferred.
+      - ?executor-interrupt
+      - ?executor-single-thread
+      - ?executor-thread
+
 builders:
   # host builder (for housekeeping tasks)
   - name: host
@@ -572,6 +616,7 @@ builders:
       install-toolchain:
         build: false
         cmd:
+          - rustup target add thumbv6m-none-eabi
           - rustup target add thumbv7m-none-eabi
           - rustup target add thumbv7em-none-eabi
           - rustup target add thumbv7em-none-eabihf

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -25,6 +25,7 @@ embassy-usb = { workspace = true, optional = true }
 
 riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 riot-rs-debug = { workspace = true }
+riot-rs-macros = { path = "../riot-rs-macros" }
 riot-rs-rt = { path = "../riot-rs-rt" }
 riot-rs-random = { path = "../riot-rs-random", optional = true }
 riot-rs-utils = { workspace = true }
@@ -38,10 +39,14 @@ once_cell = { version = "1.19.0", default-features = false, features = [
 cyw43 = { version = "0.1.0", features = ["firmware-logs"], optional = true }
 cyw43-pio = { version = "0.1.0", features = ["overclock"], optional = true }
 
+# listed here for conditional feature selection
+embassy-nrf = { workspace = true, default-features = false, optional = true }
+esp-hal = { workspace = true, default-features = false, optional = true }
+esp-hal-embassy = { workspace = true, default-features = false, optional = true }
+
 [target.'cfg(context = "cortex-m")'.dependencies]
-embassy-executor = { workspace = true, features = [
+embassy-executor = { workspace = true, default-features = false, features = [
   "arch-cortex-m",
-  "executor-interrupt",
 ] }
 
 [target.'cfg(context = "nrf")'.dependencies]
@@ -71,7 +76,9 @@ embassy-rp = { workspace = true, features = [
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-hal = { workspace = true, features = [] }
-esp-hal-embassy = { workspace = true, features = ["time-timg0"] }
+esp-hal-embassy = { workspace = true, default-features = false, features = [
+  "time-timg0",
+] }
 esp-wifi = { workspace = true, features = [
   "async",
   "embassy-net",
@@ -80,12 +87,12 @@ esp-wifi = { workspace = true, features = [
 
 [target.'cfg(context = "esp32c3")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c3"] }
-esp-hal-embassy = { workspace = true, features = ["esp32c3"] }
+esp-hal-embassy = { workspace = true, default-features = false, features = ["esp32c3"] }
 esp-wifi = { workspace = true, features = ["esp32c3"], optional = true }
 
 [target.'cfg(context = "esp32c6")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c6"] }
-esp-hal-embassy = { workspace = true, features = ["esp32c6"] }
+esp-hal-embassy = { workspace = true, default-features = false, features = ["esp32c6"] }
 esp-wifi = { workspace = true, features = ["esp32c6"], optional = true }
 
 [features]
@@ -111,5 +118,6 @@ threading = ["dep:riot-rs-threads"]
 override-network-config = []
 override-usb-config = []
 
-executor-single-thread = []
-executor-interrupt = []
+executor-single-thread = ["riot-rs-rt/executor-single-thread", "esp-hal-embassy?/executors"]
+executor-interrupt = ["embassy-executor/executor-interrupt"]
+executor-thread = ["threading"]

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -87,12 +87,16 @@ esp-wifi = { workspace = true, features = [
 
 [target.'cfg(context = "esp32c3")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c3"] }
-esp-hal-embassy = { workspace = true, default-features = false, features = ["esp32c3"] }
+esp-hal-embassy = { workspace = true, default-features = false, features = [
+  "esp32c3",
+] }
 esp-wifi = { workspace = true, features = ["esp32c3"], optional = true }
 
 [target.'cfg(context = "esp32c6")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c6"] }
-esp-hal-embassy = { workspace = true, default-features = false, features = ["esp32c6"] }
+esp-hal-embassy = { workspace = true, default-features = false, features = [
+  "esp32c6",
+] }
 esp-wifi = { workspace = true, features = ["esp32c6"], optional = true }
 
 [features]
@@ -118,6 +122,10 @@ threading = ["dep:riot-rs-threads"]
 override-network-config = []
 override-usb-config = []
 
-executor-single-thread = ["riot-rs-rt/executor-single-thread", "esp-hal-embassy?/executors"]
+executor-single-thread = [
+  "riot-rs-rt/executor-single-thread",
+  "esp-hal-embassy?/executors",
+]
 executor-interrupt = ["embassy-executor/executor-interrupt"]
 executor-thread = ["threading"]
+executor-none = []

--- a/src/riot-rs-embassy/src/arch/esp/mod.rs
+++ b/src/riot-rs-embassy/src/arch/esp/mod.rs
@@ -3,6 +3,8 @@ pub mod gpio;
 use esp_hal::{clock::ClockControl, system::SystemControl, timer::timg::TimerGroup};
 
 pub use esp_hal::peripherals::{OptionalPeripherals, Peripherals};
+
+#[cfg(feature = "executor-single-thread")]
 pub use esp_hal_embassy::Executor;
 
 pub fn init() -> OptionalPeripherals {

--- a/src/riot-rs-embassy/src/arch/nrf/mod.rs
+++ b/src/riot-rs-embassy/src/arch/nrf/mod.rs
@@ -6,11 +6,14 @@ pub mod hwrng;
 #[cfg(feature = "usb")]
 pub mod usb;
 
+#[cfg(feature = "executor-interrupt")]
 pub(crate) use embassy_executor::InterruptExecutor as Executor;
 
+#[cfg(feature = "executor-interrupt")]
 #[cfg(context = "nrf52")]
 crate::executor_swi!(SWI0_EGU0);
 
+#[cfg(feature = "executor-interrupt")]
 #[cfg(context = "nrf5340")]
 crate::executor_swi!(EGU0);
 

--- a/src/riot-rs-embassy/src/arch/rp2040/mod.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040/mod.rs
@@ -3,19 +3,24 @@ pub mod gpio;
 #[cfg(feature = "usb")]
 pub mod usb;
 
-use embassy_rp::config::Config;
-
-pub(crate) use embassy_executor::InterruptExecutor as Executor;
-pub use embassy_rp::interrupt;
 pub use embassy_rp::{peripherals, OptionalPeripherals};
 
+#[cfg(feature = "executor-interrupt")]
+pub(crate) use embassy_executor::InterruptExecutor as Executor;
+#[cfg(feature = "executor-interrupt")]
+pub use embassy_rp::interrupt;
+
+#[cfg(feature = "executor-interrupt")]
 crate::executor_swi!(SWI_IRQ_1);
 
 pub fn init() -> OptionalPeripherals {
-    // SWI & DMA priority need to match. DMA is hard-coded to P3 by upstream.
-    use embassy_rp::interrupt::{InterruptExt, Priority};
-    SWI.set_priority(Priority::P3);
+    #[cfg(feature = "executor-interrupt")]
+    {
+        // SWI & DMA priority need to match. DMA is hard-coded to P3 by upstream.
+        use embassy_rp::interrupt::{InterruptExt as _, Priority};
+        SWI.set_priority(Priority::P3);
+    }
 
-    let peripherals = embassy_rp::init(Config::default());
+    let peripherals = embassy_rp::init(embassy_rp::config::Config::default());
     OptionalPeripherals::from(peripherals)
 }

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -76,11 +76,12 @@ pub static EMBASSY_TASKS: [Task] = [..];
 
 #[cfg(not(any(
     feature = "executor-interrupt",
+    feature = "executor-none",
     feature = "executor-single-thread",
     feature = "executor-thread"
 )))]
 compile_error!(
-    "must select one of \"executor-interrupt\", \"executor-single-thread\", \"executor-thread\"!"
+    r#"must select one of "executor-interrupt", "executor-single-thread", "executor-thread", "executor-none"!"#
 );
 
 #[cfg(all(feature = "threading", feature = "executor-single-thread"))]

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -116,7 +116,22 @@ fn init() -> ! {
 }
 
 #[cfg(feature = "executor-thread")]
-#[riot_rs_macros::thread(autostart, stacksize = 65536, priority = 8)]
+mod executor_thread {
+    pub(crate) const STACKSIZE: usize = riot_rs_utils::usize_from_env_or!(
+        "CONFIG_EXECUTOR_THREAD_STACKSIZE",
+        16384,
+        "executor thread stack size"
+    );
+
+    pub(crate) const PRIORITY: u8 = riot_rs_utils::u8_from_env_or!(
+        "CONFIG_EXECUTOR_THREAD_PRIORITY",
+        8,
+        "executor thread priority"
+    );
+}
+
+#[cfg(feature = "executor-thread")]
+#[riot_rs_macros::thread(autostart, stacksize = executor_thread::STACKSIZE, priority = executor_thread::PRIORITY)]
 fn init() {
     println!("riot-rs-embassy::init(): using thread executor");
     let p = arch::init();

--- a/src/riot-rs-embassy/src/thread_executor.rs
+++ b/src/riot-rs-embassy/src/thread_executor.rs
@@ -1,0 +1,73 @@
+// This is based on the upstream embassy cortex-m interrupt executor.
+
+use core::marker::PhantomData;
+
+use embassy_executor::{raw, Spawner};
+use riot_rs_threads::{current_pid, thread_flags, thread_flags::ThreadFlags, ThreadId};
+
+// This is only used between `__pender` and `Executor::run( )`, actual flag
+// doesn't matter.
+const THREAD_FLAG_WAKEUP: ThreadFlags = 0x01;
+
+#[export_name = "__pender"]
+fn __pender(context: *mut ()) {
+    // SAFETY: `context` is a `ThreadId` passed by `ThreadExecutor::new`.
+    let thread_id = ThreadId::new(context as usize as u8);
+
+    thread_flags::set(thread_id, THREAD_FLAG_WAKEUP);
+}
+
+/// Thread mode executor for RIOT-rs threads.
+pub struct Executor {
+    inner: raw::Executor,
+    // This executor is tied to a specific thread by storing the `ThreadId` inside
+    // the inner `raw::Executor`. It thus cannot be `Send`.
+    not_send: PhantomData<*mut ()>,
+}
+
+impl Executor {
+    /// Creates a new [`Executor`].
+    ///
+    /// This must be called from the thread that will actually poll the executor.
+    /// Otherwise, the internally used thread flag will be sent to the wrong thread,
+    /// causing the executor thread to never wake up.
+    ///
+    /// # Panics
+    ///
+    /// This function panics when called without a running thread.
+    pub fn new() -> Self {
+        let current_thread = current_pid().unwrap();
+        Self {
+            inner: raw::Executor::new(usize::from(current_thread) as *mut ()),
+            not_send: PhantomData,
+        }
+    }
+
+    /// Runs the executor.
+    ///
+    /// The `init` closure is called with a [`Spawner`] that spawns tasks on
+    /// this executor. Use it to spawn the initial task(s). After `init` returns,
+    /// the executor starts running the tasks.
+    ///
+    /// To spawn more tasks later, you may keep copies of the [`Spawner`] (it is `Copy`),
+    /// for example by passing it as an argument to the initial tasks.
+    ///
+    /// This function requires `&'static mut self`. This means you have to store the
+    /// [`Executor`] instance in a place where it'll live forever and grants you mutable
+    /// access. There's a few ways to do this:
+    ///
+    /// - a [`StaticCell`](https://docs.rs/static_cell/latest/static_cell/) (safe)
+    /// - a `static mut` (unsafe)
+    /// - a local variable in a function you know never returns (like `fn main() -> !`), upgrading its lifetime with `transmute`. (unsafe)
+    pub fn run(&'static mut self, init: impl FnOnce(Spawner)) -> ! {
+        init(self.inner.spawner());
+
+        loop {
+            // SAFETY: `poll()` may net be called reentrantly on the same executor, which we don't.
+            unsafe {
+                self.inner.poll();
+            };
+            thread_flags::wait_any(THREAD_FLAG_WAKEUP);
+        }
+    }
+}

--- a/src/riot-rs-rt/src/lib.rs
+++ b/src/riot-rs-rt/src/lib.rs
@@ -90,6 +90,7 @@ fn startup() -> ! {
         extern "Rust" {
             fn riot_rs_embassy_init() -> !;
         }
+        println!("riot_rs_rt::startup() launching single thread executor");
         unsafe { riot_rs_embassy_init() };
     }
 

--- a/src/riot-rs-utils/src/env.rs
+++ b/src/riot-rs-utils/src/env.rs
@@ -28,6 +28,7 @@ macro_rules! define_env_with_default_macro {
 }
 
 define_env_with_default_macro!(usize_from_env_or, parse_usize, "a usize");
+define_env_with_default_macro!(u8_from_env_or, parse_u8, "a u8");
 
 #[macro_export]
 macro_rules! str_from_env_or {

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -76,7 +76,7 @@ bench = ["dep:riot-rs-bench"]
 ## Prints nothing in case of panics (may help reduce binary size).
 silent-panic = ["riot-rs-rt/silent-panic"]
 ## Allows to have no boards selected, useful to run target-independent tooling.
-no-boards = ["riot-rs-boards/no-boards"]
+no-boards = ["riot-rs-boards/no-boards", "executor-none"]
 
 net = ["riot-rs-embassy/net"]
 
@@ -88,3 +88,6 @@ executor-interrupt = ["riot-rs-embassy/executor-interrupt"]
 executor-single-thread = ["riot-rs-embassy/executor-single-thread"]
 ## Enables the riot-rs-threading thread executor.
 executor-thread = ["riot-rs-embassy/executor-thread", "threading"]
+# Don't start any executor automatically.
+# *Used for internal testing only.*
+executor-none = ["riot-rs-embassy/executor-none"]

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -21,17 +21,6 @@ riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 riot-rs-utils = { workspace = true }
 static_cell = { workspace = true }
 
-[target.'cfg(context = "cortex-m")'.dependencies]
-riot-rs-embassy = { path = "../riot-rs-embassy", features = [
-  "executor-interrupt",
-] }
-
-[target.'cfg(context = "esp")'.dependencies]
-riot-rs-embassy = { path = "../riot-rs-embassy", features = [
-  "executor-single-thread",
-] }
-riot-rs-rt = { path = "../riot-rs-rt", features = ["executor-single-thread"] }
-
 [features]
 default = ["riot-rs-rt/_panic-handler"]
 
@@ -90,3 +79,12 @@ silent-panic = ["riot-rs-rt/silent-panic"]
 no-boards = ["riot-rs-boards/no-boards"]
 
 net = ["riot-rs-embassy/net"]
+
+#! ## Executor type selection for the (autostarted) main executor
+#! Exactly one of the features below must be enabled at once.
+## Enables the interrupt executor.
+executor-interrupt = ["riot-rs-embassy/executor-interrupt"]
+## Enables the single thread-mode executor.
+executor-single-thread = ["riot-rs-embassy/executor-single-thread"]
+## Enables the riot-rs-threading thread executor.
+executor-thread = ["riot-rs-embassy/executor-thread", "threading"]


### PR DESCRIPTION
This PR adds an `Executor` that runs inside of a `riot-rs-threads` thread.

It also introduces laze modules for selecting an executor (`executor-interrupt, -thread, -single-thread, -none`) and new capability `sw/threading`.

- [x] implement executor
- [x] allow selecting executor type via laze modules and features
- [x] test
- [x] make thread stack size and priority configurable
- [ ] document

Marking as draft as some dependency PRs are missing and this need proper testing.

Depends on ~~#303~~, ~~#312~~, ~~#313~~.