### PR TITLE
chore: Fix GitHub request template link to coding conventions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,6 @@ We don't enforce a strict convention for commit messages, but please make sure t
 the commit history is clear and informative.
 -->
 - [ ] I have cleaned up my commit history and squashed fixup commits.
-- [ ] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
+- [ ] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
 - [ ] I have performed a self-review of my own code.
 - [ ] I have made corresponding changes to the documentation.


### PR DESCRIPTION
# Description

I'm trying to be a good project citizen an occasionally read up on coding conventions even though I think that those would way better be enforced by clippy/cargo-fmt/some-other-tool (that provide a patch for me to merge rather than just complain) and read up on those from time to time.

Turned out the link was broken, this fixes it.

## Issues/PRs references

See the broken link on this issue in the checkboxes.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
