### PR TITLE
docs(spawner-macro): add a missing parameter in a doc example

### DIFF
--- a/src/riot-rs-macros/src/spawner.rs
+++ b/src/riot-rs-macros/src/spawner.rs
@@ -20,7 +20,7 @@
 /// ```ignore
 /// use riot_rs::Spawner;
 ///
-/// #[riot_rs::spawner(autostart)]
+/// #[riot_rs::spawner(autostart, peripherals)]
 /// fn spawner(spawner: Spawner, peripherals: /* your peripheral type */) {}
 /// ```
 ///


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The `peripherals` macro parameter is required so that the decorated function gets called with a second parameter, to be able to obtain peripherals.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
