### PR TITLE
refactor(runqueue): implement `Default` now that hax supports it

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -15,7 +15,7 @@ jobs:
         uses: hacspec/hax-actions@main
         with:
           # pin hax to known-working
-          hax_reference: 5e3e6d2028db0ca8f583b427f770bbb7c26c7bed
+          hax_reference: cc29a3f8c0eee80a1682be78cb3b0447a0257d5b
 
       - name: 🏃 Extract `riot-rs-runqueue`
         working-directory: ./src/riot-rs-runqueue

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,7 +2297,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 [[package]]
 name = "hax-lib"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?rev=5e3e6d2028db0ca8f583b427f770bbb7c26c7bed#5e3e6d2028db0ca8f583b427f770bbb7c26c7bed"
+source = "git+https://github.com/hacspec/hax?rev=cc29a3f8c0eee80a1682be78cb3b0447a0257d5b#cc29a3f8c0eee80a1682be78cb3b0447a0257d5b"
 dependencies = [
  "hax-lib-macros",
  "num-bigint",
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?rev=5e3e6d2028db0ca8f583b427f770bbb7c26c7bed#5e3e6d2028db0ca8f583b427f770bbb7c26c7bed"
+source = "git+https://github.com/hacspec/hax?rev=cc29a3f8c0eee80a1682be78cb3b0447a0257d5b#cc29a3f8c0eee80a1682be78cb3b0447a0257d5b"
 dependencies = [
  "hax-lib-macros-types",
  "paste",
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "hax-lib-macros-types"
 version = "0.1.0-pre.1"
-source = "git+https://github.com/hacspec/hax?rev=5e3e6d2028db0ca8f583b427f770bbb7c26c7bed#5e3e6d2028db0ca8f583b427f770bbb7c26c7bed"
+source = "git+https://github.com/hacspec/hax?rev=cc29a3f8c0eee80a1682be78cb3b0447a0257d5b#cc29a3f8c0eee80a1682be78cb3b0447a0257d5b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/riot-rs-runqueue/Cargo.toml
+++ b/src/riot-rs-runqueue/Cargo.toml
@@ -16,4 +16,4 @@ defmt = { workspace = true, optional = true }
 # lib, as documented in the hax documentation:
 # https://hacspec.org/book/quick_start/intro.html#setup-the-crate-you-want-to-verify
 [target.'cfg(hax)'.dependencies]
-hax-lib = { git = "https://github.com/hacspec/hax", rev = "5e3e6d2028db0ca8f583b427f770bbb7c26c7bed" }
+hax-lib = { git = "https://github.com/hacspec/hax", rev = "cc29a3f8c0eee80a1682be78cb3b0447a0257d5b" }

--- a/src/riot-rs-runqueue/src/runqueue.rs
+++ b/src/riot-rs-runqueue/src/runqueue.rs
@@ -53,6 +53,7 @@ impl From<ThreadId> for usize {
 /// The current implementation needs an usize for the bit cache,
 /// an `[u8; N_QUEUES]` array for the list tail indexes
 /// and an `[u8; N_THREADS]` for the list next indexes.
+#[derive(Default)]
 pub struct RunQueue<const N_QUEUES: usize, const N_THREADS: usize> {
     /// Bitcache that represents the currently used queues
     /// in `0..N_QUEUES`.
@@ -61,9 +62,6 @@ pub struct RunQueue<const N_QUEUES: usize, const N_THREADS: usize> {
 }
 
 impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_THREADS }> {
-    // NOTE: we don't impl Default here because hax does not support it yet. When it does, we
-    // should impl it.
-    #[allow(clippy::new_without_default)]
     pub const fn new() -> RunQueue<{ N_QUEUES }, { N_THREADS }> {
         // unfortunately we cannot assert!() on N_QUEUES and N_THREADS,
         // as panics in const fn's are not (yet) implemented.
@@ -133,6 +131,12 @@ mod clist {
     pub struct CList<const N_QUEUES: usize, const N_THREADS: usize> {
         tail: [u8; N_QUEUES],
         next_idxs: [u8; N_THREADS],
+    }
+
+    impl<const N_QUEUES: usize, const N_THREADS: usize> Default for CList<N_QUEUES, N_THREADS> {
+        fn default() -> Self {
+            Self::new()
+        }
     }
 
     impl<const N_QUEUES: usize, const N_THREADS: usize> CList<N_QUEUES, N_THREADS> {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Support for `Default` has been added in https://github.com/hacspec/hax/pull/891

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
