### PR TITLE
build(profiles): make the `dev` profile suitable for embedded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,12 +91,12 @@ incremental = false
 codegen-units = 1
 debug = true
 lto = false
-opt-level = 1
+opt-level = "s"     # Optimize for size even in debug builds
 
 [profile.release]
 incremental = false
 codegen-units = 1
-debug = true
+debug = true        # Required for defmt
 lto = false
 opt-level = "s"
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
It is our opinion that the `release` profile should be reserved for production builds.
This makes the `dev` profile suitable for low-Flash targets we support, and will allow us to leverage `debug_assert!`s in debug builds.

Documentation of Cargo profiles can be found here: https://doc.rust-lang.org/cargo/reference/profiles.html

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Future work

- [ ] Change the laze configuration to use the `dev` profile by default, instead of the `release` profile, and allow to use `release` for production builds.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
