### PR TITLE
chore(threads): use `allow` instead of `expect` for unused `Thread.sp`

### DIFF
--- a/src/riot-rs-threads/src/thread.rs
+++ b/src/riot-rs-threads/src/thread.rs
@@ -4,7 +4,7 @@ use crate::{thread_flags::ThreadFlags, Arch, Cpu, RunqueueId, ThreadData, Thread
 #[derive(Debug)]
 pub struct Thread {
     /// Saved stack pointer after context switch.
-    #[expect(
+    #[allow(
         dead_code,
         reason = "sp is used in context-specific scheduler implementation"
     )]


### PR DESCRIPTION
# Description

Use `allow` instead of `expect` for `sp`.
We use the `sp` inside the scheduler implementations, so it's not dead code as soon as we compile for `cortex-m` or `riscv`.

## Issues/PRs references

Follow-up fix for #383.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
