### PR TITLE
feat(tests/benchmarks): add `bench_sched_flags`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bench_sched_flags"
+version = "0.1.0"
+dependencies = [
+ "riot-rs",
+ "riot-rs-boards",
+]
+
+[[package]]
 name = "bench_sched_yield"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "src/riot-rs-random",
   "src/riot-rs-rp",
   "src/riot-rs-stm32",
+  "tests/benchmarks/bench_sched_flags",
   "tests/benchmarks/bench_sched_yield",
   "tests/gpio",
   "tests/gpio-interrupt-nrf",

--- a/tests/benchmarks/bench_sched_flags/Cargo.toml
+++ b/tests/benchmarks/bench_sched_flags/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bench_sched_flags"
+version = "0.1.0"
+authors = ["Elena Frank <elena.frank@proton.me>"]
+license.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+riot-rs = { workspace = true, default-features = true, features = ["bench"] }
+riot-rs-boards = { workspace = true }

--- a/tests/benchmarks/bench_sched_flags/README.md
+++ b/tests/benchmarks/bench_sched_flags/README.md
@@ -1,0 +1,11 @@
+# bench_sched_flags
+
+## About
+
+This benchmark tests thread-flag signaling between two threads.
+
+## How to run
+
+In this folder, run
+
+    laze build -b nrf52840dk run

--- a/tests/benchmarks/bench_sched_flags/laze.yml
+++ b/tests/benchmarks/bench_sched_flags/laze.yml
@@ -1,0 +1,6 @@
+apps:
+  - name: bench_sched_flags
+    selects:
+      - sw/benchmark
+      - sw/threading
+      - ?release

--- a/tests/benchmarks/bench_sched_flags/src/main.rs
+++ b/tests/benchmarks/bench_sched_flags/src/main.rs
@@ -1,0 +1,36 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use riot_rs::{
+    debug::log::*,
+    thread::{current_pid, sync::Channel, thread_flags, ThreadId},
+};
+
+static ID_EXCHANGE: Channel<ThreadId> = Channel::new();
+
+#[riot_rs::thread(autostart)]
+fn thread0() {
+    let target_pid = ID_EXCHANGE.recv();
+    ID_EXCHANGE.send(&current_pid().unwrap());
+
+    match riot_rs::bench::benchmark(1000, || {
+        thread_flags::set(target_pid, 1);
+        thread_flags::wait_any(1);
+    }) {
+        Ok(ticks) => info!("took {} ticks per iteration", ticks),
+        Err(_) => warn!("benchmark returned error"),
+    }
+}
+
+#[riot_rs::thread(autostart)]
+fn thread1() {
+    ID_EXCHANGE.send(&current_pid().unwrap());
+    let target_pid = ID_EXCHANGE.recv();
+
+    loop {
+        thread_flags::set(target_pid, 1);
+        thread_flags::wait_any(1);
+    }
+}

--- a/tests/benchmarks/laze.yml
+++ b/tests/benchmarks/laze.yml
@@ -1,2 +1,3 @@
 subdirs:
+  - bench_sched_flags
   - bench_sched_yield


### PR DESCRIPTION
# Description

Add new benchmark to test signaling between threads using `thread-flags`.
Compared to the existing benchmark `bench_sched_yield`, it involves IPC between the threads and one thread changing another thread's state.

## Issues/PRs references

Extracted from #397.

## Open Question

Do we want this benchmark?

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
