### PR TITLE
chore(*): remove redundant `critical-section` pick

### DIFF
--- a/src/riot-rs-bench/Cargo.toml
+++ b/src/riot-rs-bench/Cargo.toml
@@ -14,7 +14,7 @@ cfg-if = { workspace = true }
 defmt = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
-cortex-m = { workspace = true, features = ["critical-section-single-core"] }
+cortex-m = { workspace = true }
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-hal = { workspace = true }

--- a/src/riot-rs-debug/Cargo.toml
+++ b/src/riot-rs-debug/Cargo.toml
@@ -18,7 +18,7 @@ defmt = { workspace = true, optional = true }
 esp-println = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
-cortex-m = { workspace = true, features = ["critical-section-single-core"] }
+cortex-m = { workspace = true }
 cortex-m-semihosting = { workspace = true, optional = true }
 rtt-target = { version = "0.5.0", optional = true }
 defmt-rtt-target = { git = "https://github.com/kaspar030/defmt-rtt-target", rev = "5668c92ac5a0689b165a6a07bb14e173fc47cd34" }


### PR DESCRIPTION
# Description

The `cortex-m` `critical-section-single-core` feature is enabled in `riot-rs-rt`, so no need to do it in other packages as well.

## Issues/PRs references

Extracted from #397.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
