### PR TITLE
feat(threads): sort `ThreadList` by priority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,6 +4440,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "threading-lock"
+version = "0.1.0"
+dependencies = [
+ "embassy-executor",
+ "portable-atomic",
+ "riot-rs",
+ "riot-rs-boards",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   "tests/gpio",
   "tests/gpio-interrupt-nrf",
   "tests/gpio-interrupt-stm32",
+  "tests/threading-lock",
 ]
 
 exclude = ["src/lib"]

--- a/tests/laze.yml
+++ b/tests/laze.yml
@@ -3,3 +3,4 @@ subdirs:
   - gpio
   - gpio-interrupt-nrf
   - gpio-interrupt-stm32
+  - threading-lock

--- a/tests/threading-lock/Cargo.toml
+++ b/tests/threading-lock/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "threading-lock"
+version = "0.1.0"
+authors = ["Elena Frank <elena.frank@proton.me>"]
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+embassy-executor = { workspace = true }
+riot-rs = { path = "../../src/riot-rs", features = ["threading", "time"] }
+riot-rs-boards = { path = "../../src/riot-rs-boards" }
+portable-atomic = "1.6.0"

--- a/tests/threading-lock/laze.yml
+++ b/tests/threading-lock/laze.yml
@@ -1,0 +1,6 @@
+apps:
+  - name: threading-lock
+    selects:
+      - ?release
+      - executor-thread
+      - sw/threading

--- a/tests/threading-lock/src/main.rs
+++ b/tests/threading-lock/src/main.rs
@@ -1,0 +1,72 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use portable_atomic::{AtomicUsize, Ordering};
+use riot_rs::thread::{lock::Lock, thread_flags, ThreadId};
+
+static LOCK: Lock = Lock::new();
+static RUN_ORDER: AtomicUsize = AtomicUsize::new(0);
+static LOCK_ORDER: AtomicUsize = AtomicUsize::new(0);
+
+#[riot_rs::thread(autostart, priority = 1)]
+fn thread0() {
+    assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 0);
+
+    LOCK.acquire();
+
+    // Unblock other threads in the order of their IDs.
+    //
+    // Because all other threads have higher priorities, setting
+    // a flag will each time cause a context switch and give each
+    // thread the chance to run and try acquire the lock.
+    thread_flags::set(ThreadId::new(1), 0b1);
+    thread_flags::set(ThreadId::new(2), 0b1);
+    thread_flags::set(ThreadId::new(3), 0b1);
+
+    assert_eq!(LOCK_ORDER.fetch_add(1, Ordering::AcqRel), 0);
+
+    LOCK.release();
+
+    // Wait for other threads to complete.
+    thread_flags::wait_all(0b111);
+    riot_rs::debug::log::info!("Test passed!");
+}
+
+#[riot_rs::thread(autostart, priority = 2)]
+fn thread1() {
+    thread_flags::wait_one(0b1);
+    assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 1);
+
+    LOCK.acquire();
+    assert_eq!(LOCK_ORDER.fetch_add(1, Ordering::AcqRel), 2);
+    LOCK.release();
+
+    thread_flags::set(ThreadId::new(0), 0b1);
+}
+
+#[riot_rs::thread(autostart, priority = 3)]
+fn thread2() {
+    thread_flags::wait_one(0b1);
+    assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 2);
+
+    LOCK.acquire();
+    // Expect to be the second thread that acquires the lock.
+    assert_eq!(LOCK_ORDER.fetch_add(1, Ordering::AcqRel), 1);
+    LOCK.release();
+
+    thread_flags::set(ThreadId::new(0), 0b10);
+}
+
+#[riot_rs::thread(autostart, priority = 2)]
+fn thread3() {
+    thread_flags::wait_one(0b1);
+    assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 3);
+
+    LOCK.acquire();
+    assert_eq!(LOCK_ORDER.fetch_add(1, Ordering::AcqRel), 3);
+    LOCK.release();
+
+    thread_flags::set(ThreadId::new(0), 0b100);
+}


### PR DESCRIPTION
# Description

Insert new threads in `ThreadList` based on priorities, so that the highest priority thread is the head.
Within a priority the threads are ordered in FIFO.

This reduces priority inversions, and will facilitate proper priority inheritance in the future.

The drawback of this change is that inserting a new Id in the `ThreadList` is now more complex. Not sure if we can avoid this in any way.

## Issues/PRs references

Alternative to #371, which implements the `ThreadList` as pure FIFO.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
