### PR TITLE
.github: Add templates for PRs and Issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+# Description
+
+<!-- Please write a summary of your changes and why you made them.-->
+
+## Issues/PRs references
+
+<!--
+Examples: Fixes #1234. See also #5678. Depends on PR #9876.
+
+Please use keywords (e.g., fixes, resolve) with the links to the issues you
+resolved, this way they will be automatically closed when your pull request
+is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
+-->
+
+## Open Questions
+
+<!-- Unresolved questions, if any. -->
+
+## Change checklist
+
+<!--
+We don't enforce a strict convention for commit messages, but please make sure that
+the commit history is clear and informative.
+-->
+- [ ] I have cleaned up my commit history and squashed fixup commits.
+- [ ] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
+- [ ] I have performed a self-review of my own code.
+- [ ] I have made corresponding changes to the documentation.

--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug Report
+description: Create a bug report for RIOT-rs
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filing a bug report!
+  - type: textarea
+    attributes:
+      label: Summary
+      description: Please provide a short summary of the bug, along with any information you feel relevant to replicate the bug.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Hardware/ Setup
+      description: Any relevant information about the used hardware, setup, RIOT-rs version, etc.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label:  Possible Solution
+      description: Suggest a fix/reason for the bug, or ideas how to implement the addition or change. 
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Would you like to work on fixing this bug?
+      options:
+        - "Yes"
+        - "No"
+        - Maybe
+    validations:
+      required: true

--- a/.github/workflows/ISSUE_TEMPLATE/config.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/workflows/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,30 @@
+name: Enhancement
+description: Suggest an improvement to an existing RIOT-rs feature.
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: Describe the enhancement that you are proposing.    
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Explain why this enhancement is beneficial.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current Implementation
+      description: Describe the current implementation.
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Are you planning to do it yourself in a pull request?
+      options:
+        - "Yes"
+        - "No"
+        - Maybe
+    validations:
+      required: true

--- a/.github/workflows/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest a new feature in RIOT-rs
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: Briefly describe the feature that you are requesting.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Explain why this feature is needed.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Requirements
+      description: Write a list of what you want this feature to do.
+      placeholder: "1." 
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Open questions
+      description: Use this section to ask any questions that are related to the feature.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Are you planning to do it yourself in a pull request?
+      options:
+        - "Yes"
+        - "No"
+        - Maybe
+    validations:
+      required: true


### PR DESCRIPTION
Add Issue and PR templates to help contributors.

I've used the [beta issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) for the issue templates, but I can change it back to traditional markdown if you prefer that.

I drafted the templates based on what I saw in other projects, feel free to suggestion changes.