### PR TITLE
feat(laze): select `riot-rs/threading` in `sw/threading` module

### DIFF
--- a/examples/benchmark/Cargo.toml
+++ b/examples/benchmark/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 workspace = true
 
 [dependencies]
-riot-rs = { path = "../../src/riot-rs", features = ["bench", "threading"] }
+riot-rs = { path = "../../src/riot-rs", features = ["bench"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/core-sizes/Cargo.toml
+++ b/examples/core-sizes/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 workspace = true
 
 [dependencies]
-riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs = { path = "../../src/riot-rs" }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/embassy/Cargo.toml
+++ b/examples/embassy/Cargo.toml
@@ -13,5 +13,5 @@ workspace = true
 embassy-executor = { workspace = true, default-features = false }
 embassy-sync = { workspace = true, default-features = false }
 embassy-time = { workspace = true, default-features = false }
-riot-rs = { path = "../../src/riot-rs", features = ["threading", "time"] }
+riot-rs = { path = "../../src/riot-rs", features = ["time"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 workspace = true
 
 [dependencies]
-riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs = { path = "../../src/riot-rs" }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/random/Cargo.toml
+++ b/examples/random/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 # Enabling the feature "random" is somewhat redundant with laze.yml's selects:
 # random, but helps with interactive tools.
-riot-rs = { path = "../../src/riot-rs", features = ["threading", "random"] }
+riot-rs = { path = "../../src/riot-rs", features = ["random"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }
 
 rand = { version = "0.8.5", default-features = false }

--- a/examples/threading-channel/Cargo.toml
+++ b/examples/threading-channel/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 workspace = true
 
 [dependencies]
-riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs = { path = "../../src/riot-rs" }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/threading/Cargo.toml
+++ b/examples/threading/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 workspace = true
 
 [dependencies]
-riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs = { path = "../../src/riot-rs" }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -583,6 +583,10 @@ modules:
   - name: sw/threading
     conflicts:
       - executor-single-thread
+    env:
+      global:
+        FEATURES:
+          - riot-rs/threading
 
   - name: wifi-cyw43
     context:

--- a/tests/threading-dynamic-prios/Cargo.toml
+++ b/tests/threading-dynamic-prios/Cargo.toml
@@ -7,6 +7,6 @@ license.workspace = true
 publish = false
 
 [dependencies]
-riot-rs = { path = "../../src/riot-rs", features = ["threading"] }
+riot-rs = { path = "../../src/riot-rs" }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }
 portable-atomic = { workspace = true }

--- a/tests/threading-lock/Cargo.toml
+++ b/tests/threading-lock/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 embassy-executor = { workspace = true }
-riot-rs = { path = "../../src/riot-rs", features = ["threading", "time"] }
+riot-rs = { path = "../../src/riot-rs", features = ["time"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }
 portable-atomic = "1.6.0"


### PR DESCRIPTION
# Description

Enable the `riot-rs/threading` feature in the `sw/threading` laze module.

Users that select one will always want to select the other as well, so this avoids redundancy.

## Issues/PRs references

Extracted from #397 


## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
