### PR TITLE
fix(rt): add missing linkme.x entries

### DIFF
--- a/src/riot-rs-rt/linkme.x
+++ b/src/riot-rs-rt/linkme.x
@@ -3,7 +3,9 @@ SECTIONS {
   linkm2_INIT_FUNCS : { *(linkm2_INIT_FUNCS) } > FLASH
   linkme_EMBASSY_TASKS : { *(linkme_EMBASSY_TASKS) } > FLASH
   linkm2_EMBASSY_TASKS : { *(linkm2_EMBASSY_TASKS) } > FLASH
+  linkme_USB_BUILDER_HOOKS : { *(linkme_USB_BUILDER_HOOKS) } > FLASH
   linkm2_USB_BUILDER_HOOKS : { *(linkm2_USB_BUILDER_HOOKS) } > FLASH
+  linkme_THREAD_FNS : { *(linkme_THREAD_FNS) } > FLASH
   linkm2_THREAD_FNS : { *(linkm2_THREAD_FNS) } > FLASH
 }
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Adds some missing `linkme.x` entries. This worked without before, but on toolchains >=nightly-2024-08-01, not anymore.

## Issues/PRs references

Fixes #422.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
