### PR TITLE
fix(armv6): make `coap` example deps use portable atomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,6 +4190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2975e035ce16539eecee08d7c6e5626ca26f299c6e90af343b302c6dd2e61e"
 dependencies = [
  "alloc-traits",
+ "atomic-polyfill",
 ]
 
 [[package]]
@@ -4526,8 +4527,10 @@ dependencies = [
 [[package]]
 name = "try-lock"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+source = "git+https://github.com/seanmonstar/try-lock?rev=a1aadfac9840fe23672159c12af7272e44bc684c#a1aadfac9840fe23672159c12af7272e44bc684c"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "trybuild"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,9 @@ embassy-usb-driver = { git = "https://github.com/kaspar030/embassy", branch = "f
 cyw43 = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-2024-08-18" }
 cyw43-pio = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-2024-08-18" }
 
+# patched to use portable-atomics <https://github.com/seanmonstar/try-lock/pull/11>
+try-lock = { git = "https://github.com/seanmonstar/try-lock", rev = "a1aadfac9840fe23672159c12af7272e44bc684c" }
+
 # version 0.12-to-be
 smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "125773e282bc2e0c914a49e9c75573926e26e558" }
 

--- a/deny.toml
+++ b/deny.toml
@@ -51,6 +51,7 @@ allow-git = [
   "https://github.com/smoltcp-rs/smoltcp",
   "https://github.com/twitchyliquid64/usbd-hid",
   "https://gitlab.com/oscore/liboscore",
+  "https://github.com/seanmonstar/try-lock",
 ]
 
 [sources.allow-org]

--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -41,7 +41,7 @@ coap-handler = "0.2.0"
 coap-handler-implementations = "0.5.0"
 hexlit = "0.5.5"
 
-static-alloc = "0.2.5"
+static-alloc = { version = "0.2.5", features = ["polyfill"] }
 coap-scroll-ring-server = "0.2.0"
 scroll-ring = "0.1.1"
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

Found in #413 when wiring up `random` for rp showed that `scroll-ring`, `static-alloc` and `try-lock` were depending on Atomic CAS for types the armv6 doesn't support.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
