### PR TITLE
fix(coapcore): Update liboscore dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,19 @@ jobs:
         with:
           buildtargets: esp32s3
 
+      - name: Keep general build environment clean of Xtensa peculiarities
+        # The Xtensa setup unconditionally sets LIBCLANG_PATH in GITHUB_ENV --
+        # we can't undo that. (It also sets it in ~/exports, but that is just
+        # what it uses internally to get that data around into the action
+        # script)
+        #
+        # As the shell apparently does not source any files, and until
+        # https://github.com/actions/runner/issues/1126 is fixed by GitHub, the
+        # best remedy is to stow the workaround and source it wherever we can.
+        run: |
+          set -x
+          echo 'unset LIBCLANG_PATH' >> ~/fix-environment-after-xtensa-setup
+
       - name: rust cache
         if: steps.result-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
@@ -78,6 +91,7 @@ jobs:
       - name: "installing prerequisites"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
+          source ~/fix-environment-after-xtensa-setup
           git config --global init.defaultBranch main
           git config --global user.email "ci@riot-labs.de"
           git config --global user.name "CI"
@@ -88,11 +102,13 @@ jobs:
       - name: "limit build unless nightly build"
         if: github.event_name != 'schedule'
         run: |
+          source ~/fix-environment-after-xtensa-setup
           echo "LAZE_BUILDERS=ai-c3,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-wroom-1,microbit-v2,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"
 
       - name: "riot-rs compilation test"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
+          source ~/fix-environment-after-xtensa-setup
           sccache --start-server || true # work around https://github.com/ninja-build/ninja/issues/2052
 
           CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build --global --partition hash:${{ matrix.partition }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,14 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # clang-sys and thus bindgen is sensitive to multiple installed versions
+      # around, see eg. https://github.com/rust-lang/rust-bindgen/issues/2682
+      #
+      # CLANG_PATH should be set to the most recent clang installed, no matter
+      # what /usr/bin/clang is, for some parts of the code will go for the
+      # newest standard library. It may also need to be aligned with the clang
+      # version which Xtensa provides.
+      CLANG_PATH: /usr/bin/clang-18
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,22 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           sudo apt-get install ninja-build gcc-arm-none-eabi
 
+      - name: "Show installed versions"
+        run: |
+          set -x
+          set +e
+          env
+          llvm-config --libs
+          cargo version
+          laze --version
+          arm-none-eabi-gcc --version
+          clang --version
+          set +x
+          # Check which alternative versions are installed
+          IFS=":"; for p in $PATH; do ls $p/llvm-config-* $p/clang-* 2>/dev/null; done
+          sha256sum /usr/lib/llvm-*/lib/clang/*/include/stdint.h
+          true
+
       - name: "limit build unless nightly build"
         if: github.event_name != 'schedule'
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,17 +124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,24 +191,22 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.63.0"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "lazy_static",
- "lazycell",
+ "itertools",
  "log 0.4.22",
- "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
- "which",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -333,7 +320,6 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b922faaf31122819ec80c4047cc684c6979a087366c069611e33649bf98e18d"
 dependencies = [
- "clap",
  "heck 0.4.1",
  "indexmap 1.9.3",
  "log 0.4.22",
@@ -441,30 +427,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_lex",
- "indexmap 1.9.3",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -859,7 +821,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.85",
 ]
 
@@ -2362,15 +2324,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
@@ -2397,15 +2350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2468,7 +2412,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2575,18 +2519,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "ld-memory"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,7 +2555,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 [[package]]
 name = "liboscore"
 version = "0.1.0"
-source = "git+https://gitlab.com/oscore/liboscore/?rev=e7a4ecd037cbb9c7f085047fec5896f4bdc68d50#e7a4ecd037cbb9c7f085047fec5896f4bdc68d50"
+source = "git+https://gitlab.com/oscore/liboscore/?rev=447e34fc5af427de7513f96a756babfe2f0b2c5c#447e34fc5af427de7513f96a756babfe2f0b2c5c"
 dependencies = [
  "bindgen",
  "cbindgen",
@@ -2639,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "liboscore-cryptobackend"
 version = "0.1.0"
-source = "git+https://gitlab.com/oscore/liboscore/?rev=e7a4ecd037cbb9c7f085047fec5896f4bdc68d50#e7a4ecd037cbb9c7f085047fec5896f4bdc68d50"
+source = "git+https://gitlab.com/oscore/liboscore/?rev=447e34fc5af427de7513f96a756babfe2f0b2c5c#447e34fc5af427de7513f96a756babfe2f0b2c5c"
 dependencies = [
  "aead",
  "aes",
@@ -2657,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "liboscore-msgbackend"
 version = "0.1.0"
-source = "git+https://gitlab.com/oscore/liboscore/?rev=e7a4ecd037cbb9c7f085047fec5896f4bdc68d50#e7a4ecd037cbb9c7f085047fec5896f4bdc68d50"
+source = "git+https://gitlab.com/oscore/liboscore/?rev=447e34fc5af427de7513f96a756babfe2f0b2c5c#447e34fc5af427de7513f96a756babfe2f0b2c5c"
 dependencies = [
  "coap-message",
  "coap-message-implementations",
@@ -3162,12 +3094,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,12 +3152,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "petgraph"
@@ -3424,6 +3344,16 @@ name = "pretty-hex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.85",
+]
 
 [[package]]
 name = "primeorder"
@@ -4460,12 +4390,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -4567,12 +4491,6 @@ dependencies = [
  "riot-rs",
  "riot-rs-boards",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -4883,18 +4801,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "winapi"

--- a/examples/coap/laze.yml
+++ b/examples/coap/laze.yml
@@ -8,7 +8,6 @@ apps:
       - ?release
       - network
       - random
-      - OSCORE_CLANG_CI_FIX  # https://github.com/future-proof-iot/RIOT-rs/pull/443
     conflicts:
       # see https://github.com/future-proof-iot/RIOT-rs/issues/418
       - thumbv6m-none-eabi

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -26,9 +26,9 @@ coap-message-utils = "0.3.3"
 coap-numbers = "0.2.3"
 hexlit = "0.5.5"
 lakers-crypto-rustcrypto = "0.6.0"
-liboscore = { git = "https://gitlab.com/oscore/liboscore/", rev = "e7a4ecd037cbb9c7f085047fec5896f4bdc68d50" }
+liboscore = { git = "https://gitlab.com/oscore/liboscore/", rev = "447e34fc5af427de7513f96a756babfe2f0b2c5c" }
 liboscore-msgbackend = { git = "https://gitlab.com/oscore/liboscore/", features = [
   "alloc",
-], rev = "e7a4ecd037cbb9c7f085047fec5896f4bdc68d50" }
+], rev = "447e34fc5af427de7513f96a756babfe2f0b2c5c" }
 minicbor = "0.23.0"
 heapless = "0.8.0"


### PR DESCRIPTION
# Description

This pulls in workarounds / fixes for clang-18, which would otherwise fail to define `uint8_t` & co in its stdint.h, causing bindgen failures.

Thanks @kaspar030 for noticing the issue and helping me reproduce it.

## Issues/PRs references

See-Also: https://gitlab.com/oscore/liboscore/-/issues/61

Depends on: https://github.com/future-proof-iot/RIOT-rs/pull/491

## Open Questions

<del>Let's hope everyone can use clang-18 already: as the fix for using clang-18 requires a recent clang (didn't test -17, but -16 doesn't cut it), this may require updates here and there.</del>

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
 <del> (Our documentation says to install clang on Ubuntu, but the latest Ubuntu LTS already has clang 18 by default, so that doesn't need an update.)</del>