### PR TITLE
feat: default defmt logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
+ "defmt",
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,6 +3432,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "cortex-m",
+ "defmt",
 ]
 
 [[package]]

--- a/examples/benchmark/src/main.rs
+++ b/examples/benchmark/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::debug::println;
+use riot_rs::debug::log::*;
 
 #[riot_rs::thread(autostart)]
 fn main() {
@@ -12,10 +12,10 @@ fn main() {
         // Consider using `core::hint::black_box()` where necessary.
     }) {
         Ok(ticks) => {
-            println!("took {} per iteration", ticks);
+            info!("took {} per iteration", ticks);
         }
         Err(err) => {
-            println!("benchmark returned error: {}", err);
+            info!("benchmark returned error: {}", err);
         }
     }
 }

--- a/examples/core-sizes/src/main.rs
+++ b/examples/core-sizes/src/main.rs
@@ -3,15 +3,15 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::debug::{exit, println, EXIT_SUCCESS};
+use riot_rs::debug::{exit, log::*, EXIT_SUCCESS};
 
 #[riot_rs::thread(autostart)]
 fn main() {
-    println!(
+    info!(
         "riot_rs::thread::lock::Lock: {}",
         core::mem::size_of::<riot_rs::thread::lock::Lock>(),
     );
-    println!(
+    info!(
         "riot_rs::thread::Thread: {}",
         riot_rs::thread::thread_struct_size()
     );

--- a/examples/embassy-http-server/Cargo.toml
+++ b/examples/embassy-http-server/Cargo.toml
@@ -10,7 +10,7 @@ embassy-executor = { workspace = true, default-features = false }
 embassy-net = { workspace = true, features = ["tcp"] }
 embassy-sync = { workspace = true }
 embassy-time = { workspace = true, default-features = false }
-embedded-io-async = "0.6.0"
+embedded-io-async = { version = "0.6.0", features = ["defmt-03"] }
 heapless = { workspace = true }
 httparse = { version = "1.8.0", default-features = false }
 picoserve = { version = "0.8.0", default-features = false, features = [

--- a/examples/embassy-http-server/src/main.rs
+++ b/examples/embassy-http-server/src/main.rs
@@ -7,13 +7,13 @@ mod pins;
 mod routes;
 
 use riot_rs::{
-    debug::println,
+    debug::log::*,
     embassy::{network, Spawner},
 };
 
 use embassy_net::tcp::TcpSocket;
 use embassy_time::Duration;
-use picoserve::routing::get;
+use picoserve::{io::Error, routing::get};
 use static_cell::make_static;
 
 #[cfg(feature = "button-readings")]
@@ -65,24 +65,24 @@ async fn web_task(
     loop {
         let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
 
-        println!("{}: Listening on TCP:80...", id);
+        info!("{}: Listening on TCP:80...", id);
         if let Err(e) = socket.accept(80).await {
-            println!("{}: accept error: {:?}", id, e);
+            info!("{}: accept error: {:?}", id, e);
             continue;
         }
 
         let remote_endpoint = socket.remote_endpoint();
 
-        println!("{}: Received connection from {:?}", id, remote_endpoint);
+        info!("{}: Received connection from {:?}", id, remote_endpoint);
 
         match picoserve::serve_with_state(app, config, &mut [0; 2048], socket, &state).await {
             Ok(handled_requests_count) => {
-                println!(
+                info!(
                     "{} requests handled from {:?}",
                     handled_requests_count, remote_endpoint,
                 );
             }
-            Err(err) => println!("{:?}", err),
+            Err(err) => info!("{:?}", err.kind()),
         }
     }
 }

--- a/examples/embassy-net-tcp/src/main.rs
+++ b/examples/embassy-net-tcp/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::{debug::println, embassy::network};
+use riot_rs::{debug::log::*, embassy::network};
 
 use embedded_io_async::Write;
 
@@ -20,33 +20,33 @@ async fn tcp_echo() {
         let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 
-        println!("Listening on TCP:1234...");
+        info!("Listening on TCP:1234...");
         if let Err(e) = socket.accept(1234).await {
-            println!("accept error: {:?}", e);
+            info!("accept error: {:?}", e);
             continue;
         }
 
-        println!("Received connection from {:?}", socket.remote_endpoint());
+        info!("Received connection from {:?}", socket.remote_endpoint());
 
         loop {
             let n = match socket.read(&mut buf).await {
                 Ok(0) => {
-                    println!("read EOF");
+                    info!("read EOF");
                     break;
                 }
                 Ok(n) => n,
                 Err(e) => {
-                    println!("read error: {:?}", e);
+                    info!("read error: {:?}", e);
                     break;
                 }
             };
 
-            //println!("rxd {:02x}", &buf[..n]);
+            //info!("rxd {:02x}", &buf[..n]);
 
             match socket.write_all(&buf[..n]).await {
                 Ok(()) => {}
                 Err(e) => {
-                    println!("write error: {:?}", e);
+                    info!("write error: {:?}", e);
                     break;
                 }
             };

--- a/examples/embassy-net-udp/src/main.rs
+++ b/examples/embassy-net-udp/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::{debug::println, embassy::network};
+use riot_rs::{debug::log::*, embassy::network};
 
 #[riot_rs::task(autostart)]
 async fn udp_echo() {
@@ -25,33 +25,33 @@ async fn udp_echo() {
             &mut tx_buffer,
         );
 
-        println!("Listening on UDP:1234...");
+        info!("Listening on UDP:1234...");
         if let Err(e) = socket.bind(1234) {
-            println!("bind error: {:?}", e);
+            info!("bind error: {:?}", e);
             continue;
         }
 
         loop {
             let (n, remote_endpoint) = match socket.recv_from(&mut buf).await {
                 Ok((0, _)) => {
-                    println!("read EOF");
+                    info!("read EOF");
                     break;
                 }
                 Ok((n, remote_endpoint)) => (n, remote_endpoint),
                 Err(e) => {
-                    println!("read error: {:?}", e);
+                    info!("read error: {:?}", e);
                     break;
                 }
             };
 
-            println!("Received datagram from {:?}", remote_endpoint);
+            info!("Received datagram from {:?}", remote_endpoint);
 
-            //println!("rxd {:02x}", &buf[..n]);
+            //info!("rxd {:02x}", &buf[..n]);
 
             match socket.send_to(&buf[..n], remote_endpoint).await {
                 Ok(()) => {}
                 Err(e) => {
-                    println!("write error: {:?}", e);
+                    info!("write error: {:?}", e);
                     break;
                 }
             };

--- a/examples/embassy-usb-keyboard/src/main.rs
+++ b/examples/embassy-usb-keyboard/src/main.rs
@@ -6,7 +6,7 @@
 use embassy_time::Duration;
 use embassy_usb::class::hid::{self, HidReaderWriter};
 use riot_rs::{
-    debug::println,
+    debug::log::*,
     embassy::{
         make_static,
         usb::{UsbBuilderHook, UsbDriver},
@@ -38,15 +38,15 @@ async fn usb_keyboard(button_peripherals: pins::Buttons) {
     loop {
         for (i, button) in buttons.get_mut().iter_mut().enumerate() {
             if button.is_pressed() {
-                println!("Button #{} pressed", i + 1);
+                info!("Button #{} pressed", i + 1);
 
                 let report = keyboard_report(KEYCODE_MAPPING[i]);
                 if let Err(e) = hid_writer.write_serialize(&report).await {
-                    println!("Failed to send report: {:?}", e);
+                    info!("Failed to send report: {:?}", e);
                 }
                 let report = keyboard_report(KEY_RELEASED);
                 if let Err(e) = hid_writer.write_serialize(&report).await {
-                    println!("Failed to send report: {:?}", e);
+                    info!("Failed to send report: {:?}", e);
                 }
             }
         }

--- a/examples/embassy/src/main.rs
+++ b/examples/embassy/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::debug::{exit, println};
+use riot_rs::debug::{exit, log::*};
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use riot_rs::embassy::{blocker, EXECUTOR};
@@ -16,10 +16,10 @@ async fn async_task() {
     let mut counter = 0u32;
     loop {
         if counter % 2 == 0 {
-            println!("async_task() signalling");
+            info!("async_task() signalling");
             SIGNAL.signal(counter);
         } else {
-            println!("async_task()");
+            info!("async_task()");
         }
         Timer::after(Duration::from_ticks(TICK_HZ / 10)).await;
         counter += 1;
@@ -30,7 +30,7 @@ async fn async_task() {
 fn main() {
     use embassy_time::Instant;
 
-    println!(
+    info!(
         "Hello from main()! Running on a {} board.",
         riot_rs::buildinfo::BOARD,
     );
@@ -40,7 +40,7 @@ fn main() {
 
     for _ in 0..10 {
         let val = blocker::block_on(SIGNAL.wait());
-        println!(
+        info!(
             "now={}ms threadtest() val={}",
             Instant::now().as_millis(),
             val,

--- a/examples/hello-world-async/src/main.rs
+++ b/examples/hello-world-async/src/main.rs
@@ -3,9 +3,9 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::debug::println;
+use riot_rs::debug::log::*;
 
 #[riot_rs::task(autostart)]
 async fn main() {
-    println!("Hello World!");
+    info!("Hello World!");
 }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -3,11 +3,11 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::debug::{exit, println};
+use riot_rs::debug::{exit, log::*};
 
 #[riot_rs::thread(autostart)]
 fn main() {
-    println!(
+    info!(
         "Hello from main()! Running on a {} board.",
         riot_rs::buildinfo::BOARD,
     );

--- a/examples/random/src/main.rs
+++ b/examples/random/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::debug::println;
+use riot_rs::debug::log::*;
 
 #[riot_rs::thread(autostart)]
 fn main() {
@@ -12,5 +12,5 @@ fn main() {
 
     let value = rng.gen_range(1..=6);
 
-    println!("The random value of this round is {}.", value);
+    info!("The random value of this round is {}.", value);
 }

--- a/examples/threading-channel/src/main.rs
+++ b/examples/threading-channel/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::debug::println;
+use riot_rs::debug::log::*;
 use riot_rs::thread::channel::Channel;
 
 static CHANNEL: Channel<u8> = Channel::new();
@@ -11,16 +11,16 @@ static CHANNEL: Channel<u8> = Channel::new();
 #[riot_rs::thread(autostart)]
 fn thread0() {
     let my_id = riot_rs::thread::current_pid().unwrap();
-    println!("[Thread {:?}] Sending a message...", my_id);
+    info!("[Thread {:?}] Sending a message...", my_id);
     CHANNEL.send(&42);
 }
 
 #[riot_rs::thread(autostart, stacksize = 4096, priority = 2)]
 fn thread1() {
     let my_id = riot_rs::thread::current_pid().unwrap();
-    println!("[Thread {:?}] Waiting to receive a message...", my_id);
+    info!("[Thread {:?}] Waiting to receive a message...", my_id);
     let recv = CHANNEL.recv();
-    println!(
+    info!(
         "[Thread {:?}] The answer to the Ultimate Question of Life, the Universe, and Everything is: {:?}.",
         my_id,
         recv

--- a/examples/threading/src/main.rs
+++ b/examples/threading/src/main.rs
@@ -3,15 +3,15 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::debug::println;
+use riot_rs::debug::log::*;
 
 #[riot_rs::thread(autostart)]
 fn thread0() {
-    println!("Hello from thread 0");
+    info!("Hello from thread 0");
 }
 
 // `stacksize` and `priority` can be arbitrary expressions.
 #[riot_rs::thread(autostart, stacksize = 4096, priority = 2)]
 fn thread1() {
-    println!("Hello from thread 1");
+    info!("Hello from thread 1");
 }

--- a/src/riot-rs-bench/Cargo.toml
+++ b/src/riot-rs-bench/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 cfg-if = { workspace = true }
+defmt = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 cortex-m = { workspace = true, features = ["critical-section-single-core"] }

--- a/src/riot-rs-bench/src/lib.rs
+++ b/src/riot-rs-bench/src/lib.rs
@@ -39,6 +39,7 @@ pub use bench::benchmark;
 
 /// Possible errors happening when benchmarking.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// The system timer wrapped when benchmarking.
     SystemTimerWrapped,

--- a/src/riot-rs-boards/ai-c3/src/lib.rs
+++ b/src/riot-rs-boards/ai-c3/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("ai-c3::init()");
+    debug!("ai-c3::init()");
 }

--- a/src/riot-rs-boards/dwm1001/src/lib.rs
+++ b/src/riot-rs-boards/dwm1001/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("dwm1001::init()");
+    debug!("dwm1001::init()");
     nrf52::init();
 }

--- a/src/riot-rs-boards/espressif-esp32-c6-devkitc-1/src/lib.rs
+++ b/src/riot-rs-boards/espressif-esp32-c6-devkitc-1/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("espressif-esp32-c6-devkitc-1::init()");
+    debug!("espressif-esp32-c6-devkitc-1::init()");
 }

--- a/src/riot-rs-boards/microbit-v2/src/lib.rs
+++ b/src/riot-rs-boards/microbit-v2/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("microbit_v2::init()");
+    debug!("microbit_v2::init()");
     nrf52::init();
 }

--- a/src/riot-rs-boards/microbit/src/lib.rs
+++ b/src/riot-rs-boards/microbit/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("microbit::init()");
+    debug!("microbit::init()");
     nrf51::init();
 }

--- a/src/riot-rs-boards/nrf51/src/lib.rs
+++ b/src/riot-rs-boards/nrf51/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("nrf51::init()");
+    debug!("nrf51::init()");
 }

--- a/src/riot-rs-boards/nrf52/src/lib.rs
+++ b/src/riot-rs-boards/nrf52/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("nrf52::init()");
+    debug!("nrf52::init()");
 }

--- a/src/riot-rs-boards/nrf52840-mdk/src/lib.rs
+++ b/src/riot-rs-boards/nrf52840-mdk/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("nrf52840-mdk::init()");
+    debug!("nrf52840-mdk::init()");
     nrf52::init();
 }

--- a/src/riot-rs-boards/nrf52840dk/src/lib.rs
+++ b/src/riot-rs-boards/nrf52840dk/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("nrf52840dk::init()");
+    debug!("nrf52840dk::init()");
     nrf52::init();
 }

--- a/src/riot-rs-boards/nrf52dk/src/lib.rs
+++ b/src/riot-rs-boards/nrf52dk/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("nrf52dk::init()");
+    debug!("nrf52dk::init()");
     nrf52::init();
 }

--- a/src/riot-rs-boards/nrf5340/src/lib.rs
+++ b/src/riot-rs-boards/nrf5340/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("nrf5340::init()");
+    debug!("nrf5340::init()");
 }

--- a/src/riot-rs-boards/nrf5340dk/src/lib.rs
+++ b/src/riot-rs-boards/nrf5340dk/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("nrf5340dk::init()");
+    debug!("nrf5340dk::init()");
     nrf5340::init();
 }

--- a/src/riot-rs-boards/particle-xenon/src/lib.rs
+++ b/src/riot-rs-boards/particle-xenon/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("particle_xenon::init()");
+    debug!("particle_xenon::init()");
     nrf52::init();
 }

--- a/src/riot-rs-boards/rpi-pico/src/lib.rs
+++ b/src/riot-rs-boards/rpi-pico/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 pub fn init() {
-    println!("rpi-pico::init()");
+    debug!("rpi-pico::init()");
 }

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -41,6 +41,7 @@ cyw43-pio = { version = "0.1.0", features = ["overclock"], optional = true }
 
 # listed here for conditional feature selection
 embassy-nrf = { workspace = true, default-features = false, optional = true }
+embassy-rp = { workspace = true, default-features = false, optional = true }
 embassy-stm32 = { workspace = true, default-features = false, optional = true }
 esp-hal = { workspace = true, default-features = false, optional = true }
 esp-hal-embassy = { workspace = true, default-features = false, optional = true }
@@ -146,6 +147,7 @@ executor-none = []
 defmt = [
   "embassy-net?/defmt",
   "embassy-nrf?/defmt",
+  "embassy-rp?/defmt",
   "embassy-stm32?/defmt",
   "embassy-time?/defmt",
   "embassy-usb?/defmt",

--- a/src/riot-rs-embassy/src/arch/esp/mod.rs
+++ b/src/riot-rs-embassy/src/arch/esp/mod.rs
@@ -17,7 +17,7 @@ pub fn init() -> OptionalPeripherals {
         use esp_hal::{rng::Rng, timer::systimer::SystemTimer};
         use esp_wifi::{initialize, EspWifiInitFor};
 
-        riot_rs_debug::println!("riot-rs-embassy::arch::esp::init(): wifi");
+        riot_rs_debug::log::debug!("riot-rs-embassy::arch::esp::init(): wifi");
 
         let timer = SystemTimer::new(peripherals.SYSTIMER.take().unwrap());
 

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -39,7 +39,7 @@ pub mod network;
 #[cfg(feature = "wifi")]
 mod wifi;
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::debug;
 
 // re-exports
 pub use linkme::{self, distributed_slice};
@@ -96,7 +96,7 @@ pub static EXECUTOR: arch::Executor = arch::Executor::new();
 #[cfg(feature = "executor-interrupt")]
 #[distributed_slice(riot_rs_rt::INIT_FUNCS)]
 pub(crate) fn init() {
-    println!("riot-rs-embassy::init(): using interrupt mode executor");
+    debug!("riot-rs-embassy::init(): using interrupt mode executor");
     let p = arch::init();
 
     #[cfg(any(context = "nrf", context = "rp2040", context = "stm32"))]
@@ -112,7 +112,7 @@ pub(crate) fn init() {
 #[cfg(feature = "executor-single-thread")]
 #[export_name = "riot_rs_embassy_init"]
 fn init() -> ! {
-    println!("riot-rs-embassy::init(): using single thread executor");
+    debug!("riot-rs-embassy::init(): using single thread executor");
     let p = arch::init();
 
     let executor = make_static!(arch::Executor::new());
@@ -137,7 +137,7 @@ mod executor_thread {
 #[cfg(feature = "executor-thread")]
 #[riot_rs_macros::thread(autostart, stacksize = executor_thread::STACKSIZE, priority = executor_thread::PRIORITY)]
 fn init() {
-    println!("riot-rs-embassy::init(): using thread executor");
+    debug!("riot-rs-embassy::init(): using thread executor");
     let p = arch::init();
 
     let executor = make_static!(thread_executor::Executor::new());
@@ -146,7 +146,7 @@ fn init() {
 
 #[embassy_executor::task]
 async fn init_task(mut peripherals: arch::OptionalPeripherals) {
-    println!("riot-rs-embassy::init_task()");
+    debug!("riot-rs-embassy::init_task()");
 
     #[cfg(feature = "hwrng")]
     arch::hwrng::construct_rng(&mut peripherals);
@@ -158,7 +158,7 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
         // nrf52840
         let clock: embassy_nrf::pac::CLOCK = unsafe { core::mem::transmute(()) };
 
-        println!("nrf: enabling ext hfosc...");
+        debug!("nrf: enabling ext hfosc...");
         clock.tasks_hfclkstart.write(|w| unsafe { w.bits(1) });
         while clock.events_hfclkstarted.read().bits() != 1 {}
     }
@@ -281,5 +281,5 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
     // mark used
     let _ = peripherals;
 
-    println!("riot-rs-embassy::init_task() done");
+    debug!("riot-rs-embassy::init_task() done");
 }

--- a/src/riot-rs-embassy/src/wifi/cyw43.rs
+++ b/src/riot-rs-embassy/src/wifi/cyw43.rs
@@ -7,7 +7,7 @@ use embassy_rp::{
     pio::Pio,
 };
 
-use riot_rs_debug::println;
+use riot_rs_debug::log::info;
 
 use self::rpi_pico_w::{Cyw43Periphs, CywSpi, Irqs};
 use crate::{arch::OptionalPeripherals, make_static};
@@ -21,9 +21,12 @@ pub async fn join(mut control: cyw43::Control<'static>) {
             .join_wpa2(crate::wifi::WIFI_NETWORK, crate::wifi::WIFI_PASSWORD)
             .await
         {
-            Ok(_) => break,
+            Ok(_) => {
+                info!("Wifi connected!");
+                break;
+            }
             Err(err) => {
-                println!("join failed with status={}", err.status);
+                info!(" Wifi join failed with status={}", err.status);
             }
         }
     }

--- a/src/riot-rs-rt/src/cortexm.rs
+++ b/src/riot-rs-rt/src/cortexm.rs
@@ -173,10 +173,8 @@ unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
 unsafe fn DefaultHandler(_irqn: i16) {
     #[cfg(not(feature = "silent-panic"))]
     {
-        use riot_rs_debug::{exit, println, EXIT_FAILURE};
-
-        println!("IRQn = {}", _irqn);
-        exit(EXIT_FAILURE);
+        riot_rs_debug::log::debug!("IRQn = {}", _irqn);
+        riot_rs_debug::exit(riot_rs_debug::EXIT_FAILURE);
     }
     #[allow(clippy::empty_loop)]
     loop {}

--- a/src/riot-rs-rt/src/lib.rs
+++ b/src/riot-rs-rt/src/lib.rs
@@ -16,7 +16,7 @@ pub mod testing;
 #[cfg(feature = "threading")]
 mod threading;
 
-use riot_rs_debug::println;
+use riot_rs_debug::{log::debug, println};
 
 cfg_if::cfg_if! {
     if #[cfg(context = "cortex-m")] {
@@ -71,7 +71,7 @@ fn startup() -> ! {
     #[cfg(feature = "debug-console")]
     riot_rs_debug::init();
 
-    println!("riot_rs_rt::startup()");
+    debug!("riot_rs_rt::startup()");
 
     for f in INIT_FUNCS {
         f();
@@ -90,7 +90,7 @@ fn startup() -> ! {
         extern "Rust" {
             fn riot_rs_embassy_init() -> !;
         }
-        println!("riot_rs_rt::startup() launching single thread executor");
+        debug!("riot_rs_rt::startup() launching single thread executor");
         unsafe { riot_rs_embassy_init() };
     }
 

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -76,6 +76,7 @@ defmt = [
   "riot-rs-debug/defmt",
   "riot-rs-embassy/defmt",
   "riot-rs-threads?/defmt",
+  "riot-rs-bench?/defmt",
 ]
 ## Enables benchmarking facilities.
 bench = ["dep:riot-rs-bench"]


### PR DESCRIPTION
# Description

We've agreed that we want to use defmt per default for all logging. This PR now changes all our internal `println!` statements to `log::debug!`, and the examples to `log::info!`.

Concerning the logging level, I think `debug` for all internal stuff makes the most sense, given that they are in fact only relevant for debugging.
The only exception is in `esp_wifi`, where I think `info!` makes sense when we connect/ fail to connect to the wifi. Ideally we'd also have them for `cyw43`, but that's out of scope for this PR.

## Issues/PRs references

Discussed in https://github.com/future-proof-iot/RIOT-rs/pull/349#issuecomment-2214080602.

## Open Questions

- I've enabled the `defmt` module in laze per default for `release`. Do you agree that this makes sense?
- I also wanted to default the `DEFMT_LOG` env to `info` in laze,but somehow it didn't work when I added it as global env to the `defmt` module. Any idea why?

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation. _Will change it if you agree that the defmt module should be selected per default._
