### PR TITLE
handle log level with laze, enable defmt with info log level by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
  "clang-sys",
  "lazy_static",
  "lazycell",
- "log",
+ "log 0.4.21",
  "peeking_take_while",
  "proc-macro2",
  "quote",
@@ -307,7 +307,7 @@ dependencies = [
  "clap",
  "heck 0.4.1",
  "indexmap 1.9.3",
- "log",
+ "log 0.4.21",
  "proc-macro2",
  "quote",
  "serde",
@@ -1572,7 +1572,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
- "log",
+ "log 0.4.21",
 ]
 
 [[package]]
@@ -1759,7 +1759,7 @@ checksum = "e98f0f58453dd2ce08d99228fc8757fad39d05dfd26643665d1093b8844f42cc"
 dependencies = [
  "critical-section",
  "defmt",
- "log",
+ "log 0.4.21",
 ]
 
 [[package]]
@@ -2598,6 +2598,15 @@ dependencies = [
 
 [[package]]
 name = "log"
+version = "0.1.0"
+dependencies = [
+ "embassy-executor",
+ "riot-rs",
+ "riot-rs-boards",
+]
+
+[[package]]
+name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
@@ -3096,7 +3105,7 @@ dependencies = [
  "futures-util",
  "heapless 0.8.0",
  "lhash",
- "log",
+ "log 0.4.21",
  "ryu",
  "serde",
 ]
@@ -3464,7 +3473,7 @@ dependencies = [
  "defmt",
  "defmt-rtt-target",
  "esp-println",
- "log",
+ "log 0.4.21",
  "rtt-target 0.5.0",
 ]
 
@@ -4389,7 +4398,7 @@ source = "git+https://github.com/twitchyliquid64/usbd-hid?rev=76bea16537e1a347df
 dependencies = [
  "byteorder",
  "hashbrown 0.13.2",
- "log",
+ "log 0.4.21",
  "proc-macro2",
  "quote",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,7 +2386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64eb682691d02609ff036a7416373edbc7cc769b0908bf2489af79461453669e"
 dependencies = [
  "lakers-shared",
- "log",
+ "log 0.4.21",
 ]
 
 [[package]]
@@ -2411,7 +2411,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcdc5a0e1a5ea0387ab3e334f2061c633001db79e04d40af65bc68b41b13ef3a"
 dependencies = [
- "log",
+ "log 0.4.21",
 ]
 
 [[package]]

--- a/book/src/tooling/defmt.md
+++ b/book/src/tooling/defmt.md
@@ -1,14 +1,16 @@
 # defmt
 
-RIOT-rs supports [defmt] on all platforms.
-To enable it, enable the laze module `defmt`, either on the laze command line or
-in a laze file. Don't forget to set the `DEFMT_LOG` variable, it defaults to `error`.
+RIOT-rs supports [defmt] on all platforms. It is enabled by default.
+
 See the [defmt documentation] for general info on `defmt`.
+
+In RIOT-rs, the log level defaults to `info`. It can be configured using the
+laze variable `LOG`.
 
 Example:
 
 ```shell
-# DEFMT_LOG=info laze build -C examples/hello-world-async --builders nrf52840dk --select defmt run
+# laze build -C examples/log --builders nrf52840dk -DLOG=warn run
 ```
 
 Then within Rust code, import `riot_rs::debug::log` items, then use `defmt` log

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -14,6 +14,7 @@ subdirs:
   - embassy-usb-keyboard
   - hello-world
   - hello-world-async
+  - log
   - minimal
   - random
   - threading

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "log"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+riot-rs = { path = "../../src/riot-rs" }
+riot-rs-boards = { path = "../../src/riot-rs-boards" }
+
+embassy-executor = { workspace = true, default-features = false }

--- a/examples/log/README.md
+++ b/examples/log/README.md
@@ -1,0 +1,11 @@
+# log
+
+## About
+
+This application provides a simple tester for log output of the main application.
+
+## How to run
+
+In this folder, run
+
+    laze build -b nrf52840dk -DLOG+=info -DLOG+=riot_rs_embassy=warn run

--- a/examples/log/laze.yml
+++ b/examples/log/laze.yml
@@ -1,0 +1,5 @@
+apps:
+  - name: log
+    selects:
+      - ?release
+      - defmt

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -1,0 +1,15 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::debug::log::*;
+
+#[riot_rs::task(autostart)]
+async fn main() {
+    defmt::trace!("trace log level enabled");
+    defmt::debug!("debug log level enabled");
+    defmt::info!("info log level enabled");
+    defmt::warn!("warn log level enabled");
+    defmt::error!("error log level enabled (just testing)");
+}

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -9,6 +9,7 @@ contexts:
     parent: default
     selects:
       - executor-default
+      - ?defmt
     env:
       RUSTFLAGS:
         - "-Clink-arg=--nmagic"

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -444,7 +444,7 @@ modules:
           # For some reason, `sccache` makes the build not realize changes to
           # `DEFMT_LOG`. Painful as it is, hard-disable `sccache` here.
           - RUSTC_WRAPPER=""
-          - DEFMT_LOG=${LOG}
+          - DEFMT_LOG=info,${LOG}
 
   - name: silent-panic
     context: riot-rs

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -49,6 +49,8 @@ contexts:
       FEATURES:
         start: --features=
         joiner: ","
+      LOG:
+        joiner: ","
 
       # this prefixes `--protocol=` to `PROBE_RS_PROTOCOL`
       PROBE_RS_PROTOCOL:
@@ -442,6 +444,7 @@ modules:
           # For some reason, `sccache` makes the build not realize changes to
           # `DEFMT_LOG`. Painful as it is, hard-disable `sccache` here.
           - RUSTC_WRAPPER=""
+          - DEFMT_LOG=${LOG}
 
   - name: silent-panic
     context: riot-rs


### PR DESCRIPTION
# Description

~~(I'd like to discuss this)~~

This PR adds handling of `DEFMT_LOG` with laze.

This allows adding filter clauses both in laze files and on the command line, e.g.,

```shell
# laze b -b board -DLOG+=info -DLOG+=riot_rs_embassy=error ...
```

and

```yaml
# conceived laze module
modules:
  - name: usb-trace
    env:
     global:
       LOG:
        - riot_rs_embassy::usb=trace
        - other_crate::some_module=trace
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
