### PR TITLE
chore(ci/hax): update github action to hax ref 533f870

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -15,7 +15,7 @@ jobs:
         uses: hacspec/hax-actions@main
         with:
           # pin hax to known-working
-          hax_reference: d10f891a19f96bcafa9e31b1d78763e4f3cf30b4
+          hax_reference: 533f87048f68705e8884ff9516db1371e8a2773d
 
       - name: 🏃 Extract `riot-rs-runqueue`
         working-directory: ./src/riot-rs-runqueue


### PR DESCRIPTION
# Description

Update the pinned hax version in our CI to the most recent hax main (ref 533f87048f68705e8884ff9516db1371e8a2773d). 
Since d10f891a19f96bcafa9e31b1d78763e4f3cf30b4 some features have been added, among them support for the `let else` pattern that is used in #370.

See https://github.com/future-proof-iot/RIOT-rs/pull/370#issuecomment-2268565127.

## Issues/PRs references

Unblocks #370.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have performed a self-review of my own code.
