### PR TITLE
refactor(threads): improve panic handling and docs

### DIFF
--- a/src/riot-rs-threads/src/lock.rs
+++ b/src/riot-rs-threads/src/lock.rs
@@ -20,21 +20,21 @@ enum LockState {
 }
 
 impl Lock {
-    /// Creates new **unlocked** Lock
+    /// Creates new **unlocked** Lock.
     pub const fn new() -> Self {
         Self {
             state: UnsafeCell::new(LockState::Unlocked),
         }
     }
 
-    /// Creates new **locked** Lock
+    /// Creates new **locked** Lock.
     pub const fn new_locked() -> Self {
         Self {
             state: UnsafeCell::new(LockState::Locked(ThreadList::new())),
         }
     }
 
-    /// Returns the current lock state
+    /// Returns the current lock state.
     ///
     /// true if locked, false otherwise
     pub fn is_locked(&self) -> bool {
@@ -44,13 +44,15 @@ impl Lock {
         })
     }
 
-    /// Get this lock (blocking)
+    /// Get this lock (blocking).
     ///
     /// If the lock was unlocked, it will be locked and the function returns.
     /// If the lock was locked, this function will block the current thread until the lock gets
     /// unlocked elsewhere.
     ///
-    /// **NOTE**: must not be called outside thread context!
+    /// # Panics
+    ///
+    /// Panics if this is called outside of a thread context.
     pub fn acquire(&self) {
         critical_section::with(|cs| {
             let state = unsafe { &mut *self.state.get() };
@@ -63,7 +65,7 @@ impl Lock {
         })
     }
 
-    /// Get the lock (non-blocking)
+    /// Get the lock (non-blocking).
     ///
     /// If the lock was unlocked, it will be locked and the function returns true.
     /// If the lock was locked, the function returns false

--- a/src/riot-rs-threads/src/threadlist.rs
+++ b/src/riot-rs-threads/src/threadlist.rs
@@ -16,9 +16,15 @@ impl ThreadList {
     }
 
     /// Puts the current (blocked) thread into this [`ThreadList`] and triggers the scheduler.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is called outside of a thread context.
     pub fn put_current(&mut self, cs: CriticalSection, state: ThreadState) {
         THREADS.with_mut_cs(cs, |mut threads| {
-            let &mut Thread { pid, prio, .. } = threads.current().unwrap();
+            let &mut Thread { pid, prio, .. } = threads
+                .current()
+                .expect("Function should be called inside a thread context.");
             let mut curr = None;
             let mut next = self.head;
             while let Some(n) = next {


### PR DESCRIPTION
# Description

Add some missing documentation about possible panics in `riot-rs-threads` when a function is expected to be called only inside a thread context.
Avoid panics where possible through early returns. 

Also adds some documentation for `Channel`.

## Issues/PRs references

Extracted from https://github.com/future-proof-iot/RIOT-rs/pull/381#discussion_r1721324000.

## Open Questions

- @ROMemories you proposed in https://github.com/future-proof-iot/RIOT-rs/pull/381#discussion_r1721324000 to use `NOTE(no-panic)`-style comments to document why an `unwrap` can't panic. I've instead used `expect`, because we a) don't know that it will never panic (it's the callers responsibility) and b) it prints the comment as part of the panic message. Wdyt?
 
- > Avoid panics where possible through early returns. 

This concerns the functions `yield_same` and `sleep`. If called from outside a thread context, the operations are now no-ops, instead of causing panics. Do you agree that we should prefer no-ops over panics as long as it doesn't cause any undefined behavior?

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
