### PR TITLE
docs(book): add an initial version of the support matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,6 +171,9 @@ jobs:
       - name: typos
         uses: crate-ci/typos@v1.22.0
 
+      - name: Check that the HTML support matrix is up to date
+        run: ./doc/gen_support_matrix_html.rs check doc/support_matrix.yml book/src/support_matrix.html
+
   CI-success:
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Manifesto](./manifesto.md)
 - [Introduction](./introduction.md)
+- [Hardware & Functionality Support](./hardware_functionality_support.md)
 - [Code of Conduct](./CODE_OF_CONDUCT.md)
   - [Reporting Guidelines](./COC_reporting.md)
 

--- a/book/src/hardware_functionality_support.md
+++ b/book/src/hardware_functionality_support.md
@@ -1,0 +1,5 @@
+# Hardware & Functionality Support
+
+> The table below indicates whether we support using the piece of functionality in a portable manner, trough an abstraction layer and platform-aware configuration.
+
+{{#include support_matrix.html }}

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -29,6 +29,26 @@
       <td class="support-cell" title="supported">✅</td>
     </tr>
     <tr>
+      <td>nRF52xxx</td>
+      <td>nRF52840-DK</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
+      <td class="support-cell" title="supported">✅</td>
+    </tr>
+    <tr>
+      <td>nRF53xx</td>
+      <td>nRF5340-DK</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
+      <td class="support-cell" title="supported">✅</td>
+    </tr>
+    <tr>
       <td>RP2040</td>
       <td>Raspberry Pi Pico</td>
       <td class="support-cell" title="supported">✅</td>
@@ -71,26 +91,6 @@
     <tr>
       <td>STM32W55RGVX</td>
       <td>ST NUCLEO-WB55RG</td>
-      <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>nRF52xxx</td>
-      <td>nRF52840-DK</td>
-      <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>nRF53xx</td>
-      <td>nRF5340-DK</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -1,0 +1,92 @@
+<!-- This table is auto-generated. Do not edit manually. -->
+<table>
+  <thead>
+    <tr>
+      <th>Chip</th>
+      <th>Testing Board</th>
+      <th colspan="6">Functionality</th>
+    </tr>
+    <tr>
+      <th></th>
+      <th></th>
+      <th>GPIO</th>
+      <th>Debug Output</th>
+      <th>Logging</th>
+      <th>User USB</th>
+      <th>Wi-Fi</th>
+      <th>Ethernet over USB</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>ESP32-C6</td>
+      <td>ESP32-C6-DevKitC-1</td>
+      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="work in progress">🚧</td>
+      <td class="support-cell" title="work in progress">🚧</td>
+      <td class="support-cell" title="work in progress">🚧</td>
+    </tr>
+    <tr>
+      <td>RP2040</td>
+      <td>Raspberry Pi Pico</td>
+      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="work in progress">🚧</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">🚫</td>
+      <td class="support-cell" title="supported">✅</td>
+    </tr>
+    <tr>
+      <td>RP2040</td>
+      <td>Raspberry Pi Pico W</td>
+      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="work in progress">🚧</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+    </tr>
+    <tr>
+      <td>nRF52xxx</td>
+      <td>nRF52840-DK</td>
+      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="work in progress">🚧</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">🚫</td>
+      <td class="support-cell" title="supported">✅</td>
+    </tr>
+    <tr>
+      <td>nRF53xx</td>
+      <td>nRF5340-DK</td>
+      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="work in progress">🚧</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">🚫</td>
+      <td class="support-cell" title="supported">✅</td>
+    </tr>
+  </tbody>
+</table>
+<style>
+.support-cell {
+  text-align: center;
+}
+</style><p>Key:</p>
+
+<ul>
+  <li class="no-marker">♻️&nbsp;&nbsp;rework in progress, expect breaking changes</li>
+  <li class="no-marker">❔&nbsp;&nbsp;needs testing; support may be present but we do not currently test it</li>
+  <li class="no-marker">🚫&nbsp;&nbsp;not available on this piece of hardware</li>
+  <li class="no-marker">❌&nbsp;&nbsp;not currently supported by RIOT-rs</li>
+  <li class="no-marker">✅&nbsp;&nbsp;supported</li>
+  <li class="no-marker">⚠️&nbsp;&nbsp;supported with some caveats</li>
+  <li class="no-marker">🚧&nbsp;&nbsp;work in progress</li>
+</ul>
+<style>
+.no-marker::marker {
+  content: '';
+}
+</style>

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -49,6 +49,36 @@
       <td class="support-cell" title="supported">✅</td>
     </tr>
     <tr>
+      <td>STM32F401RETX</td>
+      <td>ST NUCLEO-F401RE</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
+    </tr>
+    <tr>
+      <td>STM32F755ZITX</td>
+      <td>ST NUCLEO-H755ZI-Q</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
+      <td class="support-cell" title="available in hardware, but not currently supported by RIOT-rs">❌</td>
+    </tr>
+    <tr>
+      <td>STM32W55RGVX</td>
+      <td>ST NUCLEO-WB55RG</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
+      <td class="support-cell" title="supported">✅</td>
+    </tr>
+    <tr>
       <td>nRF52xxx</td>
       <td>nRF52840-DK</td>
       <td class="support-cell" title="supported">✅</td>

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -21,29 +21,29 @@
     <tr>
       <td>ESP32-C6</td>
       <td>ESP32-C6-DevKitC-1</td>
-      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="work in progress">🚧</td>
-      <td class="support-cell" title="work in progress">🚧</td>
-      <td class="support-cell" title="work in progress">🚧</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported with some caveats">☑️</td>
+      <td class="support-cell" title="supported">✅</td>
     </tr>
     <tr>
       <td>RP2040</td>
       <td>Raspberry Pi Pico</td>
-      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="work in progress">🚧</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="not available on this piece of hardware">🚫</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="supported">✅</td>
     </tr>
     <tr>
       <td>RP2040</td>
       <td>Raspberry Pi Pico W</td>
-      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="work in progress">🚧</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -51,21 +51,21 @@
     <tr>
       <td>nRF52xxx</td>
       <td>nRF52840-DK</td>
-      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="work in progress">🚧</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="not available on this piece of hardware">🚫</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="supported">✅</td>
     </tr>
     <tr>
       <td>nRF53xx</td>
       <td>nRF5340-DK</td>
-      <td class="support-cell" title="rework in progress, expect breaking changes">♻️</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="work in progress">🚧</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="not available on this piece of hardware">🚫</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="supported">✅</td>
     </tr>
   </tbody>
@@ -76,17 +76,22 @@
 }
 </style><p>Key:</p>
 
-<ul>
-  <li class="no-marker">✅&nbsp;&nbsp;supported</li>
-  <li class="no-marker">⚠️&nbsp;&nbsp;supported with some caveats</li>
-  <li class="no-marker">❔&nbsp;&nbsp;needs testing; support may be present but we do not currently test it</li>
-  <li class="no-marker">♻️&nbsp;&nbsp;rework in progress, expect breaking changes</li>
-  <li class="no-marker">🚧&nbsp;&nbsp;work in progress</li>
-  <li class="no-marker">❌&nbsp;&nbsp;not currently supported by RIOT-rs</li>
-  <li class="no-marker">🚫&nbsp;&nbsp;not available on this piece of hardware</li>
-</ul>
+<dl>
+  <div>
+    <dt>✅</dt><dd>supported</dd>
+  </div>
+  <div>
+    <dt>☑️</dt><dd>supported with some caveats</dd>
+  </div>
+  <div>
+    <dt>❌</dt><dd>available in hardware, but not currently supported by RIOT-rs</dd>
+  </div>
+  <div>
+    <dt>–</dt><dd>not available on this piece of hardware</dd>
+  </div>
+</dl>
 <style>
-.no-marker::marker {
-  content: '';
+dt, dd {
+  display: inline;
 }
 </style>

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -77,13 +77,13 @@
 </style><p>Key:</p>
 
 <ul>
-  <li class="no-marker">♻️&nbsp;&nbsp;rework in progress, expect breaking changes</li>
-  <li class="no-marker">❔&nbsp;&nbsp;needs testing; support may be present but we do not currently test it</li>
-  <li class="no-marker">🚫&nbsp;&nbsp;not available on this piece of hardware</li>
-  <li class="no-marker">❌&nbsp;&nbsp;not currently supported by RIOT-rs</li>
   <li class="no-marker">✅&nbsp;&nbsp;supported</li>
   <li class="no-marker">⚠️&nbsp;&nbsp;supported with some caveats</li>
+  <li class="no-marker">❔&nbsp;&nbsp;needs testing; support may be present but we do not currently test it</li>
+  <li class="no-marker">♻️&nbsp;&nbsp;rework in progress, expect breaking changes</li>
   <li class="no-marker">🚧&nbsp;&nbsp;work in progress</li>
+  <li class="no-marker">❌&nbsp;&nbsp;not currently supported by RIOT-rs</li>
+  <li class="no-marker">🚫&nbsp;&nbsp;not available on this piece of hardware</li>
 </ul>
 <style>
 .no-marker::marker {

--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -57,7 +57,7 @@ const KEY_TEMPLATE: &str =
 r##"<p>Key:</p>
 
 <ul>
-  {%- for _, support_key in matrix.support_keys|items %}
+  {%- for support_key in matrix.support_keys %}
   <li class="no-marker">{{ support_key.icon }}&nbsp;&nbsp;{{ support_key.description }}</li>
   {%- endfor %}
 </ul>
@@ -228,7 +228,8 @@ fn render_html(matrix: &schema::Matrix) -> Result<String, Error> {
                 let support_key = if let Some(support_info) = board_info.support.get(name) {
                     let status = support_info.status();
                     matrix.support_keys
-                        .get(status)
+                        .iter()
+                        .find(|s| s.name == status)
                         .ok_or(Error::InvalidSupportKeyNameBoard {
                             found: status.to_owned(),
                             functionality: name.to_owned(),
@@ -250,7 +251,8 @@ fn render_html(matrix: &schema::Matrix) -> Result<String, Error> {
                         })?;
                     let status = support_info.status();
                     matrix.support_keys
-                        .get(status)
+                        .iter()
+                        .find(|s| s.name == status)
                         .ok_or(Error::InvalidSupportKeyNameChip {
                             found: status.to_owned(),
                             functionality: name.to_owned(),
@@ -367,7 +369,7 @@ mod schema {
     #[derive(Debug, Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct Matrix {
-        pub support_keys: HashMap<String, SupportKeyInfo>,
+        pub support_keys: Vec<SupportKeyInfo>,
         pub functionalities: Vec<FunctionalityInfo>,
         pub chips: HashMap<String, ChipInfo>,
         pub boards: HashMap<String, BoardInfo>,
@@ -376,6 +378,7 @@ mod schema {
     #[derive(Debug, Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct SupportKeyInfo {
+        pub name: String,
         pub icon: String,
         pub description: String,
     }

--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -56,14 +56,16 @@ r##"<!-- This table is auto-generated. Do not edit manually. -->
 const KEY_TEMPLATE: &str =
 r##"<p>Key:</p>
 
-<ul>
+<dl>
   {%- for support_key in matrix.support_keys %}
-  <li class="no-marker">{{ support_key.icon }}&nbsp;&nbsp;{{ support_key.description }}</li>
+  <div>
+    <dt>{{ support_key.icon }}</dt><dd>{{ support_key.description }}</dd>
+  </div>
   {%- endfor %}
-</ul>
+</dl>
 <style>
-.no-marker::marker {
-  content: '';
+dt, dd {
+  display: inline;
 }
 </style>
 "##;
@@ -415,7 +417,7 @@ mod schema {
         StatusOnly(String),
         Details {
             status: String,
-            comments: Option<String>,
+            comments: Option<Vec<String>>,
             link: Option<String>,
         },
     }

--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -171,7 +171,7 @@ fn main() -> miette::Result<()> {
 
 fn validate_input(matrix: &schema::Matrix) -> Result<(), Error> {
     for (_, board_info) in &matrix.boards {
-        let invalid_functionality_name = board_info.supports
+        let invalid_functionality_name = board_info.support
             .keys()
             .find(|f| matrix.functionalities.iter().all(|functionality| functionality.name != **f));
 
@@ -184,7 +184,7 @@ fn validate_input(matrix: &schema::Matrix) -> Result<(), Error> {
     }
 
     for (_, chip_info) in &matrix.chips {
-        let invalid_functionality_name = chip_info.supports
+        let invalid_functionality_name = chip_info.support
             .keys()
             .find(|f| matrix.functionalities.iter().all(|functionality| functionality.name != **f));
 
@@ -225,7 +225,7 @@ fn render_html(matrix: &schema::Matrix) -> Result<String, Error> {
             .map(|functionality_info| {
                 let name = &functionality_info.name;
 
-                let support_key = if let Some(support_info) = board_info.supports.get(name) {
+                let support_key = if let Some(support_info) = board_info.support.get(name) {
                     let status = support_info.status();
                     matrix.support_keys
                         .get(status)
@@ -241,7 +241,7 @@ fn render_html(matrix: &schema::Matrix) -> Result<String, Error> {
                         found: chip.to_owned(),
                         board: board_name.to_owned(),
                     })?;
-                    let support_info = chip_info.supports
+                    let support_info = chip_info.support
                         .get(name)
                         .ok_or(Error::MissingSupportInfo {
                             board: board_name.to_owned(),
@@ -393,7 +393,7 @@ mod schema {
     pub struct ChipInfo {
         pub name: String,
         pub description: Option<String>,
-        pub supports: HashMap<String, SupportInfo>,
+        pub support: HashMap<String, SupportInfo>,
     }
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -402,7 +402,7 @@ mod schema {
         pub name: String,
         pub description: Option<String>,
         pub chip: String,
-        pub supports: HashMap<String, SupportInfo>,
+        pub support: HashMap<String, SupportInfo>,
     }
 
     #[derive(Debug, Serialize, Deserialize)]

--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -1,0 +1,274 @@
+#!/usr/bin/env -S cargo +nightly -Zscript
+---cargo
+[package]
+edition = "2021"
+
+[dependencies]
+miette = { version = "7.2.0", features = ["fancy"] }
+minijinja = { version = "2.0.3" }
+serde = { version = "1.0.0", features = ["derive"] }
+serde_yaml = { version = "0.9.34" } # TODO: use a maintained crate instead
+thiserror = { version = "1.0.61" }
+---
+
+use std::{env, fs, io, path::PathBuf};
+
+use serde::Serialize;
+use miette::Diagnostic;
+
+const TABLE_TEMPLATE: &str =
+r##"<!-- This table is auto-generated. Do not edit manually. -->
+<table>
+  <thead>
+    <tr>
+      <th>Chip</th>
+      <th>Testing Board</th>
+      <th colspan="{{ matrix.functionalities|length }}">Functionality</th>
+    </tr>
+    <tr>
+      <th></th>
+      <th></th>
+      {%- for functionality in matrix.functionalities %}
+      <th>{{ functionality.title }}</th>
+      {%- endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {%- for board in boards %}
+    <tr>
+      <td>{{ board.chip }}</td>
+      <td>{{ board.name }}</td>
+      {%- for functionality in board.functionalities %}
+      <td class="support-cell" title="{{ functionality.description }}">{{ functionality.icon }}</td>
+      {%- endfor %}
+    </tr>
+    {%- endfor %}
+  </tbody>
+</table>
+<style>
+.support-cell {
+  text-align: center;
+}
+</style>
+"##;
+
+const KEY_TEMPLATE: &str =
+r##"<p>Key:</p>
+
+<ul>
+  {%- for _, support_key in matrix.support_keys|items %}
+  <li class="no-marker">{{ support_key.icon }}&nbsp;&nbsp;{{ support_key.description }}</li>
+  {%- endfor %}
+</ul>
+<style>
+.no-marker::marker {
+  content: '';
+}
+</style>
+"##;
+
+fn main() -> miette::Result<()> {
+    // TODO: add a flag to only check, for CLI
+    // TODO: maybe use argh instead
+    let input_file_path = env::args()
+        .nth(1)
+        .expect("input file path as first CLI argument");
+    let output_file_path = env::args()
+        .nth(2)
+        .expect("output file path as second CLI argument");
+
+    let input_file = fs::read_to_string(&input_file_path).map_err(|source| Error::InputFile {
+        path: input_file_path.clone().into(),
+        source,
+    })?;
+
+    let matrix = serde_yaml::from_str(&input_file).map_err(|source| {
+        let err_span = miette::SourceSpan::from(source.location().unwrap().index());
+        Error::Parsing {
+            path: input_file_path.into(),
+            src: input_file,
+            err_span,
+            source,
+        }
+    })?;
+
+    let html = render_html(&matrix)?;
+    fs::write(output_file_path, html).expect("could not write the output HTML file");
+
+    Ok(())
+}
+
+fn render_html(matrix: &schema::Matrix) -> Result<String, Error> {
+    use minijinja::{Environment, context};
+
+    #[derive(Debug, Serialize)]
+    struct BoardSupport {
+        chip: String,
+        name: String,
+        functionalities: Vec<FunctionalitySupport>,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct FunctionalitySupport {
+        icon: String,
+        description: String,
+        // TODO: add comments
+        // TODO: add the PR link
+    }
+
+    let mut boards = matrix.boards.iter().map(|(_, board_info)| {
+        let functionalities = matrix.functionalities
+            .iter()
+            .map(|functionality_info| {
+                let name = &functionality_info.name;
+
+                let support_info = if let Some(support_info) = board_info.supports.get(name) {
+                    support_info
+                } else {
+                    // Implement chip info inheritance
+                    let chip_info = matrix.chips.get(&board_info.chip).ok_or(Error::InvalidChipName)?;
+                    chip_info.supports.get(name).ok_or(Error::MissingSupportInfo {
+                        board: board_info.name.to_owned(),
+                        chip: board_info.chip.to_owned(),
+                        functionality: functionality_info.title.to_owned(),
+                    })?
+                };
+
+                // FIXME: make sure invalid functionality names in boards are rejected
+
+                let status = support_info.status();
+                let support_key = matrix.support_keys.get(status)
+                    .ok_or(Error::InvalidSupportKeyName { found: status.to_owned() })?;
+
+                Ok(FunctionalitySupport {
+                    icon: support_key.icon.to_owned(),
+                    description: support_key.description.to_owned(),
+                })
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
+
+
+        let chip = matrix.chips.get(&board_info.chip).ok_or(Error::InvalidChipName)?;
+
+        Ok(BoardSupport {
+            chip: chip.name.to_owned(),
+            name: board_info.name.to_owned(),
+            functionalities,
+        })
+    }).collect::<Result<Vec<_>, Error>>()?;
+    // TODO: read the order from the YAML file instead?
+    boards.sort_unstable_by_key(|b| b.name.clone());
+
+    let mut env = Environment::new();
+    env.add_template("matrix", TABLE_TEMPLATE).unwrap();
+    env.add_template("matrix_key", KEY_TEMPLATE).unwrap();
+
+    let tmpl = env.get_template("matrix").unwrap();
+    let matrix_html = tmpl.render(context!(matrix => matrix, boards => boards)).unwrap();
+
+    let tmpl = env.get_template("matrix_key").unwrap();
+    let key_html = tmpl.render(context!(matrix => matrix, boards => boards)).unwrap();
+
+    // NOTE: We may want to return the table and its key separately later
+    Ok(format!("{matrix_html}{key_html}\n"))
+}
+
+#[derive(Debug, thiserror::Error, Diagnostic)]
+enum Error {
+    #[error("could not find file `{path}`")]
+    InputFile {
+        path: PathBuf,
+        source: io::Error,
+    },
+    #[error("could not parse YAML file `{path}`")]
+    Parsing {
+        path: PathBuf,
+        #[source_code]
+        src: String,
+        #[label = "Syntax error"]
+        err_span: miette::SourceSpan,
+        source: serde_yaml::Error,
+    },
+    #[error("invalid chip name")] // FIXME: improve this error message
+    InvalidChipName,
+    #[error("invalid functionality name")] // FIXME: improve this error message
+    InvalidFunctionalityName,
+    #[error("invalid support key name `{found}`")] // FIXME: improve this error message
+    InvalidSupportKeyName {
+        found: String,
+    },
+    #[error("missing support info on board `{board}` or chip `{chip}` regarding functionality `{functionality}`")]
+    MissingSupportInfo {
+        board: String,
+        chip: String,
+        functionality: String,
+    }
+}
+
+mod schema {
+    use std::collections::HashMap;
+
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct Matrix {
+        pub support_keys: HashMap<String, SupportKeyInfo>,
+        pub functionalities: Vec<FunctionalityInfo>,
+        pub chips: HashMap<String, ChipInfo>,
+        pub boards: HashMap<String, BoardInfo>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct SupportKeyInfo {
+        pub icon: String,
+        pub description: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct FunctionalityInfo {
+        pub name: String,
+        pub title: String, // FIXME: rename this
+        pub description: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct ChipInfo {
+        pub name: String,
+        pub description: Option<String>,
+        pub supports: HashMap<String, SupportInfo>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    pub struct BoardInfo {
+        pub name: String,
+        pub description: Option<String>,
+        pub chip: String,
+        pub supports: HashMap<String, SupportInfo>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    #[serde(untagged)]
+    pub enum SupportInfo {
+        StatusOnly(String),
+        Details {
+            status: String,
+            comments: Option<String>,
+            github_pr: Option<u32>,
+        },
+    }
+
+    impl SupportInfo {
+        pub fn status(&self) -> &str {
+            match self {
+                SupportInfo::StatusOnly(status) => status,
+                SupportInfo::Details { status, .. } => status,
+            }
+        }
+    }
+}

--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -282,7 +282,8 @@ fn render_html(matrix: &schema::Matrix) -> Result<String, Error> {
         })
     }).collect::<Result<Vec<_>, Error>>()?;
     // TODO: read the order from the YAML file instead?
-    boards.sort_unstable_by_key(|b| b.name.clone());
+    boards.sort_unstable_by_key(|b| b.name.to_lowercase());
+    dbg!(&boards);
 
     let mut env = Environment::new();
     env.add_template("matrix", TABLE_TEMPLATE).unwrap();

--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -416,7 +416,7 @@ mod schema {
         Details {
             status: String,
             comments: Option<String>,
-            github_pr: Option<u32>,
+            link: Option<String>,
         },
     }
 

--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S cargo +nightly -Zscript
+#!/usr/bin/env -S cargo -Zscript
 ---cargo
 [package]
 edition = "2021"

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -70,6 +70,30 @@ chips:
       logging: supported
       wifi: not_available
 
+  stm32f401retx:
+    name: STM32F401RETX
+    support:
+      gpio: supported
+      debug_output: supported
+      logging: supported
+      wifi: not_available
+
+  stm32h755zitx:
+    name: STM32F755ZITX
+    support:
+      gpio: supported
+      debug_output: supported
+      logging: supported
+      wifi: not_available
+
+  stm32wb55rgvx:
+    name: STM32W55RGVX
+    support:
+      gpio: supported
+      debug_output: supported
+      logging: supported
+      wifi: not_available
+
 # Encodes support status for each board.
 # Boards inherit support statuses of their chip, but can also override them.
 boards:
@@ -111,4 +135,28 @@ boards:
         status: supported_with_caveats
         comments:
           - not currently compatible with threading
+      ethernet_over_usb: supported
+
+  st-nucleo-f401re:
+    name: ST NUCLEO-F401RE
+    chip: stm32f401retx
+    support:
+      user_usb: not_available
+      wifi: not_available
+      ethernet_over_usb: not_available
+
+  st-nucleo-h755zi-q:
+    name: ST NUCLEO-H755ZI-Q
+    chip: stm32h755zitx
+    support:
+      user_usb: supported
+      wifi: not_available
+      ethernet_over_usb: not_currently_supported
+
+  st-nucleo-wb55:
+    name: ST NUCLEO-WB55RG
+    chip: stm32wb55rgvx
+    support:
+      user_usb: supported
+      wifi: not_available
       ethernet_over_usb: supported

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -1,5 +1,6 @@
 ---
 
+# Defines the different support statuses.
 support_keys:
   supported:
     icon: ✅
@@ -23,6 +24,7 @@ support_keys:
     icon: 🚫
     description: not available on this piece of hardware
 
+# Defines existing pieces of functionality, hardware or software.
 functionalities:
   - name: gpio
     title: GPIO
@@ -43,6 +45,7 @@ functionalities:
     title: Ethernet over USB
     description:
 
+# Encodes support status for each chip.
 chips:
   nrf52xxx:
     name: nRF52xxx
@@ -84,6 +87,8 @@ chips:
         github_pr: 255
       debug_output: supported
 
+# Encodes support status for each board.
+# Boards inherit support statuses of their chip, but can also override them.
 boards:
   nrf52840-dk:
     name: nRF52840-DK

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -1,0 +1,125 @@
+---
+
+support_keys:
+  supported:
+    icon: ✅
+    description: supported
+  supported_with_caveats:
+    icon: ⚠️
+    description: supported with some caveats
+  needs_testing:
+    icon: ❔
+    description: needs testing; support may be present but we do not currently test it
+  being_reworked:
+    icon: ♻️
+    description: rework in progress, expect breaking changes
+  wip:
+    icon: 🚧
+    description: work in progress
+  not_currently_supported:
+    icon: ❌
+    description: available in hardware, but not currently supported by RIOT-rs
+  not_available:
+    icon: 🚫
+    description: not available on this piece of hardware
+
+functionalities:
+  - name: gpio
+    title: GPIO
+    description:
+  - name: debug_output
+    title: Debug Output
+    description:
+  - name: logging
+    title: Logging
+    description:
+  - name: user_usb
+    title: User USB
+    description:
+  - name: wifi
+    title: Wi-Fi
+    description:
+  - name: ethernet_over_usb
+    title: Ethernet over USB
+    description:
+
+chips:
+  nrf52xxx:
+    name: nRF52xxx
+    supports:
+      gpio:
+        status: being_reworked
+        github_pr: 322
+      debug_output: supported
+      logging: wip
+      wifi: not_available
+
+  nrf53xx:
+    name: nRF53xx
+    supports:
+      gpio:
+        status: being_reworked
+        github_pr: 322
+      debug_output: supported
+      logging: wip
+      wifi: not_available
+
+  rp2040:
+    name: RP2040
+    supports:
+      gpio:
+        status: being_reworked
+        github_pr: 322
+      logging: wip
+      debug_output: supported
+
+  esp32-c6:
+    name: ESP32-C6
+    supports:
+      gpio:
+        status: being_reworked
+        github_pr: 322
+      logging:
+        status: supported
+        github_pr: 255
+      debug_output: supported
+
+boards:
+  nrf52840-dk:
+    name: nRF52840-DK
+    chip: nrf52xxx
+    supports:
+      user_usb: supported
+      ethernet_over_usb: supported
+
+  nrf5340-dk:
+    name: nRF5340-DK
+    chip: nrf53xx
+    supports:
+      user_usb: supported
+      wifi: not_available
+      ethernet_over_usb: supported
+
+  rp-pico:
+    name: Raspberry Pi Pico
+    chip: rp2040
+    supports:
+      wifi: not_available
+      user_usb: supported
+      ethernet_over_usb: supported
+
+  rp-pico-w:
+    name: Raspberry Pi Pico W
+    chip: rp2040
+    supports:
+      user_usb: supported
+      wifi: supported
+      ethernet_over_usb: supported
+
+  esp32-c6-devkitc-1:
+    name: ESP32-C6-DevKitC-1
+    chip: esp32-c6
+    supports:
+      user_usb: wip
+      wifi: wip
+      ethernet_over_usb: wip

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -6,22 +6,13 @@ support_keys:
     icon: ✅
     description: supported
   - name: supported_with_caveats
-    icon: ⚠️
+    icon: ☑️
     description: supported with some caveats
-  - name: needs_testing
-    icon: ❔
-    description: needs testing; support may be present but we do not currently test it
-  - name: being_reworked
-    icon: ♻️
-    description: rework in progress, expect breaking changes
-  - name: wip
-    icon: 🚧
-    description: work in progress
   - name: not_currently_supported
     icon: ❌
     description: available in hardware, but not currently supported by RIOT-rs
   - name: not_available
-    icon: 🚫
+    icon: '–'
     description: not available on this piece of hardware
 
 # Defines existing pieces of functionality, hardware or software.
@@ -50,43 +41,33 @@ chips:
   nrf52xxx:
     name: nRF52xxx
     support:
-      gpio:
-        status: being_reworked
-        link: https://github.com/future-proof-iot/RIOT-rs/pull/322
+      gpio: supported
       debug_output: supported
-      logging: wip
+      logging: supported
       wifi: not_available
 
   nrf53xx:
     name: nRF53xx
     support:
-      gpio:
-        status: being_reworked
-        link: https://github.com/future-proof-iot/RIOT-rs/pull/322
+      gpio: supported
       debug_output: supported
-      logging: wip
+      logging: supported
       wifi: not_available
 
   rp2040:
     name: RP2040
     support:
-      gpio:
-        status: being_reworked
-        link: https://github.com/future-proof-iot/RIOT-rs/pull/322
+      gpio: supported
       debug_output: supported
-      logging: wip
+      logging: supported
       wifi: not_available
 
   esp32-c6:
     name: ESP32-C6
     support:
-      gpio:
-        status: being_reworked
-        link: https://github.com/future-proof-iot/RIOT-rs/pull/322
+      gpio: supported
       debug_output: supported
-      logging:
-        status: supported
-        link: https://github.com/future-proof-iot/RIOT-rs/pull/255
+      logging: supported
       wifi: not_available
 
 # Encodes support status for each board.
@@ -125,6 +106,9 @@ boards:
     name: ESP32-C6-DevKitC-1
     chip: esp32-c6
     support:
-      user_usb: wip
-      wifi: wip
-      ethernet_over_usb: wip
+      user_usb: supported
+      wifi:
+        status: supported_with_caveats
+        comments:
+          - not currently compatible with threading
+      ethernet_over_usb: supported

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -52,7 +52,7 @@ chips:
     support:
       gpio:
         status: being_reworked
-        github_pr: 322
+        link: https://github.com/future-proof-iot/RIOT-rs/pull/322
       debug_output: supported
       logging: wip
       wifi: not_available
@@ -62,7 +62,7 @@ chips:
     support:
       gpio:
         status: being_reworked
-        github_pr: 322
+        link: https://github.com/future-proof-iot/RIOT-rs/pull/322
       debug_output: supported
       logging: wip
       wifi: not_available
@@ -72,7 +72,7 @@ chips:
     support:
       gpio:
         status: being_reworked
-        github_pr: 322
+        link: https://github.com/future-proof-iot/RIOT-rs/pull/322
       debug_output: supported
       logging: wip
       wifi: not_available
@@ -82,11 +82,11 @@ chips:
     support:
       gpio:
         status: being_reworked
-        github_pr: 322
+        link: https://github.com/future-proof-iot/RIOT-rs/pull/322
       debug_output: supported
       logging:
         status: supported
-        github_pr: 255
+        link: https://github.com/future-proof-iot/RIOT-rs/pull/255
       wifi: not_available
 
 # Encodes support status for each board.

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -49,7 +49,7 @@ functionalities:
 chips:
   nrf52xxx:
     name: nRF52xxx
-    supports:
+    support:
       gpio:
         status: being_reworked
         github_pr: 322
@@ -59,7 +59,7 @@ chips:
 
   nrf53xx:
     name: nRF53xx
-    supports:
+    support:
       gpio:
         status: being_reworked
         github_pr: 322
@@ -69,7 +69,7 @@ chips:
 
   rp2040:
     name: RP2040
-    supports:
+    support:
       gpio:
         status: being_reworked
         github_pr: 322
@@ -78,7 +78,7 @@ chips:
 
   esp32-c6:
     name: ESP32-C6
-    supports:
+    support:
       gpio:
         status: being_reworked
         github_pr: 322
@@ -93,14 +93,14 @@ boards:
   nrf52840-dk:
     name: nRF52840-DK
     chip: nrf52xxx
-    supports:
+    support:
       user_usb: supported
       ethernet_over_usb: supported
 
   nrf5340-dk:
     name: nRF5340-DK
     chip: nrf53xx
-    supports:
+    support:
       user_usb: supported
       wifi: not_available
       ethernet_over_usb: supported
@@ -108,7 +108,7 @@ boards:
   rp-pico:
     name: Raspberry Pi Pico
     chip: rp2040
-    supports:
+    support:
       wifi: not_available
       user_usb: supported
       ethernet_over_usb: supported
@@ -116,7 +116,7 @@ boards:
   rp-pico-w:
     name: Raspberry Pi Pico W
     chip: rp2040
-    supports:
+    support:
       user_usb: supported
       wifi: supported
       ethernet_over_usb: supported
@@ -124,7 +124,7 @@ boards:
   esp32-c6-devkitc-1:
     name: ESP32-C6-DevKitC-1
     chip: esp32-c6
-    supports:
+    support:
       user_usb: wip
       wifi: wip
       ethernet_over_usb: wip

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -73,8 +73,9 @@ chips:
       gpio:
         status: being_reworked
         github_pr: 322
-      logging: wip
       debug_output: supported
+      logging: wip
+      wifi: not_available
 
   esp32-c6:
     name: ESP32-C6
@@ -82,10 +83,11 @@ chips:
       gpio:
         status: being_reworked
         github_pr: 322
+      debug_output: supported
       logging:
         status: supported
         github_pr: 255
-      debug_output: supported
+      wifi: not_available
 
 # Encodes support status for each board.
 # Boards inherit support statuses of their chip, but can also override them.
@@ -102,14 +104,12 @@ boards:
     chip: nrf53xx
     support:
       user_usb: supported
-      wifi: not_available
       ethernet_over_usb: supported
 
   rp-pico:
     name: Raspberry Pi Pico
     chip: rp2040
     support:
-      wifi: not_available
       user_usb: supported
       ethernet_over_usb: supported
 

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -2,25 +2,25 @@
 
 # Defines the different support statuses.
 support_keys:
-  supported:
+  - name: supported
     icon: ✅
     description: supported
-  supported_with_caveats:
+  - name: supported_with_caveats
     icon: ⚠️
     description: supported with some caveats
-  needs_testing:
+  - name: needs_testing
     icon: ❔
     description: needs testing; support may be present but we do not currently test it
-  being_reworked:
+  - name: being_reworked
     icon: ♻️
     description: rework in progress, expect breaking changes
-  wip:
+  - name: wip
     icon: 🚧
     description: work in progress
-  not_currently_supported:
+  - name: not_currently_supported
     icon: ❌
     description: available in hardware, but not currently supported by RIOT-rs
-  not_available:
+  - name: not_available
     icon: 🚫
     description: not available on this piece of hardware
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This introduces a structured data file encoding current hardware and functionality support across supported chips and boards, along with a [Cargo script](https://github.com/rust-lang/cargo/issues/12207) generating HTML from this structured data. The generated HTML is written to a file which is imported into the book, providing comprehensive support information for potential users. That HTML file must be re-generated when the structured data file is updated, but a CI lint check makes sure that this HTML file is always up to date.

This support table covers hardware support as well as software/configuration support.

## Limitations

This is mostly meant to bootstrap this compatibility table and support information definitely incomplete. It must still reflect the current state of support at the time of merge.

@kaspar030 Can you check the current state of debug output and logging, and the current ESP32 support?
@kaspar030 @elenaf9 If threading needs to be added to this table, please do so in a follow-up PR.
@chrysn Could you add HWRNG to this table in a follow-up PR?

---

- The structured data file must currently be manually updated. Ideally we would leverage support information already encoded in the laze configuration to validate/invalidate that file.
- This could also benefit from later introduced an intermediate level between chips and boards, e.g., `chip_families`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
N/A

## Open Questions

<!-- Unresolved questions, if any. -->
None

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
