### PR TITLE
feat(i2c-controller): add support for I2C controller on nrf52833

### DIFF
--- a/src/riot-rs-nrf/src/i2c/controller/mod.rs
+++ b/src/riot-rs-nrf/src/i2c/controller/mod.rs
@@ -32,13 +32,13 @@ impl Default for Config {
 
 /// I2C bus frequency.
 // NOTE(arch): the datasheets only mention these frequencies.
-#[cfg(any(context = "nrf52840", context = "nrf5340"))]
+#[cfg(any(context = "nrf52833", context = "nrf52840", context = "nrf5340"))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Frequency {
     /// Standard mode.
     _100k,
-    #[cfg(context = "nrf5340")]
+    #[cfg(any(context = "nrf52833", context = "nrf5340"))]
     _250k,
     /// Fast mode.
     _400k,
@@ -58,11 +58,11 @@ impl Frequency {
 
     pub const fn next(self) -> Option<Self> {
         match self {
-            #[cfg(not(context = "nrf5340"))]
+            #[cfg(context = "nrf52840")]
             Self::_100k => Some(Self::_400k),
-            #[cfg(context = "nrf5340")]
+            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
             Self::_100k => Some(Self::_250k),
-            #[cfg(context = "nrf5340")]
+            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
             Self::_250k => Some(Self::_400k),
             Self::_400k => None,
         }
@@ -71,11 +71,11 @@ impl Frequency {
     pub const fn prev(self) -> Option<Self> {
         match self {
             Self::_100k => None,
-            #[cfg(context = "nrf5340")]
+            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
             Self::_250k => Some(Self::_100k),
-            #[cfg(not(context = "nrf5340"))]
+            #[cfg(context = "nrf52840")]
             Self::_400k => Some(Self::_100k),
-            #[cfg(context = "nrf5340")]
+            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
             Self::_400k => Some(Self::_250k),
         }
     }
@@ -83,7 +83,7 @@ impl Frequency {
     pub const fn khz(self) -> u32 {
         match self {
             Self::_100k => 100,
-            #[cfg(context = "nrf5340")]
+            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
             Self::_250k => 250,
             Self::_400k => 400,
         }
@@ -96,7 +96,7 @@ impl From<Frequency> for embassy_nrf::twim::Frequency {
     fn from(freq: Frequency) -> Self {
         match freq {
             Frequency::_100k => embassy_nrf::twim::Frequency::K100,
-            #[cfg(context = "nrf5340")]
+            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
             Frequency::_250k => embassy_nrf::twim::Frequency::K250,
             Frequency::_400k => embassy_nrf::twim::Frequency::K400,
         }
@@ -188,7 +188,7 @@ fn from_error(err: embassy_nrf::twim::Error) -> riot_rs_embassy_common::i2c::con
 
 // FIXME: support other nRF archs
 // Define a driver per peripheral
-#[cfg(context = "nrf52840")]
+#[cfg(any(context = "nrf52833", context = "nrf52840"))]
 define_i2c_drivers!(
     SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0 => TWISPI0,
     SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1 => TWISPI1,

--- a/src/riot-rs-nrf/src/i2c/mod.rs
+++ b/src/riot-rs-nrf/src/i2c/mod.rs
@@ -4,7 +4,10 @@ pub mod controller;
 pub fn init(peripherals: &mut crate::OptionalPeripherals) {
     // Take all I2C peripherals and do nothing with them.
     cfg_if::cfg_if! {
-        if #[cfg(context = "nrf52840")] {
+        if #[cfg(context = "nrf52833")] {
+            let _ = peripherals.TWISPI0.take().unwrap();
+            let _ = peripherals.TWISPI1.take().unwrap();
+        } else if #[cfg(context = "nrf52840")] {
             let _ = peripherals.TWISPI0.take().unwrap();
             let _ = peripherals.TWISPI1.take().unwrap();
         } else if #[cfg(context = "nrf5340")] {

--- a/tests/i2c-controller/README.md
+++ b/tests/i2c-controller/README.md
@@ -10,6 +10,6 @@ In this folder, run
 
     laze build -b nrf52840dk run
 
-This test requires an LIS3DH sensor (3-axis accelerometer) attached to the pins configured in the
-`pins` module.
+This test requires an LIS3DH/LSM303AGR sensor (3-axis accelerometer) attached
+to the pins configured in the `pins` module.
 It attempts to read the `WHO_AM_I` register and checks the received value against the expected id.

--- a/tests/i2c-controller/laze.yml
+++ b/tests/i2c-controller/laze.yml
@@ -6,6 +6,7 @@ apps:
           - CONFIG_ISR_STACKSIZE=16384
     context:
       - espressif-esp32-c6-devkitc-1
+      - microbit-v2
       - nrf52840
       - nrf5340
       - rp2040

--- a/tests/i2c-controller/src/main.rs
+++ b/tests/i2c-controller/src/main.rs
@@ -3,7 +3,7 @@
 //! Please use [`riot_rs::sensors`] instead for a high-level sensor abstraction that is
 //! architecture-agnostic.
 //!
-//! This example requires a LIS3DH sensor (3-axis accelerometer).
+//! This example requires a LIS3DH/LSM303AGR sensor (3-axis accelerometer).
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
@@ -24,9 +24,9 @@ use riot_rs::{
     i2c::controller::{highest_freq_in, I2cDevice, Kilohertz},
 };
 
-const LIS3DH_I2C_ADDR: u8 = 0x19;
+const TARGET_I2C_ADDR: u8 = 0x19;
 
-// WHO_AM_I register of the LIS3DH sensor
+// WHO_AM_I register of the sensor
 const WHO_AM_I_REG_ADDR: u8 = 0x0f;
 
 pub static I2C_BUS: once_cell::sync::OnceCell<
@@ -47,12 +47,12 @@ async fn main(peripherals: pins::Peripherals) {
 
     let mut id = [0];
     i2c_device
-        .write_read(LIS3DH_I2C_ADDR, &[WHO_AM_I_REG_ADDR], &mut id)
+        .write_read(TARGET_I2C_ADDR, &[WHO_AM_I_REG_ADDR], &mut id)
         .await
         .unwrap();
 
     let who_am_i = id[0];
-    info!("LIS3DH WHO_AM_I_COMMAND register value: 0x{:x}", who_am_i);
+    info!("WHO_AM_I_COMMAND register value: 0x{:x}", who_am_i);
     assert_eq!(who_am_i, 0x33);
 
     info!("Test passed!");

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -8,14 +8,19 @@ riot_rs::define_peripherals!(Peripherals {
     i2c_scl: GPIO_0,
 });
 
-#[cfg(context = "nrf52840")]
+#[cfg(any(context = "nrf52833", context = "nrf52840"))]
 pub type SensorI2c = i2c::controller::TWISPI0;
 #[cfg(context = "nrf5340")]
 pub type SensorI2c = i2c::controller::SERIAL0;
-#[cfg(context = "nrf")]
+#[cfg(all(context = "nrf", not(context = "microbit-v2")))]
 riot_rs::define_peripherals!(Peripherals {
     i2c_sda: P0_00,
     i2c_scl: P0_01,
+});
+#[cfg(context = "microbit-v2")]
+riot_rs::define_peripherals!(Peripherals {
+    i2c_sda: P0_16,
+    i2c_scl: P0_08,
 });
 
 #[cfg(context = "rp")]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Port the test for the micro:bit V2 board.
It just happens that the accelerometer found on the micro:bit V2 has the same `WHO_AM_I` register value than the other accelerometer we were using for testing I2C bus on other boards.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #463

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
