### PR TITLE
feat(threads): multicore support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,7 @@ dependencies = [
  "pio",
  "pio-proc",
  "rand_core",
- "rp-pac",
+ "rp-pac 6.0.0 (git+https://github.com/embassy-rs/rp-pac.git?rev=a7f42d25517f7124ad3b4ed492dec8b0f50a0e6c)",
  "rp2040-boot2",
  "sha2-const-stable",
 ]
@@ -3806,6 +3806,7 @@ dependencies = [
  "cfg-if",
  "cortex-m",
  "cortex-m-rt",
+ "embassy-rp",
  "esp-hal",
  "linkme",
  "portable-atomic",
@@ -3851,11 +3852,13 @@ dependencies = [
  "cortex-m-semihosting",
  "critical-section",
  "defmt",
+ "embassy-rp",
  "esp-hal",
  "linkme",
  "panic-semihosting",
  "paste",
  "riot-rs-runqueue",
+ "rp-pac 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_cell",
 ]
 
@@ -3886,6 +3889,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rp-pac"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30f6c4c846269293db805e9c77864ff7b923395b480550df44f0868e3765337"
+dependencies = [
+ "cortex-m",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "cyw43"
 version = "0.2.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -821,7 +821,7 @@ dependencies = [
 [[package]]
 name = "cyw43-pio"
 version = "0.2.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "cyw43",
  "embassy-rp",
@@ -1065,7 +1065,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.6.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -1099,7 +1099,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-internal"
 version = "0.2.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -1129,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "embassy-net"
 version = "0.4.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "defmt",
  "document-features",
@@ -1146,7 +1146,7 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "defmt",
 ]
@@ -1154,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver-channel"
 version = "0.3.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
@@ -1190,7 +1190,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.2.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -1231,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.2.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "embassy-stm32"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "aligned",
  "bit_field",
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.6.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1358,7 +1358,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "document-features",
 ]
@@ -1366,7 +1366,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 
 [[package]]
 name = "embassy-usb"
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "defmt",
 ]
@@ -1410,7 +1410,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-synopsys-otg"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#afdd20dc1f721a3be5704b2bb5f8572f0a3f8ca3"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-09-19#f5b06a847d8dd88be5670da888a8a888ac250f3f"
 dependencies = [
  "critical-section",
  "embassy-sync 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3858,6 +3858,7 @@ dependencies = [
  "panic-semihosting",
  "paste",
  "riot-rs-runqueue",
+ "riot-rs-utils",
  "rp-pac 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_cell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4534,6 +4534,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "threading-multicore"
+version = "0.1.0"
+dependencies = [
+ "riot-rs",
+ "riot-rs-boards",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
 [[package]]
 name = "esp-alloc"
 version = "0.5.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "critical-section",
  "enumset",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "esp-build"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "quote",
  "syn 2.0.79",
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "esp-config"
 version = "0.1.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "document-features",
 ]
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "esp-hal"
 version = "0.21.1"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "basic-toml",
  "bitfield 0.16.1",
@@ -1722,7 +1722,7 @@ dependencies = [
  "embedded-io 0.6.1",
  "embedded-io-async",
  "enumset",
- "esp-build 0.1.0 (git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1)",
+ "esp-build 0.1.0 (git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377)",
  "esp-config",
  "esp-hal-procmacros",
  "esp-metadata",
@@ -1753,13 +1753,13 @@ dependencies = [
 [[package]]
 name = "esp-hal-embassy"
 version = "0.4.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "critical-section",
  "document-features",
  "embassy-executor",
  "embassy-time-driver",
- "esp-build 0.1.0 (git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1)",
+ "esp-build 0.1.0 (git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377)",
  "esp-hal",
  "esp-hal-procmacros",
  "esp-metadata",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.14.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "darling",
  "document-features",
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "esp-metadata"
 version = "0.4.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "anyhow",
  "basic-toml",
@@ -1810,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "esp-riscv-rt"
 version = "0.9.0"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "document-features",
  "riscv",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "esp-wifi"
 version = "0.10.1"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "bt-hci",
  "cfg-if",
@@ -1846,7 +1846,7 @@ dependencies = [
  "embedded-io-async",
  "enumset",
  "esp-alloc",
- "esp-build 0.1.0 (git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1)",
+ "esp-build 0.1.0 (git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377)",
  "esp-config",
  "esp-hal",
  "esp-metadata",
@@ -4952,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt"
 version = "0.17.1"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "anyhow",
  "bare-metal 1.0.0",
@@ -4970,7 +4970,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
 version = "0.2.2"
-source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1#4e2280b7c7deb1251e335b90c272558cdc333702"
+source = "git+https://github.com/kaspar030/esp-hal?branch=for-riot-rs-2024-10-16-0.21.1+pr2377#d3f7a76f55b83a1fce3a75614240786324edeed9"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,11 +73,11 @@ embassy-usb = { version = "0.3", default-features = false }
 embedded-hal = { version = "1.0.0", default-features = false }
 embedded-hal-async = { version = "1.0.0", default-features = false }
 
-esp-alloc = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-10-16-0.21.1", default-features = false }
-esp-hal = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-10-16-0.21.1", default-features = false }
-esp-hal-embassy = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-10-16-0.21.1", default-features = false }
+esp-alloc = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-10-16-0.21.1+pr2377", default-features = false }
+esp-hal = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-10-16-0.21.1+pr2377", default-features = false }
+esp-hal-embassy = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-10-16-0.21.1+pr2377", default-features = false }
 esp-println = "0.11.0"
-esp-wifi = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-10-16-0.21.1", default-features = false }
+esp-wifi = { git = "https://github.com/kaspar030/esp-hal", branch = "for-riot-rs-2024-10-16-0.21.1+pr2377", default-features = false }
 
 linkme = { version = "0.3.21", features = ["used_linker"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ once_cell = { version = "=1.19.0", default-features = false, features = [
   "critical-section",
 ] }
 paste = { version = "1.0" }
+rp-pac = { version = "6.0", default-features = false }
 static_cell = { version = "2.0.0", features = ["nightly"] }
 
 [profile.dev]

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -21,4 +21,5 @@ subdirs:
   - random
   - threading
   - threading-channel
+  - threading-multicore
   - usb-serial

--- a/examples/threading-multicore/Cargo.toml
+++ b/examples/threading-multicore/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "threading-multicore"
+version = "0.1.0"
+authors = ["Elena Frank <elena.frank@proton.me>"]
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/threading-multicore/Cargo.toml
+++ b/examples/threading-multicore/Cargo.toml
@@ -7,5 +7,8 @@ license.workspace = true
 publish = false
 
 [dependencies]
-riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs = { path = "../../src/riot-rs", features = [
+  "threading",
+  "core-affinity",
+] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/threading-multicore/Cargo.toml
+++ b/examples/threading-multicore/Cargo.toml
@@ -7,8 +7,5 @@ license.workspace = true
 publish = false
 
 [dependencies]
-riot-rs = { path = "../../src/riot-rs", features = [
-  "threading",
-  "core-affinity",
-] }
+riot-rs = { path = "../../src/riot-rs", features = ["core-affinity"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/threading-multicore/README.md
+++ b/examples/threading-multicore/README.md
@@ -1,0 +1,15 @@
+# threading multicore
+
+## About
+
+This application demonstrates basic threading on multicore.
+
+## How to run
+
+In this folder, run
+
+    laze build -b rpi-pico run
+
+The application will start two threads that each print their ID and the core that they are running on, before
+entering a busy loop.
+The thread that is started first in pinned to Core 1 using core affinities.

--- a/examples/threading-multicore/laze.yml
+++ b/examples/threading-multicore/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: threading-multicore
+    selects:
+      - ?release

--- a/examples/threading-multicore/laze.yml
+++ b/examples/threading-multicore/laze.yml
@@ -3,4 +3,4 @@ apps:
     selects:
       - ?release
       - sw/threading
-      - multicore
+      - multi-core

--- a/examples/threading-multicore/laze.yml
+++ b/examples/threading-multicore/laze.yml
@@ -2,3 +2,5 @@ apps:
   - name: threading-multicore
     selects:
       - ?release
+      - sw/threading
+      - multicore

--- a/examples/threading-multicore/src/main.rs
+++ b/examples/threading-multicore/src/main.rs
@@ -3,9 +3,12 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use riot_rs::debug::log::*;
+use riot_rs::{
+    debug::log::*,
+    thread::{CoreAffinity, CoreId},
+};
 
-#[riot_rs::thread(autostart)]
+#[riot_rs::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)))]
 fn thread0() {
     let core = riot_rs::thread::core_id();
     let pid = riot_rs::thread::current_pid().unwrap();

--- a/examples/threading-multicore/src/main.rs
+++ b/examples/threading-multicore/src/main.rs
@@ -1,0 +1,22 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::debug::log::*;
+
+#[riot_rs::thread(autostart)]
+fn thread0() {
+    let core = riot_rs::thread::core_id();
+    let pid = riot_rs::thread::current_pid().unwrap();
+    info!("Hello from {:?} on {:?}", pid, core);
+    loop {}
+}
+
+#[riot_rs::thread(autostart)]
+fn thread1() {
+    let core = riot_rs::thread::core_id();
+    let pid = riot_rs::thread::current_pid().unwrap();
+    info!("Hello from {:?} on {:?}", pid, core);
+    loop {}
+}

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -597,7 +597,7 @@ modules:
     conflicts:
       - executor-single-thread
     selects:
-      - ?multicore
+      - ?multi-core
     env:
       global:
         FEATURES:
@@ -742,8 +742,8 @@ modules:
         FEATURES:
           - riot-rs/single-core
 
-  - name: multicore
-    help: usage platform as multicore system
+  - name: multi-core
+    help: usage platform as multi-core system
     context:
       - rp
       - esp32s3
@@ -752,7 +752,7 @@ modules:
     env:
       global:
         FEATURES:
-          - riot-rs/multicore
+          - riot-rs/multi-core
 
 builders:
   # host builder (for housekeeping tasks)

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -746,6 +746,7 @@ modules:
     help: usage platform as multicore system
     context:
       - rp
+      - esp32s3
     provides_unique:
       - critical-section
     env:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -9,6 +9,7 @@ contexts:
     parent: default
     selects:
       - executor-default
+      - ?critical-section
       - ?defmt
     env:
       RUSTFLAGS:
@@ -595,6 +596,8 @@ modules:
   - name: sw/threading
     conflicts:
       - executor-single-thread
+    selects:
+      - ?multicore
     env:
       global:
         FEATURES:
@@ -729,6 +732,26 @@ modules:
       - ?executor-interrupt
       - ?executor-single-thread
       - ?executor-thread
+
+  - name: single-core
+    help: usage platform as single-core system
+    provides_unique:
+      - critical-section
+    env:
+      global:
+        FEATURES:
+          - riot-rs/single-core
+
+  - name: multicore
+    help: usage platform as multicore system
+    context:
+      - rp
+    provides_unique:
+      - critical-section
+    env:
+      global:
+        FEATURES:
+          - riot-rs/multicore
 
 builders:
   # host builder (for housekeeping tasks)

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -103,7 +103,7 @@ wifi = []
 wifi-cyw43 = ["riot-rs-rp/wifi-cyw43", "net", "wifi"]
 wifi-esp = ["riot-rs-esp/wifi-esp", "net", "wifi"]
 
-threading = ["dep:riot-rs-threads", "riot-rs-esp/threading"]
+threading = ["dep:riot-rs-threads"]
 override-network-config = []
 override-usb-config = []
 

--- a/src/riot-rs-esp/Cargo.toml
+++ b/src/riot-rs-esp/Cargo.toml
@@ -81,9 +81,6 @@ spi = ["dep:fugit", "riot-rs-embassy-common/spi"]
 ## Enables defmt support.
 defmt = ["dep:defmt", "esp-wifi?/defmt", "fugit?/defmt"]
 
-## Enables threading support.
-threading = []
-
 ## Enables Wi-Fi support.
 wifi = []
 

--- a/src/riot-rs-esp/src/lib.rs
+++ b/src/riot-rs-esp/src/lib.rs
@@ -68,20 +68,6 @@ pub use esp_hal_embassy::Executor;
 pub fn init() -> OptionalPeripherals {
     let mut peripherals = OptionalPeripherals::from(esp_hal::init(esp_hal::Config::default()));
 
-    #[cfg(feature = "threading")]
-    {
-        use esp_hal::{interrupt, peripherals::Interrupt};
-        // Since https://github.com/esp-rs/esp-hal/pull/2091,
-        // `esp_hal::init()` resets all interrupts.
-        // That also disables our scheduler interrupt, which was previously enabled
-        // in `riot_rs_threads::arch::xtensa`.
-        // So, re-enable it here.
-
-        // Panics if `FROM_CPU_INTR0` is among `esp_hal::interrupt::RESERVED_INTERRUPTS`,
-        // which isn't the case.
-        interrupt::enable(Interrupt::FROM_CPU_INTR0, interrupt::Priority::min()).unwrap();
-    }
-
     #[cfg(feature = "wifi-esp")]
     {
         use esp_hal::timer::timg::TimerGroup;

--- a/src/riot-rs-rt/Cargo.toml
+++ b/src/riot-rs-rt/Cargo.toml
@@ -17,16 +17,20 @@ riot-rs-utils = { workspace = true }
 rtt-target = { version = "0.5.0", optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
-cortex-m = { workspace = true, features = ["critical-section-single-core"] }
+cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 
 [target.'cfg(context = "rp2040")'.dependencies]
 # Use critical-section to provide an atomic CAS implementation.
 portable-atomic = { workspace = true, features = ["critical-section"] }
+embassy-rp = { workspace = true, features = ["critical-section-impl"] }
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-hal = { workspace = true, default-features = false }
 portable-atomic = { workspace = true }
+
+[target.'cfg(context = "nrf")'.dependencies]
+cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 
 [features]
 #default = ["threading"]

--- a/src/riot-rs-rt/Cargo.toml
+++ b/src/riot-rs-rt/Cargo.toml
@@ -21,9 +21,8 @@ cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 
 [target.'cfg(context = "rp2040")'.dependencies]
-# Use critical-section to provide an atomic CAS implementation.
+embassy-rp = { workspace = true, optional = true }
 portable-atomic = { workspace = true, features = ["critical-section"] }
-embassy-rp = { workspace = true, features = ["critical-section-impl"] }
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-hal = { workspace = true, default-features = false }
@@ -32,14 +31,18 @@ portable-atomic = { workspace = true }
 [target.'cfg(context = "nrf")'.dependencies]
 cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 
+[target.'cfg(context = "stm32")'.dependencies]
+cortex-m = { workspace = true, features = ["critical-section-single-core"] }
+
 [features]
-#default = ["threading"]
 threading = ["dep:riot-rs-threads"]
 
 debug-console = ["riot-rs-debug/debug-console"]
 executor-single-thread = []
 silent-panic = []
 _panic-handler = []
+single-core = ["cortex-m/critical-section-single-core"]
+multicore = ["embassy-rp/critical-section-impl"]
 
 # internal
 # These features are used by `build.rs`, which doesn't "see" context

--- a/src/riot-rs-rt/Cargo.toml
+++ b/src/riot-rs-rt/Cargo.toml
@@ -42,7 +42,7 @@ executor-single-thread = []
 silent-panic = []
 _panic-handler = []
 single-core = ["cortex-m/critical-section-single-core"]
-multicore = ["embassy-rp/critical-section-impl"]
+multi-core = ["embassy-rp/critical-section-impl"]
 
 # internal
 # These features are used by `build.rs`, which doesn't "see" context

--- a/src/riot-rs-rt/src/cortexm.rs
+++ b/src/riot-rs-rt/src/cortexm.rs
@@ -198,11 +198,4 @@ pub fn init() {
             .vtor
             .write(&__RESET_VECTOR as *const _ as u32 - 4)
     };
-
-    // make sure PendSV has a low priority
-    unsafe {
-        use cortex_m::peripheral::scb::SystemHandler;
-        let mut p = cortex_m::Peripherals::take().unwrap();
-        p.SCB.set_priority(SystemHandler::PendSV, 0xFF);
-    }
 }

--- a/src/riot-rs-rt/src/lib.rs
+++ b/src/riot-rs-rt/src/lib.rs
@@ -16,6 +16,11 @@ pub mod testing;
 #[cfg(feature = "threading")]
 mod threading;
 
+#[cfg(all(feature = "single-core", feature = "multicore"))]
+compile_error!(
+    "feature \"single-core\" and feature \"multicore\" cannot be enabled at the same time"
+);
+
 use riot_rs_debug::{log::debug, println};
 
 cfg_if::cfg_if! {

--- a/src/riot-rs-rt/src/lib.rs
+++ b/src/riot-rs-rt/src/lib.rs
@@ -16,9 +16,9 @@ pub mod testing;
 #[cfg(feature = "threading")]
 mod threading;
 
-#[cfg(all(feature = "single-core", feature = "multicore"))]
+#[cfg(all(feature = "single-core", feature = "multi-core"))]
 compile_error!(
-    "feature \"single-core\" and feature \"multicore\" cannot be enabled at the same time"
+    "feature \"single-core\" and feature \"multi-core\" cannot be enabled at the same time"
 );
 
 use riot_rs_debug::{log::debug, println};

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -48,10 +48,10 @@ embassy-rp = { workspace = true, optional = true }
 
 [features]
 defmt = ["dep:defmt", "riot-rs-runqueue/defmt"]
-multicore = [
+multi-core = [
   "dep:static_cell",
   "dep:rp-pac",
   "dep:embassy-rp",
   "embassy-rp/fifo-handler",
 ]
-core-affinity = ["multicore"]
+core-affinity = ["multi-core"]

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -47,3 +47,4 @@ embassy-rp = { workspace = true, features = ["fifo-handler"] }
 
 [features]
 defmt = ["dep:defmt", "riot-rs-runqueue/defmt"]
+core-affinity = []

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -2,6 +2,10 @@
 name = "riot-rs-threads"
 version = "0.1.0"
 edition = "2021"
+authors = [
+  "Kaspar Schleiser <kaspar@schleiser.de>",
+  "Elena Frank <elena.frank@proton.me>",
+]
 license.workspace = true
 description = "generic embedded scheduler & IPC"
 include = ["src/**/*", "README.md"]
@@ -35,6 +39,11 @@ cortex-m.workspace = true
 cortex-m-rt.workspace = true
 cortex-m-semihosting.workspace = true
 panic-semihosting = { version = "0.6.0", features = ["exit"] }
+
+[target.'cfg(context = "rp2040")'.dependencies]
+static_cell.workspace = true
+rp-pac.workspace = true
+embassy-rp.workspace = true
 
 [features]
 defmt = ["dep:defmt", "riot-rs-runqueue/defmt"]

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -41,10 +41,16 @@ cortex-m-semihosting.workspace = true
 panic-semihosting = { version = "0.6.0", features = ["exit"] }
 
 [target.'cfg(context = "rp2040")'.dependencies]
-static_cell.workspace = true
-rp-pac.workspace = true
-embassy-rp = { workspace = true, features = ["fifo-handler"] }
+static_cell = { workspace = true, optional = true }
+rp-pac = { workspace = true, optional = true }
+embassy-rp = { workspace = true, optional = true }
 
 [features]
 defmt = ["dep:defmt", "riot-rs-runqueue/defmt"]
-core-affinity = []
+multicore = [
+  "dep:static_cell",
+  "dep:rp-pac",
+  "dep:embassy-rp",
+  "embassy-rp/fifo-handler",
+]
+core-affinity = ["multicore"]

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -32,6 +32,7 @@ esp-hal = { workspace = true, features = ["esp32c6"] }
 
 [target.'cfg(context = "esp32s3")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32s3"] }
+static_cell = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 # cortex-m specifics

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -20,6 +20,7 @@ critical-section.workspace = true
 linkme = { workspace = true }
 paste.workspace = true
 riot-rs-runqueue.workspace = true
+riot-rs-utils.workspace = true
 static_cell.workspace = true
 
 defmt = { workspace = true, optional = true }

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -43,7 +43,7 @@ panic-semihosting = { version = "0.6.0", features = ["exit"] }
 [target.'cfg(context = "rp2040")'.dependencies]
 static_cell.workspace = true
 rp-pac.workspace = true
-embassy-rp.workspace = true
+embassy-rp = { workspace = true, features = ["fifo-handler"] }
 
 [features]
 defmt = ["dep:defmt", "riot-rs-runqueue/defmt"]

--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -221,12 +221,13 @@ unsafe fn sched() -> u128 {
                 current.sp = cortex_m::register::psp::read() as usize;
                 current_high_regs = current.data.as_ptr();
             }
-            *threads.current_pid_mut() = Some(next_pid);
 
             let next = threads.get_unchecked(next_pid);
-
-            let next_sp = next.sp;
             let next_high_regs = next.data.as_ptr();
+            let next_sp = next.sp;
+            let next_prio = next.prio;
+
+            threads.set_current(next_pid, next_prio);
 
             // The caller (`PendSV`) expects these three pointers in r0, r1 and r2:
             // r0 = &next.sp

--- a/src/riot-rs-threads/src/arch/cortex_m.rs
+++ b/src/riot-rs-threads/src/arch/cortex_m.rs
@@ -197,16 +197,16 @@ unsafe fn sched() -> u128 {
         if let Some(res) = critical_section::with(|cs| {
             let threads = unsafe { &mut *THREADS.as_ptr(cs) };
 
-            #[cfg(feature = "multicore")]
+            #[cfg(feature = "multi-core")]
             threads.add_current_thread_to_rq();
 
             let next_pid = match threads.get_next_pid() {
                 Some(pid) => pid,
                 None => {
-                    #[cfg(feature = "multicore")]
+                    #[cfg(feature = "multi-core")]
                     unreachable!("At least one idle thread is always present for each core.");
 
-                    #[cfg(not(feature = "multicore"))]
+                    #[cfg(not(feature = "multi-core"))]
                     {
                         Cpu::wfi();
                         // this fence seems necessary, see #310.

--- a/src/riot-rs-threads/src/arch/mod.rs
+++ b/src/riot-rs-threads/src/arch/mod.rs
@@ -22,6 +22,10 @@ pub trait Arch {
 
     /// Setup and initiate the first context switch.
     fn start_threading();
+
+    /// Prompts the CPU to enter deep sleep until an interrupt occurs.
+    #[allow(dead_code, reason = "used in scheduler implementation")]
+    fn wfi();
 }
 
 cfg_if::cfg_if! {
@@ -47,6 +51,9 @@ cfg_if::cfg_if! {
                 unimplemented!()
             }
             fn schedule() {
+                unimplemented!()
+            }
+            fn wfi() {
                 unimplemented!()
             }
         }

--- a/src/riot-rs-threads/src/arch/riscv.rs
+++ b/src/riot-rs-threads/src/arch/riscv.rs
@@ -146,8 +146,13 @@ unsafe fn sched(trap_frame: &mut TrapFrame) {
                     &mut threads.threads[usize::from(current_pid)].data,
                 );
             }
-            *threads.current_pid_mut() = Some(next_pid);
-            copy_registers(&threads.threads[usize::from(next_pid)].data, trap_frame);
+
+            let thread = threads.get_unchecked(next_pid);
+            let next_prio = thread.prio;
+            copy_registers(&thread.data, trap_frame);
+
+            threads.set_current(next_pid, next_prio);
+
             true
         }) {
             break;

--- a/src/riot-rs-threads/src/arch/xtensa.rs
+++ b/src/riot-rs-threads/src/arch/xtensa.rs
@@ -13,11 +13,14 @@ impl Arch for Cpu {
     const DEFAULT_THREAD_DATA: Self::ThreadData = default_trap_frame();
 
     fn schedule() {
+        #[cfg(not(feature = "multicore"))]
         unsafe {
             (&*SYSTEM::PTR)
                 .cpu_intr_from_cpu_0()
                 .modify(|_, w| w.cpu_intr_from_cpu_0().set_bit());
         }
+        #[cfg(feature = "multicore")]
+        crate::smp::schedule_on_core(crate::core_id())
     }
 
     fn setup_stack(thread: &mut crate::thread::Thread, stack: &mut [u8], func: usize, arg: usize) {
@@ -61,7 +64,7 @@ const fn default_trap_frame() -> TrapFrame {
     TrapFrame::new()
 }
 
-/// Handler for software interrupt 0, which we use for context switching.
+/// Handler for software interrupt 0, which we use for context switching on core 0.
 #[allow(non_snake_case)]
 #[no_mangle]
 extern "C" fn FROM_CPU_INTR0(trap_frame: &mut TrapFrame) {
@@ -70,6 +73,21 @@ extern "C" fn FROM_CPU_INTR0(trap_frame: &mut TrapFrame) {
         (&*SYSTEM::PTR)
             .cpu_intr_from_cpu_0()
             .modify(|_, w| w.cpu_intr_from_cpu_0().clear_bit());
+
+        sched(trap_frame)
+    }
+}
+
+#[cfg(feature = "multicore")]
+/// Handler for software interrupt 1, which we use for context switching on core 1.
+#[allow(non_snake_case)]
+#[no_mangle]
+extern "C" fn FROM_CPU_INTR1(trap_frame: &mut TrapFrame) {
+    unsafe {
+        // clear FROM_CPU_INTR0
+        (&*SYSTEM::PTR)
+            .cpu_intr_from_cpu_1()
+            .modify(|_, w| w.cpu_intr_from_cpu_1().clear_bit());
 
         sched(trap_frame)
     }
@@ -86,6 +104,9 @@ extern "C" fn FROM_CPU_INTR0(trap_frame: &mut TrapFrame) {
 unsafe fn sched(trap_frame: &mut TrapFrame) {
     loop {
         if THREADS.with_mut(|mut threads| {
+            #[cfg(feature = "multicore")]
+            threads.add_current_thread_to_rq();
+
             let Some(next_pid) = threads.get_next_pid() else {
                 return false;
             };

--- a/src/riot-rs-threads/src/arch/xtensa.rs
+++ b/src/riot-rs-threads/src/arch/xtensa.rs
@@ -96,8 +96,12 @@ unsafe fn sched(trap_frame: &mut TrapFrame) {
                 }
                 threads.threads[usize::from(current_pid)].data = *trap_frame;
             }
-            *threads.current_pid_mut() = Some(next_pid);
-            *trap_frame = threads.threads[usize::from(next_pid)].data;
+
+            let thread = threads.get_unchecked(next_pid);
+            *trap_frame = thread.data;
+            let next_prio = thread.prio;
+            threads.set_current(next_pid, next_prio);
+
             true
         }) {
             break;

--- a/src/riot-rs-threads/src/arch/xtensa.rs
+++ b/src/riot-rs-threads/src/arch/xtensa.rs
@@ -13,13 +13,13 @@ impl Arch for Cpu {
     const DEFAULT_THREAD_DATA: Self::ThreadData = default_trap_frame();
 
     fn schedule() {
-        #[cfg(not(feature = "multicore"))]
+        #[cfg(not(feature = "multi-core"))]
         unsafe {
             (&*SYSTEM::PTR)
                 .cpu_intr_from_cpu_0()
                 .modify(|_, w| w.cpu_intr_from_cpu_0().set_bit());
         }
-        #[cfg(feature = "multicore")]
+        #[cfg(feature = "multi-core")]
         crate::smp::schedule_on_core(crate::core_id())
     }
 
@@ -78,7 +78,7 @@ extern "C" fn FROM_CPU_INTR0(trap_frame: &mut TrapFrame) {
     }
 }
 
-#[cfg(feature = "multicore")]
+#[cfg(feature = "multi-core")]
 /// Handler for software interrupt 1, which we use for context switching on core 1.
 #[allow(non_snake_case)]
 #[no_mangle]
@@ -104,7 +104,7 @@ extern "C" fn FROM_CPU_INTR1(trap_frame: &mut TrapFrame) {
 unsafe fn sched(trap_frame: &mut TrapFrame) {
     loop {
         if THREADS.with_mut(|mut threads| {
-            #[cfg(feature = "multicore")]
+            #[cfg(feature = "multi-core")]
             threads.add_current_thread_to_rq();
 
             let Some(next_pid) = threads.get_next_pid() else {

--- a/src/riot-rs-threads/src/autostart_thread.rs
+++ b/src/riot-rs-threads/src/autostart_thread.rs
@@ -3,14 +3,14 @@
 /// The thread is given a `stacksize`-byte stack, and has priority `priority`.
 #[macro_export]
 macro_rules! autostart_thread {
-    ($fn_name:ident, stacksize = $stacksize:expr, priority = $priority:expr) => {
+    ($fn_name:ident, stacksize = $stacksize:expr, priority = $priority:expr, affinity = $affinity:expr) => {
         $crate::macro_reexports::paste::paste! {
             #[$crate::macro_reexports::linkme::distributed_slice($crate::THREAD_FNS)]
             #[linkme(crate = $crate::macro_reexports::linkme)]
             fn [<__start_thread_ $fn_name>] () {
                 use $crate::macro_reexports::static_cell::ConstStaticCell;
                 static STACK: ConstStaticCell<[u8; $stacksize]> = ConstStaticCell::new([0u8; $stacksize]);
-                $crate::thread_create_noarg($fn_name, STACK.take(), $priority);
+                $crate::thread_create_noarg($fn_name, STACK.take(), $priority, $affinity);
             }
         }
     };

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -32,9 +32,11 @@
 mod arch;
 mod autostart_thread;
 mod ensure_once;
-mod smp;
 mod thread;
 mod threadlist;
+
+#[cfg(feature = "multicore")]
+mod smp;
 
 pub mod sync;
 pub mod thread_flags;
@@ -48,21 +50,31 @@ pub mod macro_reexports {
 }
 
 pub use riot_rs_runqueue::{RunqueueId, ThreadId};
-pub use smp::CoreId;
 pub use thread_flags as flags;
 
 #[cfg(feature = "core-affinity")]
 pub use smp::CoreAffinity;
+#[cfg(feature = "multicore")]
+pub use smp::CoreId;
 
 use arch::{schedule, Arch, Cpu, ThreadData};
 use ensure_once::EnsureOnce;
 use riot_rs_runqueue::RunQueue;
-use smp::{schedule_on_core, Multicore};
-use static_cell::ConstStaticCell;
 use thread::{Thread, ThreadState};
 
+#[cfg(feature = "multicore")]
+use smp::{schedule_on_core, Multicore};
+#[cfg(feature = "multicore")]
+use static_cell::ConstStaticCell;
+
+/// Dummy type that is needed because [`CoreAffinity`] is part of the general API.
+///
+/// To configure core affinities for threads, the `core-affinity` feature must be enabled.
 #[cfg(not(feature = "core-affinity"))]
-use smp::CoreAffinity;
+pub struct CoreAffinity {
+    // Phantom field to ensure that `CoreAffinity` can never be constructed by a user.
+    _phantom: core::marker::PhantomData<()>,
+}
 
 /// The number of possible priority levels.
 pub const SCHED_PRIO_LEVELS: usize = 12;
@@ -70,7 +82,9 @@ pub const SCHED_PRIO_LEVELS: usize = 12;
 /// The maximum number of concurrent threads that can be created.
 pub const THREADS_NUMOF: usize = 16;
 
+#[cfg(feature = "multicore")]
 pub const CORES_NUMOF: usize = smp::Chip::CORES as usize;
+#[cfg(feature = "multicore")]
 pub const IDLE_THREAD_STACK_SIZE: usize = smp::Chip::IDLE_THREAD_STACK_SIZE;
 
 static THREADS: EnsureOnce<Threads> = EnsureOnce::new(Threads::new());
@@ -89,8 +103,12 @@ struct Threads {
     /// `Some` when a thread is blocking another thread due to conflicting
     /// resource access.
     thread_blocklist: [Option<ThreadId>; THREADS_NUMOF],
-    /// The currently running thread.
-    current_threads: [Option<(ThreadId, RunqueueId)>; CORES_NUMOF],
+
+    /// The currently running thread(s).
+    #[cfg(feature = "multicore")]
+    current_threads: [Option<ThreadId>; CORES_NUMOF],
+    #[cfg(not(feature = "multicore"))]
+    current_thread: Option<ThreadId>,
 }
 
 impl Threads {
@@ -99,7 +117,10 @@ impl Threads {
             runqueue: RunQueue::new(),
             threads: [const { Thread::default() }; THREADS_NUMOF],
             thread_blocklist: [const { None }; THREADS_NUMOF],
+            #[cfg(feature = "multicore")]
             current_threads: [None; CORES_NUMOF],
+            #[cfg(not(feature = "multicore"))]
+            current_thread: None,
         }
     }
 
@@ -112,20 +133,42 @@ impl Threads {
     ///
     /// Returns `None` if there is no current thread.
     fn current(&mut self) -> Option<&mut Thread> {
-        self.current_threads[usize::from(core_id())]
-            .map(|(pid, _)| &mut self.threads[usize::from(pid)])
+        self.current_pid()
+            .map(|pid| &mut self.threads[usize::from(pid)])
     }
 
+    /// Returns the ID of the current thread, or [`None`] if no thread is currently
+    /// running.
+    ///
+    /// On multicore, it returns the ID of the thread that is running on the
+    /// current core.
+    #[inline]
     fn current_pid(&self) -> Option<ThreadId> {
-        self.current_threads[usize::from(core_id())].map(|(id, _)| id)
+        #[cfg(feature = "multicore")]
+        {
+            self.current_threads[usize::from(core_id())]
+        }
+        #[cfg(not(feature = "multicore"))]
+        {
+            self.current_thread
+        }
     }
 
-    #[allow(
-        dead_code,
-        reason = "used in context-specific scheduler implementation"
-    )]
-    fn set_current(&mut self, pid: ThreadId, prio: RunqueueId) {
-        self.current_threads[usize::from(core_id())] = Some((pid, prio))
+    /// Returns a mutable reference to the current thread ID, or [`None`]
+    /// if no thread is currently running.
+    ///
+    /// On multicore, it refers to the ID of the thread that is running on the
+    /// current core.
+    #[allow(dead_code, reason = "used in scheduler implementation")]
+    fn current_pid_mut(&mut self) -> &mut Option<ThreadId> {
+        #[cfg(feature = "multicore")]
+        {
+            &mut self.current_threads[usize::from(core_id())]
+        }
+        #[cfg(not(feature = "multicore"))]
+        {
+            &mut self.current_thread
+        }
     }
 
     /// Creates a new thread.
@@ -206,14 +249,19 @@ impl Threads {
     fn set_state(&mut self, pid: ThreadId, state: ThreadState) -> ThreadState {
         let thread = self.get_unchecked_mut(pid);
         let old_state = core::mem::replace(&mut thread.state, state);
+        let prio = thread.prio;
         if state == ThreadState::Running {
-            let prio = thread.prio;
             self.runqueue.add(pid, prio);
             self.schedule_if_higher_prio(pid, prio);
         } else if old_state == ThreadState::Running {
             // A running thread is only set to a non-running state
             // if it itself initiated it.
             debug_assert_eq!(Some(pid), self.current_pid());
+
+            // On multicore, the currently running thread is not in the runqueue
+            // anyway, so we don't need to remove it here.
+            #[cfg(not(feature = "multicore"))]
+            self.runqueue.pop_head(pid, prio);
 
             schedule();
         }
@@ -251,19 +299,19 @@ impl Threads {
             return;
         }
 
-        // Check if the thread is currently running and trigger the scheduler if
+        // Check if the thread is among the current threads and trigger scheduler if
         // its prio decreased and another thread might have a higher prio now.
         // This has to be done on multicore **before the runqueue changes below**, because
         // a currently running thread is not in the runqueue and therefore the runqueue changes
         // should not be applied.
-        if let Some(core) = self.is_running(thread_id, old_prio) {
-            self.current_threads[core] = Some((thread_id, prio));
-            if prio < old_prio {
-                schedule_on_core(CoreId(core as u8));
-            }
-            return;
+        #[cfg(feature = "multicore")]
+        match self.is_running(thread_id) {
+            Some(core) if prio < old_prio => return schedule_on_core(CoreId(core as u8)),
+            Some(_) => return,
+            _ => {}
         }
 
+        // Update the runqueue.
         if self.runqueue.peek_head(old_prio) == Some(thread_id) {
             self.runqueue.pop_head(thread_id, old_prio);
         } else {
@@ -271,42 +319,135 @@ impl Threads {
         }
         self.runqueue.add(thread_id, prio);
 
+        // Check & handle if the thread is among the current threads for single-core,
+        // analogous to the above multicore implementation.
+        #[cfg(not(feature = "multicore"))]
+        match self.is_running(thread_id) {
+            Some(_) if prio < old_prio => return schedule(),
+            Some(_) => return,
+            _ => {}
+        }
+
         // Thread isn't running.
-        // Only schedule if the thread has a higher priority than the running one.
+        // Only schedule if the thread has a higher priority than a running one.
         if prio > old_prio {
             self.schedule_if_higher_prio(thread_id, prio);
         }
     }
 
-    /// Triggers the scheduler if the thread has a higher priority than the currently running thread.
-    fn schedule_if_higher_prio(&mut self, thread_id: ThreadId, prio: RunqueueId) {
-        match self.lowest_running_prio(thread_id) {
+    /// Triggers the scheduler if the thread has a higher priority than (one of)
+    /// the running thread(s).
+    fn schedule_if_higher_prio(&mut self, _thread_id: ThreadId, prio: RunqueueId) {
+        #[cfg(not(feature = "multicore"))]
+        match self.current().map(|t| t.prio) {
+            Some(curr_prio) if curr_prio < prio => schedule(),
+            _ => {}
+        }
+        #[cfg(feature = "multicore")]
+        match self.lowest_running_prio(_thread_id) {
             (core, Some(lowest_prio)) if lowest_prio < prio => schedule_on_core(core),
             _ => {}
         }
     }
 
-    /// Returns the info if the thread is currently running.
-    fn is_running(&self, thread_id: ThreadId, prio: RunqueueId) -> Option<usize> {
-        self.current_threads
-            .iter()
-            .position(|pid| *pid == Some((thread_id, prio)))
+    /// Returns `Some` if the thread is currently running on a core.
+    ///
+    /// On multicore, the core-id is returned as usize, on single-core
+    /// the usize is always 0.
+    fn is_running(&self, thread_id: ThreadId) -> Option<usize> {
+        #[cfg(not(feature = "multicore"))]
+        {
+            self.current_pid()
+                .filter(|pid| *pid == thread_id)
+                .map(|_| 0)
+        }
+
+        #[cfg(feature = "multicore")]
+        {
+            self.current_threads
+                .iter()
+                .position(|pid| *pid == Some(thread_id))
+        }
     }
 
-    fn lowest_running_prio(&self, _thread_id: ThreadId) -> (CoreId, Option<RunqueueId>) {
-        #[cfg(feature = "core-affinity")]
-        let affinity = self.get_unchecked(_thread_id).core_affinity;
+    /// Adds the thread that is running on the current core to the
+    /// runqueue if it has state [`ThreadState::Running`].
+    #[cfg(feature = "multicore")]
+    #[allow(dead_code, reason = "used in scheduler implementation")]
+    fn add_current_thread_to_rq(&mut self) {
+        let (pid, prio) = match self.current() {
+            Some(&mut Thread {
+                pid,
+                prio,
+                state: ThreadState::Running,
+                ..
+            }) => (pid, prio),
+            _ => return,
+        };
+        self.runqueue.add(pid, prio);
+    }
 
+    /// Returns the next thread from the runqueue.
+    ///
+    /// On single-core, the thread remains in the runqueue, so subsequent calls
+    /// will return the same thread.
+    ///
+    /// On multi-core, the thread is removed so that subsequent calls will each
+    /// return a different thread. This prevents that a thread is picked multiple
+    /// times by the scheduler when it is invoked on different cores.
+    #[allow(dead_code, reason = "used in scheduler implementation")]
+    fn get_next_pid(&mut self) -> Option<ThreadId> {
+        // On single-core, only read the head of the runqueue.
+        #[cfg(not(feature = "multicore"))]
+        {
+            self.runqueue.get_next()
+        }
+
+        // On multi-core, the head is popped of the runqueue.
+        #[cfg(all(feature = "multicore", not(feature = "core-affinity")))]
+        {
+            self.runqueue.pop_next()
+        }
+
+        // On multicore with core-affinities, get next thread with matching affinity.
+        #[cfg(all(feature = "multicore", feature = "core-affinity"))]
+        {
+            // TODO: this would benefit from a `del_one_with_filter` to avoid
+            // iterating twice.
+            let next = self
+                .runqueue
+                .get_next_filter(|&t| self.is_affine_to_curr_core(t))?;
+            // Delete thread from runqueue to match the `pop_next`.
+            self.runqueue.del(next);
+            Some(next)
+        }
+    }
+
+    /// Searches for the lowest priority thread among the currently running threads.
+    ///
+    /// Returns the core that the lowest priority thread is running on, and its priority.
+    /// Returns `None` for the priority if an idle core was found, which is only the case
+    /// during startup.
+    ///
+    /// If core-affinities are enabled, the parameter `_pid` restricts the search to only
+    /// consider the cores that match this thread's [`CoreAffinity`].
+    #[cfg(feature = "multicore")]
+    fn lowest_running_prio(&self, _pid: ThreadId) -> (CoreId, Option<RunqueueId>) {
+        #[cfg(feature = "core-affinity")]
+        let affinity = self.get_unchecked(_pid).core_affinity;
+        // Find the lowest priority thread among the currently running threads.
         self.current_threads
             .iter()
             .enumerate()
-            .filter_map(|(core, thread)| {
-                let core = CoreId::new(core as u8);
+            .filter_map(|(core, pid)| {
+                let core = CoreId(core as u8);
+                // Skip cores that don't match the core-affinity.
                 #[cfg(feature = "core-affinity")]
                 if !affinity.contains(core) {
                     return None;
                 }
-                Some(((core), thread.unzip().1))
+                let prio = pid.map(|pid| self.get_unchecked(pid).prio);
+                Some(((core), prio))
             })
             .min_by_key(|(_, rq)| *rq)
             .unwrap()
@@ -334,25 +475,28 @@ impl Threads {
 /// Currently it expects at least:
 /// - Cortex-M: to be called from the reset handler while MSP is active
 pub unsafe fn start_threading() {
-    // Idle thread that prompts the core to enter deep sleep.
-    fn idle_thread() {
-        loop {
-            Cpu::wfi();
+    #[cfg(feature = "multicore")]
+    {
+        // Idle thread that prompts the core to enter deep sleep.
+        fn idle_thread() {
+            loop {
+                Cpu::wfi();
+            }
         }
+
+        // Stacks for the idle threads.
+        // Creating them inside the below for-loop is not possible because it would result in
+        // duplicate identifiers for the created `static`.
+        static STACKS: [ConstStaticCell<[u8; IDLE_THREAD_STACK_SIZE]>; CORES_NUMOF] =
+            [const { ConstStaticCell::new([0u8; IDLE_THREAD_STACK_SIZE]) }; CORES_NUMOF];
+
+        // Create one idle thread for each core with lowest priority.
+        for stack in &STACKS {
+            thread_create_noarg(idle_thread, stack.take(), 0, None);
+        }
+
+        smp::Chip::startup_other_cores();
     }
-
-    // Stacks for the idle threads.
-    // Creating them inside the below for-loop is not possible because it would result in
-    // duplicate identifiers for the created `static`.
-    static STACKS: [ConstStaticCell<[u8; IDLE_THREAD_STACK_SIZE]>; CORES_NUMOF] =
-        [const { ConstStaticCell::new([0u8; IDLE_THREAD_STACK_SIZE]) }; CORES_NUMOF];
-
-    // Create one idle thread for each core with lowest priority.
-    for stack in &STACKS {
-        thread_create_noarg(idle_thread, stack.take(), 0, None);
-    }
-
-    smp::Chip::startup_other_cores();
     Cpu::start_threading();
 }
 
@@ -447,6 +591,7 @@ pub fn current_pid() -> Option<ThreadId> {
 }
 
 /// Returns the id of the CPU that this thread is running on.
+#[cfg(feature = "multicore")]
 pub fn core_id() -> CoreId {
     smp::Chip::core_id()
 }
@@ -480,6 +625,16 @@ pub fn yield_same() {
         let Some(prio) = threads.current().map(|t| t.prio) else {
             return;
         };
+
+        #[cfg(not(feature = "multicore"))]
+        if threads.runqueue.advance(prio) {
+            schedule()
+        }
+
+        // On multicore, the current thread is removed from the runqueue, and then
+        // re-added **at the tail** in `sched` the next time the scheduler is triggered.
+        // Simply triggering the scheduler therefore implicitly advances the runqueue.
+        #[cfg(feature = "multicore")]
         if !threads.runqueue.is_empty(prio) {
             schedule();
         }

--- a/src/riot-rs-threads/src/smp/esp32s3.rs
+++ b/src/riot-rs-threads/src/smp/esp32s3.rs
@@ -1,0 +1,88 @@
+use esp_hal::{
+    cpu_control::{CpuControl, Stack},
+    interrupt,
+    peripherals::{Interrupt, CPU_CTRL, SYSTEM},
+    Cpu,
+};
+
+use static_cell::ConstStaticCell;
+
+use super::{CoreId, Multicore};
+
+impl From<Cpu> for CoreId {
+    fn from(value: Cpu) -> Self {
+        match value {
+            Cpu::ProCpu => CoreId(0),
+            Cpu::AppCpu => CoreId(1),
+        }
+    }
+}
+
+pub struct Chip;
+
+impl Multicore for Chip {
+    const CORES: u32 = 2;
+    const IDLE_THREAD_STACK_SIZE: usize = 2048;
+
+    fn core_id() -> CoreId {
+        esp_hal::get_core().into()
+    }
+
+    fn startup_other_cores() {
+        // TODO: How much stack do we really need here?
+        static STACK: ConstStaticCell<Stack<4096>> = ConstStaticCell::new(Stack::new());
+        // Trigger scheduler.
+        let start_threading = move || {
+            // Use `CPU_INTR1` to trigger the scheduler on our second core.
+            // We need to use a different interrupt here than on the first core so that
+            // we specifically trigger the scheduler on one or the other core.
+            interrupt::disable(esp_hal::Cpu::ProCpu, Interrupt::FROM_CPU_INTR1);
+            Self::schedule_on_core(Self::core_id());
+            // Panics if `FROM_CPU_INTR1` is among `esp_hal::interrupt::RESERVED_INTERRUPTS`,
+            // which isn't the case.
+            interrupt::enable(Interrupt::FROM_CPU_INTR1, interrupt::Priority::min()).unwrap();
+
+            unreachable!()
+        };
+
+        let mut cpu_ctrl = unsafe { CpuControl::new(CPU_CTRL::steal()) };
+        let guard = cpu_ctrl.start_app_core(STACK.take(), start_threading);
+
+        // Dropping the guard would park the other core.
+        core::mem::forget(guard)
+    }
+
+    fn schedule_on_core(id: CoreId) {
+        let ptr = unsafe { &*SYSTEM::PTR };
+        let mut id = id.0;
+        let already_set = match id {
+            0 => ptr
+                .cpu_intr_from_cpu_0()
+                .read()
+                .cpu_intr_from_cpu_0()
+                .bit_is_set(),
+            1 => ptr
+                .cpu_intr_from_cpu_1()
+                .read()
+                .cpu_intr_from_cpu_1()
+                .bit_is_set(),
+            _ => unreachable!(),
+        };
+        if already_set {
+            // If a scheduling attempt is already pending, there must have been multiple
+            // changes in the runqueue at the same time.
+            // Trigger the scheduler on the other core as well to make sure that both schedulers
+            // have the most recent runqueue state.
+            id ^= 1;
+        }
+        match id {
+            0 => ptr
+                .cpu_intr_from_cpu_0()
+                .write(|w| w.cpu_intr_from_cpu_0().set_bit()),
+            1 => ptr
+                .cpu_intr_from_cpu_1()
+                .write(|w| w.cpu_intr_from_cpu_1().set_bit()),
+            _ => unreachable!(),
+        };
+    }
+}

--- a/src/riot-rs-threads/src/smp/esp32s3.rs
+++ b/src/riot-rs-threads/src/smp/esp32s3.rs
@@ -7,7 +7,7 @@ use esp_hal::{
 
 use static_cell::ConstStaticCell;
 
-use super::{CoreId, Multicore};
+use super::{CoreId, Multicore, ISR_STACKSIZE_CORE1};
 
 impl From<Cpu> for CoreId {
     fn from(value: Cpu) -> Self {
@@ -30,7 +30,8 @@ impl Multicore for Chip {
 
     fn startup_other_cores() {
         // TODO: How much stack do we really need here?
-        static STACK: ConstStaticCell<Stack<4096>> = ConstStaticCell::new(Stack::new());
+        static STACK: ConstStaticCell<Stack<ISR_STACKSIZE_CORE1>> =
+            ConstStaticCell::new(Stack::new());
         // Trigger scheduler.
         let start_threading = move || {
             // Use `CPU_INTR1` to trigger the scheduler on our second core.

--- a/src/riot-rs-threads/src/smp/mod.rs
+++ b/src/riot-rs-threads/src/smp/mod.rs
@@ -75,10 +75,13 @@ pub fn schedule_on_core(id: CoreId) {
     Chip::schedule_on_core(id)
 }
 
+/// Affinity mask that defines on what cores a thread can be scheduled.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg(feature = "core-affinity")]
 pub struct CoreAffinity(u8);
 
+#[cfg(feature = "core-affinity")]
 impl CoreAffinity {
     /// Allows a thread to be scheduled on any core and to migrate
     /// from one core to another between executions.

--- a/src/riot-rs-threads/src/smp/mod.rs
+++ b/src/riot-rs-threads/src/smp/mod.rs
@@ -42,6 +42,9 @@ pub trait Multicore {
     fn startup_other_cores();
 
     fn sev();
+
+    /// Triggers the scheduler on core `id`.
+    fn schedule_on_core(id: CoreId);
 }
 
 cfg_if::cfg_if! {
@@ -50,6 +53,8 @@ cfg_if::cfg_if! {
         pub use rp2040::Chip;
     }
     else {
+        use crate::{Arch as _, Cpu};
+
         pub struct Chip;
         impl Multicore for Chip {
             const CORES: u32 = 1;
@@ -61,10 +66,19 @@ cfg_if::cfg_if! {
             fn startup_other_cores() {}
 
             fn sev() {}
+
+            fn schedule_on_core(_id: CoreId) {
+                Cpu::schedule();
+            }
         }
     }
 }
 
 pub fn sev() {
     Chip::sev()
+}
+
+/// Triggers the scheduler on core `id`.
+pub fn schedule_on_core(id: CoreId) {
+    Chip::schedule_on_core(id)
 }

--- a/src/riot-rs-threads/src/smp/mod.rs
+++ b/src/riot-rs-threads/src/smp/mod.rs
@@ -41,8 +41,6 @@ pub trait Multicore {
     /// This is called at boot time by the first core.
     fn startup_other_cores();
 
-    fn sev();
-
     /// Triggers the scheduler on core `id`.
     fn schedule_on_core(id: CoreId);
 }
@@ -65,17 +63,11 @@ cfg_if::cfg_if! {
 
             fn startup_other_cores() {}
 
-            fn sev() {}
-
             fn schedule_on_core(_id: CoreId) {
                 Cpu::schedule();
             }
         }
     }
-}
-
-pub fn sev() {
-    Chip::sev()
 }
 
 /// Triggers the scheduler on core `id`.

--- a/src/riot-rs-threads/src/smp/mod.rs
+++ b/src/riot-rs-threads/src/smp/mod.rs
@@ -1,7 +1,4 @@
-/// ID of a physical core.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct CoreId(pub(crate) u8);
+use crate::CoreId;
 
 impl CoreId {
     /// Creates a new [`CoreId`].
@@ -18,12 +15,6 @@ impl CoreId {
             )
         }
         Self(value)
-    }
-}
-
-impl From<CoreId> for usize {
-    fn from(value: CoreId) -> Self {
-        value.0 as usize
     }
 }
 

--- a/src/riot-rs-threads/src/smp/mod.rs
+++ b/src/riot-rs-threads/src/smp/mod.rs
@@ -1,4 +1,5 @@
 use crate::CoreId;
+use riot_rs_utils::usize_from_env_or;
 
 impl CoreId {
     /// Creates a new [`CoreId`].
@@ -105,3 +106,15 @@ impl Default for CoreAffinity {
         Self::no_affinity()
     }
 }
+
+/// Main stack size for the second core, that is also used by the ISR.
+///
+/// Uses default from `riot-rs-rt` if not specified.
+/// The `CONFIG_ISR_STACKSIZE` env name and default is copied from
+/// `riot-rs-rt`.
+#[allow(dead_code, reason = "used in chip submodules")]
+const ISR_STACKSIZE_CORE1: usize = usize_from_env_or!(
+    "CONFIG_ISR_STACKSIZE_CORE1",
+    usize_from_env_or!("CONFIG_ISR_STACKSIZE", 8192, "ISR stack size (in bytes)"),
+    "Core 1 ISR stack size (in bytes)"
+);

--- a/src/riot-rs-threads/src/smp/mod.rs
+++ b/src/riot-rs-threads/src/smp/mod.rs
@@ -1,0 +1,70 @@
+/// ID of a physical core.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct CoreId(pub(crate) u8);
+
+impl CoreId {
+    /// Creates a new [`CoreId`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` >= [`Chip::CORES`].
+    pub fn new(value: u8) -> Self {
+        if value >= Chip::CORES as u8 {
+            panic!(
+                "Invalid CoreId {}: only core ids 0..{} available.",
+                value,
+                Chip::CORES
+            )
+        }
+        Self(value)
+    }
+}
+
+impl From<CoreId> for usize {
+    fn from(value: CoreId) -> Self {
+        value.0 as usize
+    }
+}
+
+pub trait Multicore {
+    /// Number of available core.
+    const CORES: u32;
+    /// Stack size for the idle threads.
+    const IDLE_THREAD_STACK_SIZE: usize = 256;
+
+    /// Returns the ID of the current core.
+    fn core_id() -> CoreId;
+
+    /// Starts other available cores.
+    ///
+    /// This is called at boot time by the first core.
+    fn startup_other_cores();
+
+    fn sev();
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(context = "rp2040")] {
+        mod rp2040;
+        pub use rp2040::Chip;
+    }
+    else {
+        pub struct Chip;
+        impl Multicore for Chip {
+            const CORES: u32 = 1;
+
+            fn core_id() -> CoreId {
+                CoreId(0)
+            }
+
+            fn startup_other_cores() {}
+
+            fn sev() {}
+        }
+    }
+}
+
+pub fn sev() {
+    Chip::sev()
+}

--- a/src/riot-rs-threads/src/smp/mod.rs
+++ b/src/riot-rs-threads/src/smp/mod.rs
@@ -49,6 +49,9 @@ cfg_if::cfg_if! {
     if #[cfg(context = "rp2040")] {
         mod rp2040;
         pub use rp2040::Chip;
+    } else if #[cfg(context = "esp32s3")] {
+        mod esp32s3;
+        pub use esp32s3::Chip;
     }
     else {
         use crate::{Arch as _, Cpu};

--- a/src/riot-rs-threads/src/smp/rp2040.rs
+++ b/src/riot-rs-threads/src/smp/rp2040.rs
@@ -1,6 +1,8 @@
 use crate::arch::{Arch as _, Cpu};
 
 use embassy_rp::{
+    interrupt,
+    interrupt::InterruptExt as _,
     multicore::{spawn_core1, Stack},
     peripherals::CORE1,
 };
@@ -23,15 +25,53 @@ impl Multicore for Chip {
         static STACK: ConstStaticCell<Stack<4096>> = ConstStaticCell::new(Stack::new());
         // Trigger scheduler.
         let start_threading = move || {
+            unsafe {
+                interrupt::SIO_IRQ_PROC1.enable();
+            }
             Cpu::start_threading();
             unreachable!()
         };
         unsafe {
             spawn_core1(CORE1::steal(), STACK.take(), start_threading);
+            interrupt::SIO_IRQ_PROC0.enable();
         }
     }
 
     fn sev() {
         cortex_m::asm::sev()
     }
+
+    fn schedule_on_core(id: CoreId) {
+        if id == Self::core_id() {
+            crate::schedule();
+            return;
+        }
+
+        // Use the FIFO queue between the cores to trigger the scheduler
+        // on the other core.
+        let sio = SIO;
+        // If its already full, no need to send another `SCHEDULE_TOKEN`.
+        if !sio.fifo().st().read().rdy() {
+            return;
+        }
+        sio.fifo().wr().write_value(SCHEDULE_TOKEN);
+    }
+}
+
+const SCHEDULE_TOKEN: u32 = 0x11;
+
+/// Handles FIFO message from other core and triggers scheduler
+/// if a [`SCHEDULE_TOKEN`] was received.
+///
+/// This method is injected into the `embassy_rp` interrupt handler
+/// for FIFO messages.
+#[no_mangle]
+#[link_section = ".data.ram_func"]
+#[inline]
+fn handle_fifo_token(token: u32) -> bool {
+    if token != SCHEDULE_TOKEN {
+        return false;
+    }
+    crate::schedule();
+    true
 }

--- a/src/riot-rs-threads/src/smp/rp2040.rs
+++ b/src/riot-rs-threads/src/smp/rp2040.rs
@@ -37,10 +37,6 @@ impl Multicore for Chip {
         }
     }
 
-    fn sev() {
-        cortex_m::asm::sev()
-    }
-
     fn schedule_on_core(id: CoreId) {
         if id == Self::core_id() {
             crate::schedule();

--- a/src/riot-rs-threads/src/smp/rp2040.rs
+++ b/src/riot-rs-threads/src/smp/rp2040.rs
@@ -10,7 +10,7 @@ use embassy_rp::{
 use rp_pac::SIO;
 use static_cell::ConstStaticCell;
 
-use super::{CoreId, Multicore};
+use super::{CoreId, Multicore, ISR_STACKSIZE_CORE1};
 
 pub struct Chip;
 
@@ -23,7 +23,8 @@ impl Multicore for Chip {
 
     fn startup_other_cores() {
         // TODO: How much stack do we really need here?
-        static STACK: ConstStaticCell<Stack<4096>> = ConstStaticCell::new(Stack::new());
+        static STACK: ConstStaticCell<Stack<ISR_STACKSIZE_CORE1>> =
+            ConstStaticCell::new(Stack::new());
         // Trigger scheduler.
         let start_threading = move || {
             unsafe {

--- a/src/riot-rs-threads/src/smp/rp2040.rs
+++ b/src/riot-rs-threads/src/smp/rp2040.rs
@@ -1,0 +1,37 @@
+use crate::arch::{Arch as _, Cpu};
+
+use embassy_rp::{
+    multicore::{spawn_core1, Stack},
+    peripherals::CORE1,
+};
+use rp_pac::SIO;
+use static_cell::ConstStaticCell;
+
+use super::{CoreId, Multicore};
+
+pub struct Chip;
+
+impl Multicore for Chip {
+    const CORES: u32 = 2;
+
+    fn core_id() -> CoreId {
+        CoreId(SIO.cpuid().read() as u8)
+    }
+
+    fn startup_other_cores() {
+        // TODO: How much stack do we really need here?
+        static STACK: ConstStaticCell<Stack<4096>> = ConstStaticCell::new(Stack::new());
+        // Trigger scheduler.
+        let start_threading = move || {
+            Cpu::start_threading();
+            unreachable!()
+        };
+        unsafe {
+            spawn_core1(CORE1::steal(), STACK.take(), start_threading);
+        }
+    }
+
+    fn sev() {
+        cortex_m::asm::sev()
+    }
+}

--- a/src/riot-rs-threads/src/thread.rs
+++ b/src/riot-rs-threads/src/thread.rs
@@ -22,6 +22,9 @@ pub struct Thread {
     /// Arch-specific thread data.
     #[allow(dead_code)]
     pub(crate) data: ThreadData,
+    /// Core affinity of the thread.
+    #[cfg(feature = "core-affinity")]
+    pub core_affinity: crate::CoreAffinity,
 }
 
 /// Possible states of a thread
@@ -57,6 +60,8 @@ impl Thread {
             flags: 0,
             prio: RunqueueId::new(0),
             pid: ThreadId::new(0),
+            #[cfg(feature = "core-affinity")]
+            core_affinity: crate::CoreAffinity::no_affinity(),
         }
     }
 }

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -106,4 +106,7 @@ executor-thread = ["riot-rs-embassy/executor-thread", "threading"]
 # *Used for internal testing only.*
 executor-none = ["riot-rs-embassy/executor-none"]
 
-core-affinity = ["threading", "riot-rs-threads/core-affinity"]
+#! ## Multicore functionality.
+single-core = ["riot-rs-rt/single-core"]
+multicore = ["riot-rs-threads?/multicore", "riot-rs-rt/multicore"]
+core-affinity = ["multicore", "riot-rs-threads?/core-affinity"]

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -105,3 +105,5 @@ executor-thread = ["riot-rs-embassy/executor-thread", "threading"]
 # Don't start any executor automatically.
 # *Used for internal testing only.*
 executor-none = ["riot-rs-embassy/executor-none"]
+
+core-affinity = ["threading", "riot-rs-threads/core-affinity"]

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -108,5 +108,5 @@ executor-none = ["riot-rs-embassy/executor-none"]
 
 #! ## Multicore functionality.
 single-core = ["riot-rs-rt/single-core"]
-multicore = ["riot-rs-threads?/multicore", "riot-rs-rt/multicore"]
-core-affinity = ["multicore", "riot-rs-threads?/core-affinity"]
+multi-core = ["riot-rs-threads?/multi-core", "riot-rs-rt/multi-core"]
+core-affinity = ["multi-core", "riot-rs-threads?/core-affinity"]

--- a/tests/threading-dynamic-prios/laze.yml
+++ b/tests/threading-dynamic-prios/laze.yml
@@ -2,4 +2,5 @@ apps:
   - name: threading-dynamic-prios
     selects:
       - ?release
+      - single-core
       - sw/threading


### PR DESCRIPTION
# Description

This PR adds support for symmetric multiprocessing (SMP) for `riot-rs-threads`. It's a refactor and continuation of #241.
Right now, only the RP2040 is supported. I am planning to also add support for esp32s3 in a follow-up PR.

The implementation follows a global scheduling approach where the highest _n_ ready threads are scheduled on the _n_ available cores. 
The main change in the scheduler logic is that it now removes the current thread from the runqueue, which is necessary so that a thread doesn't get picked twice. This also means that the thread has to be added to the runqueue again each time the scheduler is triggered (if it's still running). 
This introduces some overhead if the scheduler is triggered unnecessarily. The PR therefore also includes optimizations that make sure that the scheduler is only triggered when a context switch is actually needed.
The implementation furthermore also supports affinity masks, which allow restricting a thread to certain cores.

All multicore logic is feature-gated, so that the single-core implementation largely remains the same. I still notice some difference in preliminary benchmark data, which I am still investigating.

## Issues/PRs references

Tracking issue: #243 

Depends on:
- #455
- #456
- #457
- #458
- #459
- #460

## Open Questions

### Idle threads

If there are no ready threads in the runqueue, the current (= on main) `sched` implementation `WFI`s in a loop. The context of the previous thread is only saved **after** a new thread is ready and the context is actually switched.
This causes some issues on multicore:
1. there is a race condition where it can happen that the still "unsaved" thread becomes ready again, and scheduled on the other core. That core would then pick up an outdated state.
2. we can't WFI inside the critical section because it would also block the other core

By adding idle threads, both of these issues are fixed and we furthermore avoid footguns related to interrupt priorities (e.g. right now we require that all embassy interrupts have a larger priority than `PendSV` so that they can preempt our scheduler when it's stuck in WFI). Wdyt?

## Open TODOS

- [x] Drop commits that have later been reverted (I kept them in the history for now for transparency)
- [ ] Post preliminary benchmark data 
   - compare: main vs this PR (`multicore` not enabled) vs this PR (`multicore` enabled) 
   - boards: RP2040 and nrf52840
   - benchmarks: `bench_sched_yield`, `bench_sched_flags` (new)

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
