### PR TITLE
riot-rs-threads: cortex-m: add compiler fence around `wfi` dance

### DIFF
--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -172,6 +172,8 @@ unsafe fn sched() -> u128 {
                 Some(pid) => pid,
                 None => {
                     cortex_m::asm::wfi();
+                    // this fence seems necessary, see #310.
+                    core::sync::atomic::fence(core::sync::atomic::Ordering::Acquire);
                     return None;
                 }
             };


### PR DESCRIPTION
Fixes Cortex-M `sched()` not seeing changes to the runqueue.

See https://github.com/future-proof-iot/RIOT-rs/issues/310#issuecomment-2150039448.

As to why the fence is necessary, I cannot explain. The critical section should actually imply a fence. In this case, the runqueue accesses are heavily inlined, so maybe something is off with the optimizer. Or, we're doing something wrong with how we access `THREADS`, which is a lot more likely than a compiler bug. :smirk: