### PR TITLE
feat(CI): add some missing package checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,7 +138,7 @@ jobs:
       - name: clippy
         uses: clechasseur/rs-clippy-check@v3
         with:
-          args: --verbose --locked --features no-boards -p riot-rs -p riot-rs-boards -p riot-rs-chips -p riot-rs-debug -p riot-rs-embassy -p riot-rs-macros -p riot-rs-random -p riot-rs-rt -p riot-rs-utils
+          args: --verbose --locked --features no-boards -p riot-rs -p riot-rs-boards -p riot-rs-chips -p riot-rs-debug -p riot-rs-embassy -p riot-rs-macros -p riot-rs-random -p riot-rs-rt -p riot-rs-threads -p riot-rs-utils
 
       - name: rustdoc
         run: RUSTDOCFLAGS='-D warnings' cargo doc -p riot-rs --features no-boards,bench,threading,random,csprng,hwrng

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
       # TODO: we'll eventually want to enable relevant features
       - name: Run crate tests
         run: |
-            cargo test --no-default-features --features no-boards -p riot-rs -p riot-rs-embassy -p riot-rs-threads -p riot-rs-macros
+            cargo test --no-default-features --features no-boards -p riot-rs -p riot-rs-embassy -p riot-rs-runqueue -p riot-rs-threads -p riot-rs-macros
             cargo test -p rbi -p ringbuffer -p coapcore
 
   lint:


### PR DESCRIPTION
# Description

I noticed that `riot-rs-runqueue` is missing in the CI crate tests, and `riot-rs-runqueue` in the CI clippy check.
This PR adds them.

## Open Questions

Was there are reason why the packages weren't added to the list in these two cases?
