### PR TITLE
feat(examples): add `usb-serial` example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4177,6 +4177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
 
 [[package]]
+name = "usb-serial"
+version = "0.1.0"
+dependencies = [
+ "embassy-executor",
+ "embassy-time",
+ "riot-rs",
+ "riot-rs-boards",
+]
+
+[[package]]
 name = "usbd-hid"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -18,3 +18,4 @@ subdirs:
   - random
   - threading
   - threading-channel
+  - usb-serial

--- a/examples/usb-serial/Cargo.toml
+++ b/examples/usb-serial/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "usb-serial"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+embassy-executor = { workspace = true, default-features = false }
+embassy-time = { workspace = true, default-features = false }
+riot-rs = { path = "../../src/riot-rs", features = [
+  "usb",
+  "override-usb-config",
+] }
+riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/usb-serial/README.md
+++ b/examples/usb-serial/README.md
@@ -1,0 +1,16 @@
+# usb-serial
+
+## About
+
+This application is showing basic
+[Embassy](https://github.com/embassy-rs/embassy) _USB serial_ usage with RIOT-rs.
+
+## How to run
+
+In this folder, run
+
+    laze build -b nrf52840dk run
+
+With the device USB cable connected, a USB ACM serial port should show up on
+your laptop / workstation.
+It will simply echo every sent character.

--- a/examples/usb-serial/laze.yml
+++ b/examples/usb-serial/laze.yml
@@ -1,0 +1,5 @@
+apps:
+  - name: usb-serial
+    selects:
+      - hw/usb-device-port
+      - ?release

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -1,0 +1,75 @@
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::{
+    debug::log::info,
+    embassy::{
+        embassy_usb, make_static,
+        usb::{UsbBuilderHook, UsbDriver},
+    },
+};
+
+use embassy_usb::{
+    class::cdc_acm::{CdcAcmClass, State},
+    driver::EndpointError,
+};
+
+#[riot_rs::config(usb)]
+fn usb_config() -> embassy_usb::Config<'static> {
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("RIOT-rs");
+    config.product = Some("USB serial example");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    // Required for Windows support.
+    config.composite_with_iads = true;
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config
+}
+
+#[riot_rs::task(autostart, usb_builder_hook)]
+async fn main() {
+    info!("Hello World!");
+
+    let state = make_static!(State::new());
+
+    // Inject class on the system USB builder.
+    let mut class = USB_BUILDER_HOOK
+        .with(|builder| CdcAcmClass::new(builder, state, 64))
+        .await;
+
+    // Do stuff with the class!
+    loop {
+        class.wait_connection().await;
+        info!("Connected");
+        let _ = echo(&mut class).await;
+        info!("Disconnected");
+    }
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn echo(class: &mut CdcAcmClass<'static, UsbDriver>) -> Result<(), Disconnected> {
+    let mut buf = [0; 64];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        let data = &buf[..n];
+        info!("data: {:x}", data);
+        class.write_packet(data).await?;
+    }
+}


### PR DESCRIPTION
# Description

This adds a usb serial example.
It is basically a port of one of Embassy's [examples](https://github.com/embassy-rs/embassy/blob/main/examples/stm32h7/src/bin/usb_serial.rs).

I tested that it works, with Linux as host, on nrf52840dk, rpi-pico and two stm32 (which are not in main yet).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
