### PR TITLE
chore(build): bump Rust toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.6.0"
-source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-08-18#164b3a99efbeccc442971b63dc1b90f03db637ea"
+source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-08-18-wakers#c17dc6cc90d6b9e8c18c8b0ea58c1a4dd868b6f1"
 dependencies = [
  "cortex-m",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ opt-level = 3
 
 [patch.crates-io]
 # riot-rs embassy fork
-embassy-executor = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-2024-08-18" }
+embassy-executor = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-2024-08-18-wakers" }
 embassy-hal-internal = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-2024-08-18" }
 embassy-nrf = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-2024-08-18" }
 embassy-net = { git = "https://github.com/kaspar030/embassy", branch = "for-riot-rs-2024-08-18" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 # this file is parsed with grep & sed for parsing out the actual toolchain
 # from the "channel" line. Please keep that in mind when modifying.
 [toolchain]
-channel = "nightly-2024-05-20"
+channel = "nightly-2024-09-16"
 targets = [
   "thumbv6m-none-eabi",
   "thumbv7m-none-eabi",

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -10,7 +10,6 @@
 //! for at least as long as the OSCORE component is tightly coupled to a particular implementation
 //! of [`coap-message`]).
 #![no_std]
-#![feature(lint_reasons)]
 
 // Might warrant a standalone crate at some point
 //

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
-#![feature(lint_reasons)]
 #![feature(doc_auto_cfg)]
 
 pub mod define_peripherals;

--- a/src/riot-rs-nrf/src/lib.rs
+++ b/src/riot-rs-nrf/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![feature(doc_auto_cfg)]
-#![feature(lint_reasons)]
 
 pub mod gpio;
 

--- a/src/riot-rs-rp/src/lib.rs
+++ b/src/riot-rs-rp/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(doc_auto_cfg)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(type_alias_impl_trait)]
-#![feature(lint_reasons)]
 
 pub mod gpio;
 

--- a/src/riot-rs-runqueue/src/lib.rs
+++ b/src/riot-rs-runqueue/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(test), no_std)]
-#![feature(lint_reasons)]
 
 mod runqueue;
 pub use runqueue::{RunQueue, RunqueueId, ThreadId};

--- a/src/riot-rs-threads/src/lib.rs
+++ b/src/riot-rs-threads/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(test), no_std)]
 #![feature(naked_functions)]
 #![feature(used_with_arg)]
-#![feature(lint_reasons)]
 // Disable indexing lints for now, possible panics are documented or rely on internally-enforced
 // invariants
 #![allow(clippy::indexing_slicing)]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

This PR bumps the Rust toolchain to `nightly-2024-09-16`.
It points the `embassy-executor` tip to a commit updating some wakers API to above's nightly.
Also, all `#[feature(lint_reasons)]` are removed (that feature is now stable).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
