### PR TITLE
feat(net): wrap network stack in a `OnceLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ name = "embassy"
 version = "0.1.0"
 dependencies = [
  "embassy-executor",
- "embassy-sync 0.5.0",
+ "embassy-sync 0.6.0",
  "embassy-time",
  "riot-rs",
  "riot-rs-boards",
@@ -1068,7 +1068,7 @@ dependencies = [
  "embassy-executor",
  "embassy-net",
  "embassy-nrf",
- "embassy-sync 0.5.0",
+ "embassy-sync 0.6.0",
  "embassy-time",
  "embedded-io-async",
  "heapless 0.8.0",
@@ -1244,8 +1244,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e0c49ff02ebe324faf3a8653ba91582e2d0a7fdef5bc88f449d5aa1bfcc05c"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-240605#584940fc7ea02fe184f3ae346ecaa3d00008c95e"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1317,7 +1316,7 @@ version = "0.1.0"
 dependencies = [
  "embassy-executor",
  "embassy-nrf",
- "embassy-sync 0.5.0",
+ "embassy-sync 0.6.0",
  "embassy-time",
  "embassy-usb",
  "riot-rs",
@@ -3388,7 +3387,7 @@ dependencies = [
  "embassy-net-driver-channel",
  "embassy-nrf",
  "embassy-rp",
- "embassy-sync 0.5.0",
+ "embassy-sync 0.6.0",
  "embassy-time",
  "embassy-usb",
  "esp-hal",
@@ -3425,7 +3424,7 @@ dependencies = [
 name = "riot-rs-random"
 version = "0.1.0"
 dependencies = [
- "embassy-sync 0.5.0",
+ "embassy-sync 0.6.0",
  "rand_chacha",
  "rand_core",
  "rand_pcg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ embassy-net = { version = "0.4", default-features = false }
 embassy-net-driver-channel = { version = "0.2.0", default-features = false }
 embassy-nrf = { version = "0.1", default-features = false }
 embassy-rp = { version = "0.1", default-features = false }
-embassy-sync = { version = "0.5", default-features = false }
+embassy-sync = { version = "0.6", default-features = false }
 embassy-time = { version = "0.3", default-features = false }
 embassy-usb = { version = "0.1", default-features = false }
 
@@ -96,6 +96,7 @@ embassy-net = { git = "https://github.com/kaspar030/embassy", branch = "for-riot
 embassy-rp = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-240605" }
 embassy-net-driver = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-240605" }
 embassy-net-driver-channel = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-240605" }
+embassy-sync = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-240605" }
 embassy-time-driver = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-240605" }
 embassy-time-queue-driver = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-240605" }
 embassy-usb-driver = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-240605" }

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -265,10 +265,7 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
 
         spawner.spawn(network::net_task(stack)).unwrap();
 
-        if STACK
-            .lock(|c| c.set(SendCell::new(stack, spawner)))
-            .is_err()
-        {
+        if STACK.init(SendCell::new(stack, spawner)).is_err() {
             unreachable!();
         }
     }


### PR DESCRIPTION
# Description

This PR wraps the network stack in a `OnceCell`. Without this, if tasks call `network_stack()` before `STACK` has been initialized will just panic, e.g., on `rpi-pico-w` where the wifi initialization is not finished before the first tasks get to run.

The PR also bumps the used version of `embassy-sync` to 0.6 from our fork. We were previously using the crates-io released 05, which does not yet include `OnceLock`.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

First encountered in #146.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
