### PR TITLE
refactor!: remove the embassy module and all its uses

### DIFF
--- a/examples/blinky/src/main.rs
+++ b/examples/blinky/src/main.rs
@@ -6,7 +6,7 @@
 mod pins;
 
 use embassy_time::{Duration, Timer};
-use riot_rs::embassy::gpio::{Level, Output};
+use riot_rs::gpio::{Level, Output};
 
 #[riot_rs::task(autostart, peripherals)]
 async fn blinky(peripherals: pins::LedPeripherals) {

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -1,4 +1,4 @@
-use riot_rs::embassy::arch::peripherals;
+use riot_rs::arch::peripherals;
 
 #[cfg(context = "microbit-v2")]
 riot_rs::define_peripherals!(LedPeripherals {

--- a/examples/coap/src/main.rs
+++ b/examples/coap/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::{debug::log::*, embassy::network};
+use riot_rs::{debug::log::*, network};
 
 use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embedded_nal_coap::TransportError;

--- a/examples/embassy-http-server/src/main.rs
+++ b/examples/embassy-http-server/src/main.rs
@@ -6,10 +6,7 @@
 mod pins;
 mod routes;
 
-use riot_rs::{
-    debug::log::*,
-    embassy::{network, Spawner},
-};
+use riot_rs::{debug::log::*, network, Spawner};
 
 use embassy_net::tcp::TcpSocket;
 use embassy_time::Duration;
@@ -143,8 +140,8 @@ fn network_config() -> embassy_net::Config {
 
 #[cfg(capability = "hw/usb-device-port")]
 #[riot_rs::config(usb)]
-fn usb_config() -> riot_rs::embassy::embassy_usb::Config<'static> {
-    let mut config = riot_rs::embassy::embassy_usb::Config::new(0xc0de, 0xcafe);
+fn usb_config() -> riot_rs::embassy_usb::Config<'static> {
+    let mut config = riot_rs::embassy_usb::Config::new(0xc0de, 0xcafe);
     config.manufacturer = Some("Embassy");
     config.product = Some("HTTP-over-USB-Ethernet example");
     config.serial_number = Some("12345678");

--- a/examples/embassy-http-server/src/pins.rs
+++ b/examples/embassy-http-server/src/pins.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "button-readings")]
-use riot_rs::embassy::arch::peripherals;
+use riot_rs::arch::peripherals;
 
 #[cfg(all(feature = "button-readings", builder = "nrf52840dk"))]
 riot_rs::define_peripherals!(Buttons {

--- a/examples/embassy-net-tcp/src/main.rs
+++ b/examples/embassy-net-tcp/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::{debug::log::*, embassy::network};
+use riot_rs::{debug::log::*, network};
 
 use embedded_io_async::Write;
 

--- a/examples/embassy-net-udp/src/main.rs
+++ b/examples/embassy-net-udp/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::{debug::log::*, embassy::network};
+use riot_rs::{debug::log::*, network};
 
 #[riot_rs::task(autostart)]
 async fn udp_echo() {

--- a/examples/embassy-usb-keyboard/src/main.rs
+++ b/examples/embassy-usb-keyboard/src/main.rs
@@ -7,10 +7,8 @@ use embassy_time::Duration;
 use embassy_usb::class::hid::{self, HidReaderWriter};
 use riot_rs::{
     debug::log::*,
-    embassy::{
-        make_static,
-        usb::{UsbBuilderHook, UsbDriver},
-    },
+    make_static,
+    usb::{UsbBuilderHook, UsbDriver},
 };
 
 use usbd_hid::descriptor::KeyboardReport;
@@ -121,8 +119,8 @@ mod buttons {
 }
 
 #[riot_rs::config(usb)]
-fn usb_config() -> riot_rs::embassy::embassy_usb::Config<'static> {
-    let mut config = riot_rs::embassy::embassy_usb::Config::new(0xc0de, 0xcafe);
+fn usb_config() -> riot_rs::embassy_usb::Config<'static> {
+    let mut config = riot_rs::embassy_usb::Config::new(0xc0de, 0xcafe);
     config.manufacturer = Some("Embassy");
     config.product = Some("HID keyboard example");
     config.serial_number = Some("12345678");

--- a/examples/embassy/src/main.rs
+++ b/examples/embassy/src/main.rs
@@ -6,7 +6,7 @@
 use riot_rs::debug::{exit, log::*};
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
-use riot_rs::embassy::{blocker, EXECUTOR};
+use riot_rs::{blocker, EXECUTOR};
 
 static SIGNAL: Signal<CriticalSectionRawMutex, u32> = Signal::new();
 

--- a/examples/gpio/src/main.rs
+++ b/examples/gpio/src/main.rs
@@ -6,7 +6,7 @@
 mod pins;
 
 use embassy_time::{Duration, Timer};
-use riot_rs::embassy::gpio::{Input, Level, Output, Pull};
+use riot_rs::gpio::{Input, Level, Output, Pull};
 
 #[riot_rs::task(autostart, peripherals)]
 async fn blinky(peripherals: pins::Peripherals) {

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -1,4 +1,4 @@
-use riot_rs::embassy::arch::peripherals;
+use riot_rs::arch::peripherals;
 
 #[cfg(context = "nrf52840dk")]
 riot_rs::define_peripherals!(Peripherals {

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -5,10 +5,8 @@
 
 use riot_rs::{
     debug::log::info,
-    embassy::{
-        embassy_usb, make_static,
-        usb::{UsbBuilderHook, UsbDriver},
-    },
+    embassy_usb, make_static,
+    usb::{UsbBuilderHook, UsbDriver},
 };
 
 use embassy_usb::{

--- a/src/riot-rs-macros/src/config.rs
+++ b/src/riot-rs-macros/src/config.rs
@@ -61,11 +61,11 @@ pub fn config(args: TokenStream, item: TokenStream) -> TokenStream {
     let (config_fn_name, return_type) = match attrs.kind {
         Some(ConfigKind::Network) => (
             format_ident!("riot_rs_network_config"),
-            quote! {#riot_rs_crate::embassy::embassy_net::Config},
+            quote! {#riot_rs_crate::embassy_net::Config},
         ),
         Some(ConfigKind::Usb) => (
             format_ident!("riot_rs_usb_config"),
-            quote! {#riot_rs_crate::embassy::embassy_usb::Config<'static>},
+            quote! {#riot_rs_crate::embassy_usb::Config<'static>},
         ),
         None => {
             panic!("a configuration kind must be specified");

--- a/src/riot-rs-macros/src/spawner.rs
+++ b/src/riot-rs-macros/src/spawner.rs
@@ -18,7 +18,7 @@
 /// # Examples
 ///
 /// ```ignore
-/// use riot_rs::embassy::Spawner;
+/// use riot_rs::Spawner;
 ///
 /// #[riot_rs::spawner(autostart)]
 /// fn spawner(spawner: Spawner, peripherals: /* your peripheral type */) {}
@@ -84,11 +84,11 @@ pub fn spawner(args: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let expanded = quote! {
-        #[#riot_rs_crate::embassy::distributed_slice(#riot_rs_crate::embassy::EMBASSY_TASKS)]
-        #[linkme(crate = #riot_rs_crate::embassy::linkme)]
+        #[#riot_rs_crate::distributed_slice(#riot_rs_crate::EMBASSY_TASKS)]
+        #[linkme(crate = #riot_rs_crate::linkme)]
         fn #new_function_name(
-            spawner: #riot_rs_crate::embassy::Spawner,
-            mut peripherals: &mut #riot_rs_crate::embassy::arch::OptionalPeripherals,
+            spawner: #riot_rs_crate::Spawner,
+            mut peripherals: &mut #riot_rs_crate::arch::OptionalPeripherals,
         ) {
             use #riot_rs_crate::define_peripherals::TakePeripherals;
             #spawner_function_name(spawner #peripheral_param);

--- a/src/riot-rs-macros/src/task.rs
+++ b/src/riot-rs-macros/src/task.rs
@@ -26,7 +26,7 @@
 /// # Examples
 ///
 /// ```ignore
-/// use riot_rs::embassy::usb::UsbBuilderHook;
+/// use riot_rs::usb::UsbBuilderHook;
 ///
 /// #[riot_rs::task(autostart, peripherals, usb_builder_hook)]
 /// async fn task(peripherals: /* your peripheral type */) {}
@@ -96,25 +96,25 @@ pub fn task(args: TokenStream, item: TokenStream) -> TokenStream {
         quote! {
             #delegates
 
-            #[#riot_rs_crate::embassy::distributed_slice(#riot_rs_crate::embassy::EMBASSY_TASKS)]
-            #[linkme(crate = #riot_rs_crate::embassy::linkme)]
+            #[#riot_rs_crate::distributed_slice(#riot_rs_crate::EMBASSY_TASKS)]
+            #[linkme(crate = #riot_rs_crate::linkme)]
             fn #new_function_name(
-                spawner: #riot_rs_crate::embassy::Spawner,
-                mut peripherals: &mut #riot_rs_crate::embassy::arch::OptionalPeripherals,
+                spawner: #riot_rs_crate::Spawner,
+                mut peripherals: &mut #riot_rs_crate::arch::OptionalPeripherals,
             ) {
                 use #riot_rs_crate::define_peripherals::TakePeripherals;
                 let task = #task_function_name(#peripheral_param);
                 spawner.spawn(task).unwrap();
             }
 
-            #[#riot_rs_crate::embassy::embassy_executor::task]
+            #[#riot_rs_crate::embassy_executor::task]
             #task_function
         }
     } else {
         let pool_size = attrs.pool_size.unwrap_or_else(|| syn::parse_quote! { 1 });
 
         quote! {
-            #[#riot_rs_crate::embassy::embassy_executor::task(pool_size = #pool_size)]
+            #[#riot_rs_crate::embassy_executor::task(pool_size = #pool_size)]
             #task_function
         }
     };
@@ -209,8 +209,8 @@ mod task {
             // initialization
             [HookDefinition {
                 kind: Self::UsbBuilder,
-                delegate_inner_type: quote! {#riot_rs_crate::embassy::usb::UsbBuilder},
-                distributed_slice_type: quote! {#riot_rs_crate::embassy::usb::USB_BUILDER_HOOKS},
+                delegate_inner_type: quote! {#riot_rs_crate::usb::UsbBuilder},
+                distributed_slice_type: quote! {#riot_rs_crate::usb::USB_BUILDER_HOOKS},
             }]
         }
     }
@@ -229,7 +229,7 @@ mod task {
     ) -> proc_macro2::TokenStream {
         use quote::{format_ident, quote};
 
-        let delegate_type = quote! {#riot_rs_crate::embassy::delegate::Delegate};
+        let delegate_type = quote! {#riot_rs_crate::delegate::Delegate};
 
         let enabled_hooks = hooks.iter().filter(|hook| match hook.kind {
             Hook::UsbBuilder => attrs.hooks.iter().any(|h| *h == Hook::UsbBuilder),
@@ -250,8 +250,8 @@ mod task {
             quote! {
                 static #delegate_hook_ident: #delegate_type<#delegate_inner_type> = #delegate_type::new();
 
-                #[#riot_rs_crate::embassy::distributed_slice(#distributed_slice_type)]
-                #[linkme(crate=#riot_rs_crate::embassy::linkme)]
+                #[#riot_rs_crate::distributed_slice(#distributed_slice_type)]
+                #[linkme(crate=#riot_rs_crate::linkme)]
                     static #delegate_hook_ref_ident: #type_name = &#delegate_hook_ident;
                 }
             }

--- a/src/riot-rs-macros/tests/ui/config/conflicting_config_kind.rs
+++ b/src/riot-rs-macros/tests/ui/config/conflicting_config_kind.rs
@@ -3,7 +3,7 @@
 
 // This will not get used because the attribute macro is expected to fail
 #[allow(unused_imports)]
-use riot_rs::embassy::embassy_net;
+use riot_rs::embassy_net;
 
 // FAIL: network and usb cannot be used at the same time
 #[riot_rs::config(network, usb)]

--- a/src/riot-rs-macros/tests/ui/config/misspelled_config_kind.rs
+++ b/src/riot-rs-macros/tests/ui/config/misspelled_config_kind.rs
@@ -3,7 +3,7 @@
 
 // This will not get used because the attribute macro is expected to fail
 #[allow(unused_imports)]
-use riot_rs::embassy::embassy_net;
+use riot_rs::embassy_net;
 
 // FAIL: misspelled config kind
 #[riot_rs::config(networkk)]

--- a/src/riot-rs-macros/tests/ui/config/no_parameters.rs
+++ b/src/riot-rs-macros/tests/ui/config/no_parameters.rs
@@ -3,7 +3,7 @@
 
 // This will not get used because the attribute macro is expected to fail
 #[allow(unused_imports)]
-use riot_rs::embassy::embassy_net;
+use riot_rs::embassy_net;
 
 // FAIL: this attribute macro requires parameters
 #[riot_rs::config]

--- a/src/riot-rs-macros/tests/ui/spawner/async_fn.rs
+++ b/src/riot-rs-macros/tests/ui/spawner/async_fn.rs
@@ -4,7 +4,7 @@
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]
-use riot_rs::embassy::Spawner;
+use riot_rs::Spawner;
 
 // FAIL: spawner functions cannot be async
 #[riot_rs::spawner(autostart)]

--- a/src/riot-rs-macros/tests/ui/spawner/missing_peripherals_param.rs
+++ b/src/riot-rs-macros/tests/ui/spawner/missing_peripherals_param.rs
@@ -4,7 +4,7 @@
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]
-use riot_rs::embassy::Spawner;
+use riot_rs::Spawner;
 
 // FAIL: the `peripherals` parameter is required in this case
 #[riot_rs::spawner(autostart)]

--- a/src/riot-rs-macros/tests/ui/spawner/no_autostart_param.rs
+++ b/src/riot-rs-macros/tests/ui/spawner/no_autostart_param.rs
@@ -4,7 +4,7 @@
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]
-use riot_rs::embassy::Spawner;
+use riot_rs::Spawner;
 
 // FAIL: the macro expects a mandatory `autostart` parameter
 #[riot_rs::spawner]

--- a/src/riot-rs-macros/tests/ui/task/missing_autostart_param_for_hook.rs
+++ b/src/riot-rs-macros/tests/ui/task/missing_autostart_param_for_hook.rs
@@ -4,7 +4,7 @@
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]
-use riot_rs::embassy::usb::UsbBuilderHook;
+use riot_rs::usb::UsbBuilderHook;
 
 // FAIL: using hooks require the task to be autostart
 #[riot_rs::task(usb_builder_hook)]

--- a/src/riot-rs-macros/tests/ui/task/misspelled_hook_name.rs
+++ b/src/riot-rs-macros/tests/ui/task/misspelled_hook_name.rs
@@ -4,7 +4,7 @@
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]
-use riot_rs::embassy::usb::UsbBuilderHook;
+use riot_rs::usb::UsbBuilderHook;
 
 // FAIL: misspelled hook name
 #[riot_rs::task(autostart, usb_builder_hooook)]

--- a/src/riot-rs/src/lib.rs
+++ b/src/riot-rs/src/lib.rs
@@ -19,9 +19,6 @@ pub use riot_rs_bench as bench;
 #[doc(inline)]
 pub use riot_rs_debug as debug;
 pub use riot_rs_embassy::*;
-// Keep the `embassy` module for backward compatibility, but hide it from documentation.
-#[doc(hidden)]
-pub use riot_rs_embassy as embassy;
 #[cfg(feature = "random")]
 #[doc(inline)]
 pub use riot_rs_random as random;

--- a/src/riot-rs/src/lib.rs
+++ b/src/riot-rs/src/lib.rs
@@ -18,9 +18,10 @@ pub mod buildinfo;
 pub use riot_rs_bench as bench;
 #[doc(inline)]
 pub use riot_rs_debug as debug;
-#[doc(inline)]
+pub use riot_rs_embassy::*;
+// Keep the `embassy` module for backward compatibility, but hide it from documentation.
+#[doc(hidden)]
 pub use riot_rs_embassy as embassy;
-pub use riot_rs_embassy::{define_peripherals, group_peripherals};
 #[cfg(feature = "random")]
 #[doc(inline)]
 pub use riot_rs_random as random;

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -4,11 +4,9 @@
 #![feature(used_with_arg)]
 
 use riot_rs::{
+    arch::peripherals,
     debug::log::info,
-    embassy::{
-        arch::peripherals,
-        gpio::{self, Input, Pull},
-    },
+    gpio::{self, Input, Pull},
 };
 
 #[cfg(context = "nrf51")]

--- a/tests/gpio-interrupt-stm32/src/main.rs
+++ b/tests/gpio-interrupt-stm32/src/main.rs
@@ -4,11 +4,9 @@
 #![feature(used_with_arg)]
 
 use riot_rs::{
+    arch::peripherals,
     debug::log::info,
-    embassy::{
-        arch::peripherals,
-        gpio::{self, Input, Pull},
-    },
+    gpio::{self, Input, Pull},
 };
 
 // These pins should be available on all STM32 chips.

--- a/tests/gpio/src/main.rs
+++ b/tests/gpio/src/main.rs
@@ -8,7 +8,7 @@ mod pins;
 #[allow(unused_imports)]
 use riot_rs::{
     debug::log::info,
-    embassy::gpio::{DriveStrength, Input, Level, Output, Pull, Speed},
+    gpio::{DriveStrength, Input, Level, Output, Pull, Speed},
 };
 
 #[riot_rs::task(autostart, peripherals)]

--- a/tests/gpio/src/pins.rs
+++ b/tests/gpio/src/pins.rs
@@ -1,4 +1,4 @@
-use riot_rs::embassy::arch::peripherals;
+use riot_rs::arch::peripherals;
 
 #[cfg(context = "nrf52")]
 riot_rs::define_peripherals!(Peripherals {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The first commits keeps the `embassy` module for backward compatibility, but hides it from documentation.
The second one removes all uses and removes the `embassy` module entirely.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->
~~Should we rewrite every uses of the `embassy` modules as part of this PR, or shall we do this gradually?~~ There were fewer uses than I anticipated, so I just went with it and removed them all.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
