### PR TITLE
fix(stm32): fix the executor-interrupt mode

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -663,6 +663,9 @@ modules:
         FEATURES:
           - riot-rs/executor-single-thread
 
+  # Enabled for architectures that provide a dedicated software interrupt (SWI),
+  # and thus do not require to sacrifice another, arbitrarily-chosen peripheral
+  # interrupt.
   - name: executor-interrupt
     help: use the Embassy interrupt executor
     context:

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -94,6 +94,7 @@ executor-single-thread = [
 executor-interrupt = [
   "riot-rs-nrf/executor-interrupt",
   "riot-rs-rp/executor-interrupt",
+  "riot-rs-stm32/executor-interrupt",
 ]
 executor-thread = ["threading"]
 executor-none = []

--- a/src/riot-rs-stm32/build.rs
+++ b/src/riot-rs-stm32/build.rs
@@ -11,7 +11,7 @@ fn main() {
         if let Ok(var) = env::var("CONFIG_SWI") {
             fs::write(
                 &dest_path,
-                format!("crate::executor_swi!({});\n", var).as_bytes(),
+                format!("riot_rs_embassy_common::executor_swi!({});\n", var).as_bytes(),
             )
             .expect("write failed");
         } else {

--- a/src/riot-rs-stm32/src/lib.rs
+++ b/src/riot-rs-stm32/src/lib.rs
@@ -44,6 +44,9 @@ use {core::mem::MaybeUninit, embassy_stm32::SharedData};
 #[cfg(capability = "hw/stm32-dual-core")]
 static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 
+#[cfg(feature = "executor-interrupt")]
+pub static EXECUTOR: Executor = Executor::new();
+
 pub fn init() -> OptionalPeripherals {
     let mut config = Config::default();
     board_config(&mut config);


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
That mode has been broken during #392

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
