### PR TITLE
fix(blinky): blinky does not need `external-interrupts`

### DIFF
--- a/examples/blinky/Cargo.toml
+++ b/examples/blinky/Cargo.toml
@@ -12,8 +12,5 @@ workspace = true
 [dependencies]
 embassy-executor = { workspace = true }
 embassy-time = { workspace = true }
-riot-rs = { path = "../../src/riot-rs", features = [
-  "external-interrupts",
-  "time",
-] }
+riot-rs = { path = "../../src/riot-rs", features = ["time"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The `external-interrupts` Cargo feature was unnecessarily enabled for the `blinky` example. This PR disables it.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
