### PR TITLE
chore(rustc-lint): set `unsafe_op_in_unsafe_fn` to `deny`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "125773e282
 # rustc lints are documented here: https://doc.rust-lang.org/rustc/lints/listing/index.html
 private_interfaces = "deny"
 private_bounds = "deny"
-unsafe_op_in_unsafe_fn = "warn"
+unsafe_op_in_unsafe_fn = "deny"
 unused_must_use = "deny"
 # ... until we figure out a way to generate a list of all used cfg variables
 # across build configurations ...


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
`unsafe_op_in_unsafe_fn` is expected to be set to `warn` in the 2024 Rust edition [1], thus asserting that the previously accepted usage of the `unsafe` keyword on functions allowing the use of `unsafe` operations without `unsafe` blocks is deprecated.

We therefore enforce this by setting this lint to `deny` instead of `warn`.

[1]: https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
