### PR TITLE
feat(esp): add support for esp32 & espressif-esp32-wroom-32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,6 +1889,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "espressif-esp32-wroom-32"
+version = "0.1.0"
+dependencies = [
+ "riot-rs-debug",
+ "riot-rs-rt",
+]
+
+[[package]]
 name = "example-random"
 version = "0.1.0"
 dependencies = [
@@ -3472,6 +3480,7 @@ dependencies = [
  "dwm1001",
  "espressif-esp32-c6-devkitc-1",
  "espressif-esp32-s3-wroom-1",
+ "espressif-esp32-wroom-32",
  "linkme",
  "microbit",
  "microbit-v2",

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -296,6 +296,17 @@ contexts:
       CARGO_ARGS:
         - -Zbuild-std=core,alloc
 
+  - name: esp32
+    parent: esp
+    selects:
+      - xtensa
+    env:
+      CARGO_TOOLCHAIN: +esp
+      RUSTFLAGS:
+        - --cfg context=\"esp32\"
+      RUSTC_TARGET: xtensa-esp32-none-elf
+      CARGO_TARGET_PREFIX: CARGO_TARGET_XTENSA_ESP32_NONE_ELF
+
   - name: esp32c3
     parent: esp
     selects:
@@ -689,12 +700,19 @@ modules:
 
   - name: sw/benchmark
     help: provided if a target supports `benchmark()`
-    # Currently there's only one implementation based on Systick, so Cortex-M only.
     context:
+      # The Cortex-M implementation is using Systick.
       - nrf
       - rp
       - stm32
-      - esp
+      # The esp32 implementation is using systimer.
+      - esp32c3
+      - esp32c6
+      - esp32s3
+      # These esp32 also have a systimer, uncomment when support is added.
+      # - esp32c2
+      # - esp32h2
+      # - esp32s2
 
   - name: wifi-esp
     context:
@@ -889,6 +907,9 @@ builders:
 
   - name: ai-c3
     parent: esp32c3
+
+  - name: espressif-esp32-wroom-32
+    parent: esp32
 
   - name: espressif-esp32-c6-devkitc-1
     parent: esp32c6

--- a/src/riot-rs-boards/Cargo.toml
+++ b/src/riot-rs-boards/Cargo.toml
@@ -17,6 +17,7 @@ riot-rs-rt = { path = "../riot-rs-rt" }
 ai-c3 = { optional = true, path = "ai-c3" }
 espressif-esp32-c6-devkitc-1 = { optional = true, path = "espressif-esp32-c6-devkitc-1" }
 espressif-esp32-s3-wroom-1 = { optional = true, path = "espressif-esp32-s3-wroom-1" }
+espressif-esp32-wroom-32 = { optional = true, path = "espressif-esp32-wroom-32" }
 dwm1001 = { optional = true, path = "dwm1001" }
 microbit = { optional = true, path = "microbit" }
 microbit-v2 = { optional = true, path = "microbit-v2" }

--- a/src/riot-rs-boards/espressif-esp32-wroom-32/Cargo.toml
+++ b/src/riot-rs-boards/espressif-esp32-wroom-32/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "espressif-esp32-wroom-32"
+version = "0.1.0"
+license.workspace = true
+edition = "2021"
+
+[dependencies]
+riot-rs-rt = { workspace = true, features = ["_esp32"] }
+riot-rs-debug = { workspace = true }

--- a/src/riot-rs-boards/espressif-esp32-wroom-32/src/lib.rs
+++ b/src/riot-rs-boards/espressif-esp32-wroom-32/src/lib.rs
@@ -1,0 +1,7 @@
+#![no_std]
+
+use riot_rs_debug::println;
+
+pub fn init() {
+    println!("espressif-esp32-wroom-32::init()");
+}

--- a/src/riot-rs-boards/src/lib.rs
+++ b/src/riot-rs-boards/src/lib.rs
@@ -6,6 +6,8 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(feature = "ai-c3")] {
         pub use ai_c3 as board;
+    } else if #[cfg(feature = "espressif-esp32-wroom-32")] {
+        pub use espressif_esp32_wroom_32 as board;
     } else if #[cfg(feature = "espressif-esp32-c6-devkitc-1")] {
         pub use espressif_esp32_c6_devkitc_1 as board;
     } else if #[cfg(feature = "espressif-esp32-s3-wroom-1")] {

--- a/src/riot-rs-debug/Cargo.toml
+++ b/src/riot-rs-debug/Cargo.toml
@@ -26,6 +26,9 @@ semihosting = { version = "0.1.16", optional = true, features = [
 esp-println = { workspace = true, optional = true, features = ["log"] }
 log = { version = "0.4.20" }
 
+[target.'cfg(context = "esp32")'.dependencies]
+esp-println = { workspace = true, features = ["esp32"] }
+
 [target.'cfg(context = "esp32c3")'.dependencies]
 esp-println = { workspace = true, optional = true, features = ["esp32c3"] }
 

--- a/src/riot-rs-esp/Cargo.toml
+++ b/src/riot-rs-esp/Cargo.toml
@@ -37,6 +37,15 @@ embassy-executor = { workspace = true, default-features = false, features = [
   "arch-cortex-m",
 ] }
 
+[target.'cfg(context = "esp32")'.dependencies]
+esp-hal = { workspace = true, features = ["esp32"] }
+esp-hal-embassy = { workspace = true, default-features = false, features = [
+  "esp32",
+] }
+esp-wifi = { workspace = true, default-features = false, features = [
+  "esp32",
+], optional = true }
+
 [target.'cfg(context = "esp32c3")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c3"] }
 esp-hal-embassy = { workspace = true, default-features = false, features = [

--- a/src/riot-rs-esp/src/gpio.rs
+++ b/src/riot-rs-esp/src/gpio.rs
@@ -40,6 +40,24 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
         peripherals.GPIO_29.replace(pins.gpio29);
         peripherals.GPIO_30.replace(pins.gpio30);
     }
+
+    #[cfg(context = "esp32")]
+    {
+        peripherals.GPIO_21.replace(pins.gpio21);
+        peripherals.GPIO_22.replace(pins.gpio22);
+        peripherals.GPIO_23.replace(pins.gpio23);
+        peripherals.GPIO_24.replace(pins.gpio24);
+        peripherals.GPIO_25.replace(pins.gpio25);
+        peripherals.GPIO_26.replace(pins.gpio26);
+        peripherals.GPIO_27.replace(pins.gpio27);
+        peripherals.GPIO_32.replace(pins.gpio32);
+        peripherals.GPIO_33.replace(pins.gpio33);
+        peripherals.GPIO_34.replace(pins.gpio34);
+        peripherals.GPIO_35.replace(pins.gpio35);
+        peripherals.GPIO_37.replace(pins.gpio37);
+        peripherals.GPIO_38.replace(pins.gpio38);
+        peripherals.GPIO_39.replace(pins.gpio39);
+    }
 }
 
 pub mod input {

--- a/src/riot-rs-esp/src/lib.rs
+++ b/src/riot-rs-esp/src/lib.rs
@@ -63,6 +63,22 @@ pub mod peripherals {
             pub use esp_hal::gpio::GPIO_29;
             pub use esp_hal::gpio::GPIO_30;
         }
+        else if #[cfg(context = "esp32")] {
+            pub use esp_hal::gpio::GPIO_22;
+            pub use esp_hal::gpio::GPIO_23;
+            pub use esp_hal::gpio::GPIO_24;
+            pub use esp_hal::gpio::GPIO_25;
+            pub use esp_hal::gpio::GPIO_26;
+            pub use esp_hal::gpio::GPIO_27;
+            pub use esp_hal::gpio::GPIO_32;
+            pub use esp_hal::gpio::GPIO_33;
+            pub use esp_hal::gpio::GPIO_34;
+            pub use esp_hal::gpio::GPIO_35;
+            pub use esp_hal::gpio::GPIO_36;
+            pub use esp_hal::gpio::GPIO_37;
+            pub use esp_hal::gpio::GPIO_38;
+            pub use esp_hal::gpio::GPIO_39;
+        }
     }
 }
 

--- a/src/riot-rs-rt/Cargo.toml
+++ b/src/riot-rs-rt/Cargo.toml
@@ -46,6 +46,7 @@ multi-core = ["embassy-rp/critical-section-impl"]
 # internal
 # These features are used by `build.rs`, which doesn't "see" context
 # variables.
+_esp32 = []
 _esp32c3 = []
 _esp32c6 = []
 _esp32s3 = []

--- a/src/riot-rs-threads/Cargo.toml
+++ b/src/riot-rs-threads/Cargo.toml
@@ -26,6 +26,9 @@ static_cell.workspace = true
 
 defmt = { workspace = true, optional = true }
 
+[target.'cfg(context = "esp32")'.dependencies]
+esp-hal = { workspace = true, features = ["esp32"] }
+
 [target.'cfg(context = "esp32c3")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c3"] }
 

--- a/tests/gpio/src/pins.rs
+++ b/tests/gpio/src/pins.rs
@@ -24,7 +24,15 @@ riot_rs::define_peripherals!(Peripherals {
     pin_3: PIN_3,
 });
 
-#[cfg(context = "esp")]
+#[cfg(context = "esp32")]
+riot_rs::define_peripherals!(Peripherals {
+    pin_0: GPIO_16,
+    pin_1: GPIO_17,
+    pin_2: GPIO_18,
+    pin_3: GPIO_19,
+});
+
+#[cfg(all(context = "esp", not(context = "esp32")))]
 riot_rs::define_peripherals!(Peripherals {
     pin_0: GPIO_0,
     pin_1: GPIO_1,


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This PR wires up the `espressif-esp32-wroom-32`.

Tested blinky, http-server, tests/gpio.

## Issues/PRs references

Depends on #442.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
