### PR TITLE
ci(lint): introduce source code spellchecking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,9 @@ jobs:
         with:
           args: format --check  # Only check formatting for now
 
+      - name: typos
+        uses: crate-ci/typos@v1.22.0
+
   CI-success:
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,11 @@
+[default.extend-words]
+hax = "hax"
+
+[default.extend-identifiers]
+celcius = "celcius" # Until embedded-aht20 is fixed
+
+[files]
+extend-exclude = [
+  "doc/*.svg",
+  "src/riot-rs-embassy/src/wifi/cyw43/firmware/README.md",
+]

--- a/doc/code_overview.md
+++ b/doc/code_overview.md
@@ -7,7 +7,7 @@ This file tries to provide some links into the guts of RIOT-rs.
 This module contains the scheduler and IPC code, as well as RIOT C bindings /
 glue code.
 
-| file                                             | function                                              | RIOT eqivalent              |
+| file                                             | function                                              | RIOT equivalent             |
 | ------------------------------------------------ | ----------------------------------------------------- | --------------------------- |
 | [thread.rs](../src/riot-rs-core/src/thread.rs)   | scheduling, task switching, thread flags, C glue code | core/sched.c, core/thread.c |
 | [lock.rs](../src/riot-rs-core/src/lock.rs)       | locks                                                 | core/mutex.c                |
@@ -15,7 +15,7 @@ glue code.
 
 ## src/libs
 
-| module                                         | function                | RIOT eqivalent       |
+| module                                         | function                | RIOT equivalent      |
 | ---------------------------------------------- | ----------------------- | -------------------- |
 | [ringbuffer](../src/lib/ringbuffer/src/lib.rs) | ringbuffer              | core/ringbuffer.c    |
 | [rbi](../src/lib/rbi/src/lib.rs)               | ringbuffer index        | core/include/cib.h   |

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ and debugging, the USB device port is also connected to the host computer with
 a second cable.
 
 For *WiFi* (default on `rpi-pico-w` and the esp32 based boards), the actual WiFi
-network credentials have to be suppplied via environment variables:
+network credentials have to be supplied via environment variables:
 
     $ CONFIG_WIFI_NETWORK=<ssid> CONFIG_WIFI_PASSWORD=<pwd> laze build ...
 

--- a/examples/coap/src/seccontext.rs
+++ b/examples/coap/src/seccontext.rs
@@ -18,7 +18,7 @@ const MAX_CONTEXTS: usize = 4;
 // implementations that work well for us.
 type LakersCrypto = lakers_crypto_rustcrypto::Crypto<riot_rs::random::CryptoRng>;
 
-/// A pool of security contexts sharable by several users inside a thread.
+/// A pool of security contexts shareable by several users inside a thread.
 ///
 /// Access through the inner RefCell always happens with panicking errors, because all accessors
 /// (in this module, given it's a private member) promise to not call code would cause double
@@ -37,7 +37,7 @@ impl SecContextPool {
             }
         }
         for (index, place) in self.0.borrow_mut().iter_mut().enumerate() {
-            // As a possible improvement, define a "keep value" in 0..n, and find the slot withthe
+            // As a possible improvement, define a "keep value" in 0..n, and find the slot with the
             // minimum keep value.
             if place.is_gc_eligible() {
                 *place = new;
@@ -519,7 +519,7 @@ impl<'a, H: coap_handler::Handler> coap_handler::Handler for OscoreEdhocHandler<
                     oscore_context,
                     |request| self.inner.extract_request_data(request),
                 ) else {
-                    // FIXME is that the righ tcode?
+                    // FIXME is that the right code?
                     println!("Decryption failure");
                     return Err(Own(CoAPError::unauthorized()));
                 };
@@ -559,7 +559,7 @@ impl<'a, H: coap_handler::Handler> coap_handler::Handler for OscoreEdhocHandler<
                     // FIXME render late error (it'd help if CoAPError also offered a type that unions it
                     // with an arbitrary other error). As it is, depending on the CoAP stack, there may be
                     // DoS if a peer can send many requests before the server starts rendering responses.
-                    panic!("State vanished before respone was built.");
+                    panic!("State vanished before response was built.");
                 };
 
                 // We have a lock, let's pick one now
@@ -592,7 +592,7 @@ impl<'a, H: coap_handler::Handler> coap_handler::Handler for OscoreEdhocHandler<
                     // FIXME render late error (it'd help if CoAPError also offered a type that unions it
                     // with an arbitrary other error). As it is, depending on the CoAP stack, there may be
                     // DoS if a peer can send many requests before the server starts rendering responses.
-                    panic!("State vanished before respone was built.");
+                    panic!("State vanished before response was built.");
                 };
 
                 // Almost-but-not: This'd require 'static on Message which we can't have b/c the

--- a/examples/coap/src/udp_nal/mod.rs
+++ b/examples/coap/src/udp_nal/mod.rs
@@ -8,7 +8,7 @@
 //! useful enough. (FIXME: Given we construct from Socket, Stack could really be implemented on
 //! `Cell<Option<Socket>>` by `.take()`ing, couldn't it?)
 //!
-//! The constructors of the various socket types mimick the UdpStack's socket creation functions,
+//! The constructors of the various socket types mimic the UdpStack's socket creation functions,
 //! but take an owned (uninitialized) Socket instead of a shared stack.
 //!
 //! No `bind_single` style constructor is currently provided. FIXME: Not sure we have all the

--- a/src/riot-rs-core/src/mutex.rs
+++ b/src/riot-rs-core/src/mutex.rs
@@ -1,6 +1,6 @@
 //! Data-carrying mutex
 //!
-//! This roughly mimicks [std::sync::Mutex]. Aims for compatibility with
+//! This roughly mimics [std::sync::Mutex]. Aims for compatibility with
 //! [riot-wrappers::mutex::Mutex].
 
 use core::ops::{Deref, DerefMut};
@@ -15,7 +15,7 @@ use crate::lock::Lock;
 /// A mutual exclusion primitive useful for protecting shared data
 ///
 /// Unlike the [std::sync::Mutex], this has no concept of poisoning, so waiting for mutexes in
-/// paniced (and thus locked) threads will lock the accessing thread as well. This is because RIOT
+/// panicked (and thus locked) threads will lock the accessing thread as well. This is because RIOT
 /// threads don't unwind Rust code. As a consequence, the mutex interface is different from the
 /// standard library's.
 ///


### PR DESCRIPTION
Use crate-ci/typos, a spellchecker built for CI checking by aiming for few false positives.