### PR TITLE
chore(CI): temporarily disable `examples/coap`

### DIFF
--- a/examples/coap/laze.yml
+++ b/examples/coap/laze.yml
@@ -8,6 +8,7 @@ apps:
       - ?release
       - network
       - random
+      - OSCORE_CLANG_CI_FIX #https://github.com/future-proof-iot/RIOT-rs/pull/443
     conflicts:
       # see https://github.com/future-proof-iot/RIOT-rs/issues/418
       - thumbv6m-none-eabi


### PR DESCRIPTION
# Description

A clang stable update broke `liboscore`: https://gitlab.com/oscore/liboscore/-/issues/61

Temporarily disable `examples/coap` until fixed.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

Potential fix: #443
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
