### PR TITLE
ci(cargo-deny): force the installation when already restored from cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,9 +137,11 @@ jobs:
           tool: cargo-binstall
 
       # Should run as soon as possible to avoid using unwanted crates
+      # `--force`ing is required as the installed binary could have been
+      # restored from cache.
       - name: cargo-deny
         run: |
-          cargo binstall --no-confirm --no-discover-github-token cargo-deny
+          cargo binstall --no-confirm --no-discover-github-token --force cargo-deny
           cargo deny check bans licenses sources
 
       # Must run after the cargo-deny job as it requires the downloaded


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
`cargo-deny` installation could fail in CI when the binary was restored from a previous run. Using `--force` forces the installation in that case.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
