### PR TITLE
feat(embassy): reexport `thread_executor` in `api`

### DIFF
--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -53,6 +53,9 @@ pub mod api {
 
     #[cfg(feature = "executor-interrupt")]
     pub use crate::arch::EXECUTOR;
+
+    #[cfg(feature = "executor-thread")]
+    pub use crate::thread_executor;
 }
 
 // These are made available in `riot_rs::reexports`.


### PR DESCRIPTION
# Description

#408 didn't include the `thread_executor` in its re-exports, so this PR is adding it.
Needed if a user wants to create multiple threads with an executor each.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
