### PR TITLE
fix(threads): add stm32 wfi bug workaround

### DIFF
--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -172,6 +172,11 @@ unsafe fn sched() -> u128 {
                 Some(pid) => pid,
                 None => {
                     cortex_m::asm::wfi();
+
+                    // see https://cliffle.com/blog/stm32-wfi-bug/
+                    #[cfg(context = "stm32")]
+                    cortex_m::asm::isb();
+
                     // this fence seems necessary, see #310.
                     core::sync::atomic::fence(core::sync::atomic::Ordering::Acquire);
                     return None;


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

Adds a workaround for a nasty stm32 silicon bug.

See https://cliffle.com/blog/stm32-wfi-bug/ for more info.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
