### PR TITLE
riot-rs-threads: introduce `THREAD_FLAG_WAKEUP`, use in `block_on()`

### DIFF
--- a/src/riot-rs-embassy/src/blocker.rs
+++ b/src/riot-rs-embassy/src/blocker.rs
@@ -1,14 +1,12 @@
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
-use riot_rs_threads::{current_pid, flags, flags::ThreadFlags, ThreadId};
-
-const THREAD_FLAG_WAKER: ThreadFlags = 1; // TODO: find more appropriate value
+use riot_rs_threads::{current_pid, flags, flags::THREAD_FLAG_WAKEUP, ThreadId};
 
 fn wake(ptr: *const ()) {
     // wake
     let thread_id = ThreadId::new(ptr as usize as u8);
-    flags::set(thread_id, THREAD_FLAG_WAKER);
+    flags::set(thread_id, THREAD_FLAG_WAKEUP);
 }
 
 static VTABLE: RawWakerVTable = RawWakerVTable::new(
@@ -31,6 +29,6 @@ pub fn block_on<F: Future>(mut fut: F) -> F::Output {
         if let Poll::Ready(res) = fut.as_mut().poll(&mut cx) {
             return res;
         }
-        flags::wait_any(THREAD_FLAG_WAKER);
+        flags::wait_any(THREAD_FLAG_WAKEUP);
     }
 }

--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -1,8 +1,16 @@
 //! Thread flags.
+//!
+//! Every thread in RIOT-rs has a set of 16 flags that can be set and waited on.
+//!
+//! Note: The highest 4 bits (`1<<15, 1<<14, 1<<13, 1<<12`) are used inside
+//!       RIOT-rs and should not be used for applications.
 use crate::{ThreadId, ThreadState, Threads, THREADS};
 
 /// Bitmask that represent the flags that are set for a thread.
 pub type ThreadFlags = u16;
+
+/// Thread flag used to kick thread loops.
+pub const THREAD_FLAG_WAKEUP: ThreadFlags = 1 << 15;
 
 /// Possible waiting modes for [`ThreadFlags`].
 #[derive(Copy, Clone, PartialEq, Debug)]


### PR DESCRIPTION
This PR introduces `THREAD_FLAG_WAKEUP`, which will be used to kick thread loops like `block_on()` and the executor from #304.