### PR TITLE
refactor(threads): avoid unnecessary scheduler invocations

### DIFF
--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -99,16 +99,12 @@ impl Threads {
     fn flag_set(&mut self, thread_id: ThreadId, mask: ThreadFlags) {
         let thread = self.get_unchecked_mut(thread_id);
         thread.flags |= mask;
-        if match thread.state {
-            ThreadState::FlagBlocked(mode) => match mode {
-                WaitMode::Any(bits) => thread.flags & bits != 0,
-                WaitMode::All(bits) => thread.flags & bits == bits,
-            },
-            _ => false,
-        } {
-            self.set_state(thread_id, ThreadState::Running);
-            crate::schedule();
-        }
+        match thread.state {
+            ThreadState::FlagBlocked(WaitMode::Any(bits)) if thread.flags & bits != 0 => {}
+            ThreadState::FlagBlocked(WaitMode::All(bits)) if thread.flags & bits == bits => {}
+            _ => return,
+        };
+        self.set_state(thread_id, ThreadState::Running);
     }
 
     fn flag_wait_all(&mut self, mask: ThreadFlags) -> Option<ThreadFlags> {
@@ -119,7 +115,6 @@ impl Threads {
         } else {
             let thread_id = thread.pid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::All(mask)));
-            crate::schedule();
             None
         }
     }
@@ -133,7 +128,6 @@ impl Threads {
         } else {
             let thread_id = thread.pid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::Any(mask)));
-            crate::schedule();
             None
         }
     }
@@ -149,7 +143,6 @@ impl Threads {
         } else {
             let thread_id = thread.pid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::Any(mask)));
-            crate::schedule();
             None
         }
     }


### PR DESCRIPTION
# Description

This PR implements some changes and checks to avoid unnecessary scheduler invocations:
- the scheduler is now triggered in `set_state` as a central point
- if a thread changes into `ThreadState::Running`, only trigger the scheduler if the thread has a higher priority than the currently running one (**new**)
- always trigger the scheduler when a thread changes from `ThreadState::Running` into another state because this only ever happens if a currently running thread gets blocked
- only trigger the scheduler in `yield_now` if the runqueue contains any other threads

## Issues/PRs references

Extracted from #397.

## Benchmarks

(ticks **per iteration**)
`bench_sched_flags` is PR'd in #456

nRF52840dk: 

benchmark | main | this PR
| - | - | -
`bench_sched_yield` with two threads |  560 | 580
`bench_sched_yield` with one thread | 235 | 98
`bench_sched_flags` | 1848 |  1461

RPI-Pico

benchmark | main | this PR
| - | - | -
`bench_sched_yield` with two threads |  631 | 647
`bench_sched_yield` with one thread | 243 | 78
`bench_sched_flags` | 1739 |  1495

The additional checks come a some cost when the scheduler invocation is really needed, as visible in the `bench_sched_yield` benchmark. 
But I think this is tolerable, because the actual context switching logic (i.e. `sched`) is not affected, and in many cases we save an unnecessary scheduler call that would be much more expensive.

## Open Questions

See self review.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
