### PR TITLE
.editorconfig: add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+spelling_language = en
+end_of_line = lf
+
+[*.rs]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,toml}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
This adds an [EditorConfig][homepage] file in the root of the repo. Most editors support it [natively][native-support] or via a [plugin][plugin-support].

This is particularly useful for occasional contributors, who with this no longer need to configure the editor to properly show and format source code.

[homepage]: https://editorconfig.org/
[native-support]: https://editorconfig.org/#pre-installed
[plugin-support]: https://editorconfig.org/#download