### PR TITLE
fix(wifi): make Wi-Fi-related env vars mandatory when required

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           sccache --start-server || true # work around https://github.com/ninja-build/ninja/issues/2052
 
-          laze build --global --partition hash:${{ matrix.partition }}
+          CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build --global --partition hash:${{ matrix.partition }}
 
   cargo-test:
     runs-on: ubuntu-latest

--- a/src/riot-rs-embassy/src/wifi/cyw43.rs
+++ b/src/riot-rs-embassy/src/wifi/cyw43.rs
@@ -8,7 +8,6 @@ use embassy_rp::{
 };
 
 use riot_rs_debug::println;
-use riot_rs_utils::str_from_env_or;
 
 use self::rpi_pico_w::{Cyw43Periphs, CywSpi, Irqs};
 use crate::{arch::OptionalPeripherals, make_static};

--- a/src/riot-rs-embassy/src/wifi/mod.rs
+++ b/src/riot-rs-embassy/src/wifi/mod.rs
@@ -3,18 +3,14 @@ pub mod cyw43;
 #[cfg(feature = "wifi-esp")]
 pub mod esp_wifi;
 
+use riot_rs_utils::str_from_env;
+
 #[cfg(feature = "wifi-cyw43")]
 pub(crate) use cyw43::NetworkDevice;
 
 #[cfg(feature = "wifi-esp")]
 pub(crate) use esp_wifi::NetworkDevice;
 
-use riot_rs_utils::str_from_env_or;
-
-pub(crate) const WIFI_NETWORK: &str = str_from_env_or!(
-    "CONFIG_WIFI_NETWORK",
-    "test_network",
-    "Wi-Fi SSID (network name)"
-);
-pub(crate) const WIFI_PASSWORD: &str =
-    str_from_env_or!("CONFIG_WIFI_PASSWORD", "test_password", "Wi-Fi password");
+pub(crate) const WIFI_NETWORK: &str =
+    str_from_env!("CONFIG_WIFI_NETWORK", "Wi-Fi SSID (network name)");
+pub(crate) const WIFI_PASSWORD: &str = str_from_env!("CONFIG_WIFI_PASSWORD", "Wi-Fi password");

--- a/src/riot-rs-utils/src/env.rs
+++ b/src/riot-rs-utils/src/env.rs
@@ -41,3 +41,19 @@ macro_rules! str_from_env_or {
         }
     };
 }
+
+#[macro_export]
+macro_rules! str_from_env {
+    ($env_var:literal, $doc:literal) => {
+        if let Some(str_value) = option_env!($env_var) {
+            str_value
+        } else {
+            $crate::env::const_panic::concat_panic!(
+                "`",
+                $env_var,
+                "` environment variable was expected to provide the ",
+                $doc,
+            );
+        }
+    };
+}


### PR DESCRIPTION
Introduce a new macro that makes it easy to access environment variables for configuration, when it makes no sense to have a default value when the environment variable is not provided by the user.