### PR TITLE
fix(task-macro): make the `riot_rs::task` macro work with no parameters

### DIFF
--- a/src/riot-rs-macros/src/task.rs
+++ b/src/riot-rs-macros/src/task.rs
@@ -20,7 +20,7 @@
 ///         of type `UsbBuilderHook`, allowing to access and modify the system-provided
 ///         `embassy_usb::Builder` through `Delegate::with()`, *before* it is built by the system.
 /// - `pool_size`: (*optional*) set the maximum number of concurrent tasks that can be spawned for
-///     the function.
+///     the function (defaults to `1`).
 ///     Cannot be used on `autostart` tasks.
 ///
 /// # Examples
@@ -111,7 +111,7 @@ pub fn task(args: TokenStream, item: TokenStream) -> TokenStream {
             #task_function
         }
     } else {
-        let pool_size = attrs.pool_size;
+        let pool_size = attrs.pool_size.unwrap_or_else(|| syn::parse_quote! { 1 });
 
         quote! {
             #[#riot_rs_crate::embassy::embassy_executor::task(pool_size = #pool_size)]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The pool size was always specified in the Embassy `task` macro, in the generation code, but when the `autostart` and the `pool_size` parameters were not specified to the `riot_rs::task` macro, the pool size expression passed to that underlying Embassy task macro was a `None`, making the compilation fail with a syntax error in the generated code.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #352

## Open Questions

<!-- Unresolved questions, if any. -->
None

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
