### PR TITLE
ci(clippy): fail the `lint` job on clippy warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,31 +170,31 @@ jobs:
       - name: clippy
         uses: clechasseur/rs-clippy-check@v3
         with:
-          args: --verbose --locked --features no-boards,external-interrupts -p riot-rs -p riot-rs-boards -p riot-rs-chips -p riot-rs-debug -p riot-rs-embassy -p riot-rs-macros -p riot-rs-random -p riot-rs-rt -p riot-rs-threads -p riot-rs-utils
+          args: --verbose --locked --features no-boards,external-interrupts -p riot-rs -p riot-rs-boards -p riot-rs-chips -p riot-rs-debug -p riot-rs-embassy -p riot-rs-macros -p riot-rs-random -p riot-rs-rt -p riot-rs-threads -p riot-rs-utils -- --deny warnings
 
       - run: echo 'RUSTFLAGS=--cfg context="esp32c6"' >> $GITHUB_ENV
       - name: clippy for ESP32
         uses: clechasseur/rs-clippy-check@v3
         with:
-          args: --verbose --locked --target=riscv32imac-unknown-none-elf --features external-interrupts,i2c,esp-hal/esp32c6,esp-hal-embassy/esp32c6 -p riot-rs-esp
+          args: --verbose --locked --target=riscv32imac-unknown-none-elf --features external-interrupts,i2c,esp-hal/esp32c6,esp-hal-embassy/esp32c6 -p riot-rs-esp -- --deny warnings
 
       - run: echo 'RUSTFLAGS=--cfg context="rp2040"' >> $GITHUB_ENV
       - name: clippy for RP
         uses: clechasseur/rs-clippy-check@v3
         with:
-          args: --verbose --locked --features external-interrupts,i2c,embassy-rp/rp2040 -p riot-rs-rp
+          args: --verbose --locked --features external-interrupts,i2c,embassy-rp/rp2040 -p riot-rs-rp -- --deny warnings
 
       - run: echo 'RUSTFLAGS=--cfg context="nrf52840"' >> $GITHUB_ENV
       - name: clippy for nRF
         uses: clechasseur/rs-clippy-check@v3
         with:
-          args: --verbose --locked --features external-interrupts,i2c,embassy-nrf/nrf52840 -p riot-rs-nrf
+          args: --verbose --locked --features external-interrupts,i2c,embassy-nrf/nrf52840 -p riot-rs-nrf -- --deny warnings
 
       - run: echo 'RUSTFLAGS=--cfg context="stm32wb55rgvx"' >> $GITHUB_ENV
       - name: clippy for STM32
         uses: clechasseur/rs-clippy-check@v3
         with:
-          args: --verbose --locked --features external-interrupts,i2c,embassy-stm32/stm32wb55rg -p riot-rs-stm32
+          args: --verbose --locked --features external-interrupts,i2c,embassy-stm32/stm32wb55rg -p riot-rs-stm32 -- --deny warnings
 
       # Reset `RUSTFLAGS`
       - run: echo 'RUSTFLAGS=' >> $GITHUB_ENV


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Now that CI is free of clippy warnings, we can forbid them in CI, so they don't creep in again.

This does seem to print every encountered warnings/errors when found in the same crate; however it does seem to return early when linting multiple crates at a time and encountering a warning/error.
See this [clippy discussion for details](https://github.com/rust-lang/rust-clippy/discussions/11942).  

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
