### PR TITLE
chore: inherit workspace lints in every crate

### DIFF
--- a/examples/benchmark/Cargo.toml
+++ b/examples/benchmark/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 riot-rs = { path = "../../src/riot-rs", features = ["bench", "threading"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 embassy-executor = { workspace = true, default-features = false }
 embassy-net = { workspace = true, features = ["udp"] }

--- a/examples/core-sizes/Cargo.toml
+++ b/examples/core-sizes/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/embassy-http-server/Cargo.toml
+++ b/examples/embassy-http-server/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 embassy-executor = { workspace = true, default-features = false }
 embassy-net = { workspace = true, features = ["tcp"] }

--- a/examples/embassy-net-tcp/Cargo.toml
+++ b/examples/embassy-net-tcp/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 embassy-executor = { workspace = true, default-features = false }
 embassy-net = { workspace = true, features = ["tcp"] }

--- a/examples/embassy-net-udp/Cargo.toml
+++ b/examples/embassy-net-udp/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 embassy-executor = { workspace = true, default-features = false }
 embassy-net = { workspace = true, features = ["udp"] }

--- a/examples/embassy-usb-keyboard/Cargo.toml
+++ b/examples/embassy-usb-keyboard/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 embassy-executor = { workspace = true, default-features = false }
 embassy-nrf = { workspace = true, default-features = false }

--- a/examples/embassy/Cargo.toml
+++ b/examples/embassy/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 embassy-executor = { workspace = true, default-features = false }
 embassy-sync = { workspace = true, default-features = false }

--- a/examples/hello-world-async/Cargo.toml
+++ b/examples/hello-world-async/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 riot-rs = { path = "../../src/riot-rs" }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 riot-rs = { path = "../../src/riot-rs" }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2021"
 
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 riot-rs = { path = "../../src/riot-rs" }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/random/Cargo.toml
+++ b/examples/random/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 # Enabling the feature "random" is somewhat redundant with laze.yml's selects:
 # random, but helps with interactive tools.

--- a/examples/threading-channel/Cargo.toml
+++ b/examples/threading-channel/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/threading/Cargo.toml
+++ b/examples/threading/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/usb-serial/Cargo.toml
+++ b/examples/usb-serial/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 embassy-executor = { workspace = true, default-features = false }
 embassy-time = { workspace = true, default-features = false }

--- a/src/lib/clist/Cargo.toml
+++ b/src/lib/clist/Cargo.toml
@@ -8,6 +8,9 @@ homepage = "https://github.com/future-proof-iot/RIOT-rs"
 description = "A hairy circular linked list for no_std environments."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies.memoffset]
 version = "0.6.5"
 features = ["unstable_const"]

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 
 description = "A CoAP stack for embedded devices with built-in OSCORE/EDHOC support"
 
+[lints]
+workspace = true
+
 [dependencies]
 # public
 coap-handler = "0.2.0"

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -615,7 +615,8 @@ impl<'a, H: coap_handler::Handler, L: Write, Crypto: lakers::Crypto> coap_handle
                                 self.log,
                                 "Got credential by value: {:?}..",
                                 &id_cred_i.value.get_slice(0, 5)
-                            );
+                            )
+                            .unwrap();
 
                             cred_i = lakers::CredentialRPK::new(id_cred_i.value)
                                 // FIXME What kind of error do we send here?

--- a/src/lib/rbi/Cargo.toml
+++ b/src/lib/rbi/Cargo.toml
@@ -10,4 +10,7 @@ homepage = "https://github.com/future-proof-iot/RIOT-rs"
 
 description = "A FIFO index queue that can be used for implementing a ring buffer."
 
+[lints]
+workspace = true
+
 [dependencies]

--- a/src/lib/ringbuffer/Cargo.toml
+++ b/src/lib/ringbuffer/Cargo.toml
@@ -6,5 +6,8 @@ license.workspace = true
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 rbi = { path = "../rbi" }

--- a/src/riot-rs-random/Cargo.toml
+++ b/src/riot-rs-random/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 rand_core = "0.6.4"
 
@@ -13,9 +16,6 @@ embassy-sync.workspace = true
 
 rand_pcg = "0.3.1"
 rand_chacha = { version = "0.3.1", default-features = false, optional = true }
-
-[lints]
-workspace = true
 
 [features]
 ## If set, the one global RNG is also a cryptographically secure pseudo

--- a/tests/benchmarks/bench_sched_yield/Cargo.toml
+++ b/tests/benchmarks/bench_sched_yield/Cargo.toml
@@ -6,6 +6,9 @@ license.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 riot-rs = { workspace = true, default-features = true, features = [
   "bench",


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
- This should avoid mistakes which are supposed to be prevented by
workspace lints.
- Fix one lint error found.

**Not all crates are currently checked by clippy, later PRs will add other crates to the list of crates checked by clippy and fix the lint errors found.**

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->
None

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
