### PR TITLE
fix(laze): add `stm32` to the implementors of `sw/benchmark`

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -625,6 +625,7 @@ modules:
     context:
       - nrf
       - rp
+      - stm32
 
   - name: wifi-esp
     context:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

All supported stm32 are Cortex-M, so they also support the SysTick based benchmark implementation.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
