### PR TITLE
chore(i2c): update the `Cargo.lock` file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,16 +2456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
-name = "i2c"
-version = "0.1.0"
-dependencies = [
- "embassy-executor",
- "embedded-hal-async",
- "riot-rs",
- "riot-rs-boards",
-]
-
-[[package]]
 name = "i2c-controller"
 version = "0.1.0"
 dependencies = [


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
It seems that #421 didn't update the `Cargo.lock` completely, this PR fixes that.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
