### PR TITLE
riot-rs-embassy: arch/esp: shuffle uses, fix warning

### DIFF
--- a/src/riot-rs-embassy/src/arch/esp/mod.rs
+++ b/src/riot-rs-embassy/src/arch/esp/mod.rs
@@ -1,10 +1,6 @@
 pub mod gpio;
 
-use esp_hal::{
-    clock::ClockControl,
-    system::SystemControl,
-    timer::{systimer::SystemTimer, timg::TimerGroup},
-};
+use esp_hal::{clock::ClockControl, system::SystemControl, timer::timg::TimerGroup};
 
 pub use esp_hal::peripherals::{OptionalPeripherals, Peripherals};
 pub use esp_hal_embassy::Executor;
@@ -16,7 +12,7 @@ pub fn init() -> OptionalPeripherals {
 
     #[cfg(feature = "wifi-esp")]
     {
-        use esp_hal::rng::Rng;
+        use esp_hal::{rng::Rng, timer::systimer::SystemTimer};
         use esp_wifi::{initialize, EspWifiInitFor};
 
         riot_rs_debug::println!("riot-rs-embassy::arch::esp::init(): wifi");


### PR DESCRIPTION
Fixes:

```
warning: unused import: `systimer::SystemTimer`
 --> src/riot-rs-embassy/src/arch/esp/mod.rs:6:13                                                                                                              
  |                                                                                                                                                            
6 |     timer::{systimer::SystemTimer, timg::TimerGroup},                                                                                                      
  |             ^^^^^^^^^^^^^^^^^^^^^                                                                                                                          
  |
  = note: `#[warn(unused_imports)]` on by default
```
... which I caused with #318.