### PR TITLE
feat: introduce a sensor abstraction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,7 @@ jobs:
                 mdns,
                 net,
                 no-boards,
+                sensors,
                 spi,
                 storage,
                 tcp,
@@ -141,6 +142,7 @@ jobs:
             -p ariel-os-power
             -p ariel-os-random
             -p ariel-os-rt
+            -p ariel-os-sensors
             -p ariel-os-storage
             -p ariel-os-threads
             -p ariel-os-utils
@@ -274,6 +276,7 @@ jobs:
                     no-boards,
                     random,
                     ariel-os-coap/doc,
+                    sensors,
                     spi,
                     storage,
                     tcp,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,14 +49,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "ariel-os"
@@ -162,6 +162,7 @@ dependencies = [
  "ariel-os-power",
  "ariel-os-random",
  "ariel-os-rt",
+ "ariel-os-sensors",
  "ariel-os-storage",
  "ariel-os-threads",
  "ariel-os-utils",
@@ -233,7 +234,7 @@ dependencies = [
  "hexlit",
  "lakers",
  "lakers-crypto-rustcrypto",
- "minicbor 0.26.0",
+ "minicbor 0.26.5",
  "serde",
  "serde_yml",
  "static_cell",
@@ -394,7 +395,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
  "trybuild",
 ]
 
@@ -505,6 +506,17 @@ version = "0.2.0"
 dependencies = [
  "defmt 1.0.1",
  "hax-lib",
+]
+
+[[package]]
+name = "ariel-os-sensors"
+version = "0.1.0"
+dependencies = [
+ "ariel-os-macros",
+ "defmt 1.0.1",
+ "embassy-sync 0.6.2",
+ "linkme",
+ "pin-project",
 ]
 
 [[package]]
@@ -684,9 +696,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
 ]
@@ -713,7 +725,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -724,7 +736,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -774,9 +786,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "ble-advertiser"
@@ -836,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "bt-hci"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69c6b9d78fe4db539449fc8782dd2554fd4baee27f6e6dbf2e4757fcbc36139"
+checksum = "f377753756ec12e76b52d2dd657437be0448cc9736402ffadd0b8b8b9602c8a1"
 dependencies = [
  "defmt 0.3.100",
  "embassy-sync 0.6.2",
@@ -874,9 +886,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -911,7 +923,7 @@ dependencies = [
  "bs58",
  "chrono",
  "data-encoding",
- "half 2.4.1",
+ "half 2.6.0",
  "nom",
  "num-bigint",
  "num-rational",
@@ -952,20 +964,23 @@ dependencies = [
  "hex",
  "quote",
  "regex",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cboritem"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eecd087b04fde72cbb708bb68f34229e8dfad2464fb706579817a46464b2d4a"
+checksum = "6e3c9350d61c6316b5272d458c213ce8377b79bb202f2eb1a924db1985b53fa0"
+dependencies = [
+ "document-features",
+]
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
 dependencies = [
  "shlex",
 ]
@@ -1023,16 +1038,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -1065,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1075,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1087,14 +1102,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1140,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "coap-handler-implementations"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be078e893f1f88cab31e2af83bbbb90cd5f8e9e95384cbbb4b45c8d537dffe35"
+checksum = "6f1999f9d308e6d5d3bfa857e471cc58ecbbf7732f06b3b8acf25127142f73ea"
 dependencies = [
  "ciborium-io",
  "coap-handler",
@@ -1154,6 +1169,7 @@ dependencies = [
  "embedded-io 0.4.0",
  "minicbor 0.19.1",
  "minicbor 0.24.4",
+ "minicbor 0.26.5",
  "serde",
  "serde_cbor",
  "windowed-infinity",
@@ -1211,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "coap-numbers"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d78a5634393ab2c11d173d66107200a730e200a3b3ca063c344d4459c90a5f9"
+checksum = "62940de3d016deb4c2e8bf5062435d69eba7f2c64b35537de4c56586db52231c"
 
 [[package]]
 name = "coap-request"
@@ -1270,7 +1286,7 @@ dependencies = [
  "lakers-crypto-rustcrypto",
  "liboscore",
  "log",
- "minicbor 0.26.0",
+ "minicbor 0.26.5",
  "minicbor-adapters",
  "p256",
  "rand_core",
@@ -1318,9 +1334,9 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "const-str"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671927c085eb5827d30b95df08f6c6a2301eafe2274c368bb2c16f42e03547eb"
+checksum = "9e991226a70654b49d34de5ed064885f0bef0348a8e70018b8ff1ac80aa984a2"
 
 [[package]]
 name = "const_panic"
@@ -1364,7 +1380,7 @@ checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1378,18 +1394,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -1492,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1502,40 +1518,40 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b16d9d0d88a5273d830dac8b78ceb217ffc9b1d5404e5597a3542515329405b"
+checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1543,12 +1559,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
+checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1586,7 +1602,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1608,7 +1624,7 @@ checksum = "d675dd299edbb7c8e01d4e9f520a0d8f22a8fe4af812c211c3fad5e9dcf41763"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1622,20 +1638,20 @@ dependencies = [
 
 [[package]]
 name = "delegate"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
+checksum = "b9b6483c2bbed26f97861cf57651d4f2b731964a28cd2257f934a4b452480d21"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1669,14 +1685,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "document-features"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
@@ -1705,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -1763,7 +1779,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1828,7 +1844,7 @@ name = "embassy-nrf"
 version = "0.3.1"
 source = "git+https://github.com/ariel-os/embassy?rev=1d258e63acc0a322ccea28786a4143115ba303b8#1d258e63acc0a322ccea28786a4143115ba303b8"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "cortex-m",
  "cortex-m-rt",
@@ -1902,7 +1918,7 @@ source = "git+https://github.com/ariel-os/embassy?rev=90c8da09646d5fd97b7d416720
 dependencies = [
  "aligned",
  "bit_field",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "block-device-driver",
  "cfg-if",
  "cortex-m",
@@ -2207,7 +2223,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2265,7 +2281,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2285,41 +2301,41 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "enumset"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a4b049558765cef5f0c1a273c3fc57084d768b44d2f98127aef4cceb17293"
+checksum = "11a6b7c3d347de0a9f7bfd2f853be43fe32fa6fac30c70f6d6d67a1e936b87ee"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c3b24c345d8c314966bdc1832f6c2635bfcce8e7cf363bd115987bba2ee242"
+checksum = "6da3ea9e1d1a3b1593e15781f930120e72aa7501610b2f82e5b6739c72e8eac5"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2343,7 +2359,7 @@ version = "0.2.0"
 source = "git+https://github.com/ariel-os/esp-hal?rev=aa8d1995fc06eb5e6d04a2022ecf3679b4929e63#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
  "termcolor",
 ]
 
@@ -2362,7 +2378,7 @@ source = "git+https://github.com/ariel-os/esp-hal?rev=aa8d1995fc06eb5e6d04a2022e
 dependencies = [
  "basic-toml",
  "bitfield 0.17.0",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "bytemuck",
  "cfg-if",
  "chrono",
@@ -2448,7 +2464,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2756,15 +2772,15 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c486f63dbdcad99caa45f900ee8b51c8213483e7f53ff8992aa2b0c4d971362"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
 ]
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core",
  "subtle",
@@ -2772,13 +2788,13 @@ dependencies = [
 
 [[package]]
 name = "fixed"
-version = "1.28.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c6e0b89bf864acd20590dbdbad56f69aeb898abfc9443008fd7bd48b2cc85a"
+checksum = "707070ccf8c4173548210893a0186e29c266901b71ed20cd9e2ca0193dfe95c3"
 dependencies = [
  "az",
  "bytemuck",
- "half 2.4.1",
+ "half 2.6.0",
  "typenum",
 ]
 
@@ -2867,7 +2883,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2933,13 +2949,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3002,9 +3030,9 @@ checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -3054,9 +3082,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hax-lib"
@@ -3078,7 +3106,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3162,9 +3190,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -3234,9 +3262,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "i2c-controller"
@@ -3262,14 +3290,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -3285,21 +3314,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3309,30 +3339,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -3340,65 +3350,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
 ]
 
 [[package]]
@@ -3420,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3446,26 +3443,26 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.7",
 ]
@@ -3480,14 +3477,14 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -3520,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -3651,25 +3648,25 @@ checksum = "744a4c881f502e98c2241d2e5f50040ac73b30194d64452bb6260393b53f0dc9"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "liboscore"
@@ -3751,20 +3748,20 @@ checksum = "71a98813fa0073a317ed6a8055dcd4722a49d9b862af828ee68449adb799b6be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litrs"
@@ -3820,11 +3817,11 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "0.26.0"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661deac75bd438730c7335469ea8aee72a607e2bc93282386ef765b4ea7cdc0"
+checksum = "8a309f581ade7597820083bc275075c4c6986e57e53f8d26f88507cfefc8c987"
 dependencies = [
- "minicbor-derive 0.16.0",
+ "minicbor-derive 0.16.2",
 ]
 
 [[package]]
@@ -3835,7 +3832,7 @@ checksum = "548808f4038a8f55c06ee593d5732b0132459e719a6bbffc0db9c93101c56e7a"
 dependencies = [
  "cboritem",
  "heapless 0.8.0",
- "minicbor 0.26.0",
+ "minicbor 0.26.5",
 ]
 
 [[package]]
@@ -3846,25 +3843,25 @@ checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1164934feccd1ca0b67754a8656c409ec80c5888bcbdb6a7ccd2e43722d819c1"
+checksum = "a9882ef5c56df184b8ffc107fc6c61e33ee3a654b021961d790a78571bb9d67a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "minijinja"
-version = "2.6.0"
+version = "2.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212b4cab3aad057bc6e611814472905546c533295723b9e26a31c7feb19a8e65"
+checksum = "dd72e8b4e42274540edabec853f607c015c73436159b06c39c7af85a20433155"
 dependencies = [
  "serde",
 ]
@@ -3916,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "nourl"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c12edfda65fe16901d81d3bd93fd18ac07078b5007875a1c3b0d35f7725269"
+checksum = "aa07b0722c63805057dec824444fdc814bdfd30d1c782a3a8f63bbcf67c4ed1c"
 
 [[package]]
 name = "nrf-mpsl"
@@ -4001,7 +3998,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4070,7 +4067,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4106,7 +4103,7 @@ checksum = "969ccca8ffc4fb105bd131a228107d5c9dd89d9d627edf3295cbe979156f9712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4151,7 +4148,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4162,9 +4159,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peg"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295283b02df346d1ef66052a757869b2876ac29a6bb0ac3f5f7cd44aebe40e8f"
+checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
 dependencies = [
  "peg-macros",
  "peg-runtime",
@@ -4172,9 +4169,9 @@ dependencies = [
 
 [[package]]
 name = "peg-macros"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdad6a1d9cf116a059582ce415d5f5566aabcd4008646779dab7fdc2a9a9d426"
+checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
 dependencies = [
  "peg-runtime",
  "proc-macro2",
@@ -4183,9 +4180,9 @@ dependencies = [
 
 [[package]]
 name = "peg-runtime"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3aeb8f54c078314c2065ee649a7241f46b9d8e418e1a9581ba0546657d7aa3a"
+checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
 
 [[package]]
 name = "percent-encoding"
@@ -4200,7 +4197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -4210,7 +4207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared 0.11.3",
+ "phf_shared",
 ]
 
 [[package]]
@@ -4219,7 +4216,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
+ "phf_shared",
  "rand",
 ]
 
@@ -4230,19 +4227,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.3",
+ "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4251,7 +4239,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.1",
+ "siphasher",
 ]
 
 [[package]]
@@ -4283,13 +4271,33 @@ dependencies = [
 
 [[package]]
 name = "picoserve_derive"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ba0d83906d0357fedd23de7c5e3a5235342c248cc1d954d43d5e7b455c375c"
+checksum = "82a7350bdbef1ef80e4f058b89ca974dcc6526b04ac4d2095763b69760abf7ea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4349,7 +4357,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4402,7 +4410,7 @@ checksum = "a33fa6ec7f2047f572d49317cca19c87195de99c6e5b6ee492da701cfe02b053"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4429,12 +4437,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
+name = "potential_utf"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -4451,12 +4468,12 @@ checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4470,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -4520,26 +4537,32 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "r0"
@@ -4578,7 +4601,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -4596,11 +4619,11 @@ version = "0.1.1"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -4731,7 +4754,7 @@ checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4748,7 +4771,7 @@ checksum = "30f19a85fe107b65031e0ba8ec60c34c2494069fe910d6c297f5e7cb5a6f76d0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4765,9 +4788,9 @@ dependencies = [
 
 [[package]]
 name = "rp-binary-info"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534e2a451671116f5b9391cb15fae43b9abdc56817bcaca9a95ed32c3e4c6b38"
+checksum = "88ed2051a0bf2c726df01cfce378ed8a367be2a6e402fc183857f429a346d429"
 
 [[package]]
 name = "rp-pac"
@@ -4821,16 +4844,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.25",
+ "semver 1.0.26",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4839,15 +4862,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -4896,9 +4919,9 @@ dependencies = [
 
 [[package]]
 name = "semihosting"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d00d0037a88d97379cc27d815a471350923a1dc5880d5325c49695edcdc0d37"
+checksum = "c3e1c7d2b77d80283c750a39c52f1ab4d17234e8f30bca43550f5b2375f41d5f"
 
 [[package]]
 name = "semver"
@@ -4911,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "semver-parser"
@@ -4984,14 +5007,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -5014,7 +5037,7 @@ version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "itoa",
  "libyml",
  "memchr",
@@ -5025,9 +5048,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5068,21 +5091,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smart-leds"
@@ -5201,14 +5218,13 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "once_cell",
  "parking_lot",
- "phf_shared 0.10.0",
+ "phf_shared",
  "precomputed-hash",
 ]
 
@@ -5237,7 +5253,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5281,9 +5297,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5292,20 +5308,20 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "target-triple"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tcp-echo"
@@ -5318,13 +5334,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -5332,12 +5347,12 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3bb6001afcea98122260987f8b7b5da969ecad46dbf0b5453702f776b491a41"
+checksum = "8a984c8d058c627faaf5e8e2ed493fa3c51771889196de1016cf9c1c6e90d750"
 dependencies = [
  "home",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5380,22 +5395,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5469,9 +5484,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5479,9 +5494,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5528,7 +5543,7 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5558,7 +5573,7 @@ dependencies = [
  "rand_core",
  "static_cell",
  "trouble-host-macros",
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5571,7 +5586,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
  "uuid",
 ]
 
@@ -5585,9 +5600,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
+checksum = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2"
 dependencies = [
  "glob",
  "serde",
@@ -5600,9 +5615,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typewit"
@@ -5635,9 +5650,9 @@ checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -5732,12 +5747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5751,11 +5760,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -5797,9 +5806,18 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5823,7 +5841,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -5845,7 +5863,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5870,9 +5888,9 @@ dependencies = [
 
 [[package]]
 name = "windowed-infinity"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2d2f319a9cb78dfc654f88ff1ca936ed463580d6279417e17b28c4207107a1"
+checksum = "2b0ecf5dbfe6eecaae159df1cbf0945c9194c2b0512fbab6a3513c8257d7ccec"
 dependencies = [
  "ciborium-io",
  "crc",
@@ -5880,17 +5898,68 @@ dependencies = [
  "embedded-io 0.4.0",
  "minicbor 0.19.1",
  "minicbor 0.24.4",
+ "minicbor 0.26.5",
  "serde",
  "serde_cbor",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5910,20 +5979,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5935,11 +5995,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5955,6 +6031,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5965,6 +6047,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5979,10 +6067,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5997,6 +6097,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6007,6 +6113,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6021,6 +6133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6031,6 +6149,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -6051,16 +6175,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
+name = "wit-bindgen-rt"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xtensa-lx"
@@ -6096,14 +6223,14 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6113,24 +6240,14 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
 ]
 
 [[package]]
@@ -6139,18 +6256,7 @@ version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -6161,27 +6267,27 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -6192,10 +6298,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6204,11 +6321,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "src/ariel-os-power",
   "src/ariel-os-random",
   "src/ariel-os-rp",
+  "src/ariel-os-sensors",
   "src/ariel-os-stm32",
   "src/ariel-os-storage",
   "tests/benchmarks/bench_sched_flags",
@@ -116,12 +117,14 @@ ariel-os-embassy-common = { path = "src/ariel-os-embassy-common" }
 ariel-os-esp = { path = "src/ariel-os-esp" }
 ariel-os-hal = { path = "src/ariel-os-hal", default-features = false }
 ariel-os-identity = { path = "src/ariel-os-identity" }
+ariel-os-macros = { path = "src/ariel-os-macros" }
 ariel-os-nrf = { path = "src/ariel-os-nrf" }
 ariel-os-power = { path = "src/ariel-os-power" }
 ariel-os-random = { path = "src/ariel-os-random" }
 ariel-os-rp = { path = "src/ariel-os-rp" }
 ariel-os-rt = { path = "src/ariel-os-rt" }
 ariel-os-runqueue = { path = "src/ariel-os-runqueue" }
+ariel-os-sensors = { path = "src/ariel-os-sensors" }
 ariel-os-stm32 = { path = "src/ariel-os-stm32" }
 ariel-os-storage = { path = "src/ariel-os-storage" }
 ariel-os-threads = { path = "src/ariel-os-threads" }
@@ -140,6 +143,7 @@ once_cell = { version = "=1.19.0", default-features = false, features = [
   "critical-section",
 ] }
 paste = { version = "1.0" }
+pin-project = "1.1.10"
 rand = { version = "0.8.5", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 rtt-target = { version = "0.6.0" }

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -30,4 +30,13 @@ trybuild = "1.0.89"
 proc-macro = true
 
 [features]
+# These features could be codegened
+max-sample-min-count-2 = []
+max-sample-min-count-3 = []
+max-sample-min-count-4 = []
+max-sample-min-count-6 = []
+max-sample-min-count-7 = []
+max-sample-min-count-9 = []
+max-sample-min-count-12 = []
+
 _test = []

--- a/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
+++ b/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
@@ -1,0 +1,134 @@
+/// Generates sensor-related enums whose number of variants needs to be adjusted based on Cargo
+/// features, to accommodate the sensor driver returning the largest number of samples.
+///
+/// One single type must be defined so that it can be used in the Future returned by sensor
+/// drivers, which must be the same for every sensor driver so it can be part of the `Sensor`
+/// trait.
+#[proc_macro]
+pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
+    use quote::quote;
+
+    #[allow(clippy::wildcard_imports)]
+    use define_count_adjusted_enum::*;
+
+    // The order of these feature-gated statements is important as these features are not meant to
+    // be mutually exclusive.
+    #[allow(unused_variables, reason = "overridden by feature selection")]
+    let count = 1;
+    #[cfg(feature = "max-sample-min-count-2")]
+    let count = 2;
+    #[cfg(feature = "max-sample-min-count-3")]
+    let count = 3;
+    #[cfg(feature = "max-sample-min-count-4")]
+    let count = 4;
+    #[cfg(feature = "max-sample-min-count-6")]
+    let count = 6;
+    #[cfg(feature = "max-sample-min-count-7")]
+    let count = 7;
+    #[cfg(feature = "max-sample-min-count-9")]
+    let count = 9;
+    #[cfg(feature = "max-sample-min-count-12")]
+    let count = 12;
+
+    let samples_variants = (1..=count).map(|i| {
+        let variant = variant_name(i);
+        quote! { #variant([Sample; #i]) }
+    });
+    let samples_first_sample = (1..=count).map(|i| {
+        let variant = variant_name(i);
+        quote! {
+            Self::#variant(samples) => {
+                if let Some(sample) = samples.first() {
+                    *sample
+                } else {
+                    // NOTE(no-panic): there is always at least one sample
+                    unreachable!();
+                }
+            }
+        }
+    });
+
+    let reading_channels_variants = (1..=count).map(|i| {
+        let variant = variant_name(i);
+        quote! { #variant([ReadingChannel; #i]) }
+    });
+
+    let samples_iter = (1..=count)
+        .map(|i| {
+            let variant = variant_name(i);
+            quote! { Self::#variant(samples) => samples.iter().copied() }
+        })
+        .collect::<Vec<_>>();
+
+    let expanded = quote! {
+        /// Samples returned by a sensor driver.
+        ///
+        /// This type implements [`Reading`] to iterate over the samples.
+        ///
+        /// # Note
+        ///
+        /// This type is automatically generated, the number of variants is automatically adjusted.
+        #[derive(Debug, Copy, Clone)]
+        pub enum Samples {
+            #[doc(hidden)]
+            #(#samples_variants),*
+        }
+
+        impl Reading for Samples {
+            fn sample(&self) -> Sample {
+                match self {
+                    #(#samples_first_sample),*
+                }
+            }
+
+            fn samples(&self) -> impl ExactSizeIterator<Item = Sample> {
+                match self {
+                    #(#samples_iter),*
+                }
+            }
+        }
+
+        /// Metadata required to interpret samples returned by [`Sensor::wait_for_reading()`].
+        ///
+        /// # Note
+        ///
+        /// This type is automatically generated, the number of variants is automatically adjusted.
+        #[derive(Debug, Copy, Clone)]
+        pub enum ReadingChannels {
+            #[doc(hidden)]
+            #(#reading_channels_variants),*,
+        }
+
+        impl ReadingChannels {
+            /// Returns an iterator over the underlying [`ReadingChannel`] items.
+            ///
+            /// For a given sensor driver, the number and order of items match the one of
+            /// [`Samples`].
+            /// [`Iterator::zip()`] can be useful to zip the returned iterator with the one
+            /// obtained with [`Reading::samples()`].
+            pub fn iter(&self) -> impl Iterator<Item = ReadingChannel> + '_ {
+                match self {
+                    #(#samples_iter),*,
+                }
+            }
+
+            /// Returns the first [`ReadingChannel`].
+            pub fn first(&self) -> ReadingChannel {
+                if let Some(sample) = self.iter().next() {
+                    sample
+                } else {
+                    // NOTE(no-panic): there is always at least one sample.
+                    unreachable!();
+                }
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+mod define_count_adjusted_enum {
+    pub fn variant_name(index: usize) -> syn::Ident {
+        quote::format_ident!("V{index}")
+    }
+}

--- a/src/ariel-os-macros/src/lib.rs
+++ b/src/ariel-os-macros/src/lib.rs
@@ -3,6 +3,7 @@ mod utils;
 use proc_macro::TokenStream;
 
 include!("config.rs");
+include!("define_count_adjusted_sensor_enums.rs");
 include!("spawner.rs");
 include!("task.rs");
 include!("thread.rs");

--- a/src/ariel-os-rt/linkme.x
+++ b/src/ariel-os-rt/linkme.x
@@ -5,6 +5,8 @@ SECTIONS {
   linkm2_EMBASSY_TASKS : { KEEP(*(linkm2_EMBASSY_TASKS)) } > FLASH
   linkme_USB_BUILDER_HOOKS : { KEEP(*(linkme_USB_BUILDER_HOOKS)) } > FLASH
   linkm2_USB_BUILDER_HOOKS : { KEEP(*(linkm2_USB_BUILDER_HOOKS)) } > FLASH
+  linkme_SENSOR_REFS : { KEEP(*(linkme_SENSOR_REFS)) } > FLASH
+  linkm2_SENSOR_REFS : { KEEP(*(linkm2_SENSOR_REFS)) } > FLASH
   linkme_THREAD_FNS : { KEEP(*(linkme_THREAD_FNS)) } > FLASH
   linkm2_THREAD_FNS : { KEEP(*(linkm2_THREAD_FNS)) } > FLASH
 }

--- a/src/ariel-os-sensors/Cargo.toml
+++ b/src/ariel-os-sensors/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ariel-os-sensors"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true
+rust-version = "1.85"
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ariel-os-macros = { workspace = true }
+defmt = { workspace = true, optional = true }
+embassy-sync = { workspace = true }
+linkme = { workspace = true }
+pin-project = { workspace = true }
+
+[features]
+defmt = ["dep:defmt"]
+
+# These features could be codegened
+max-sample-min-count-2 = ["ariel-os-macros/max-sample-min-count-2"]
+max-sample-min-count-3 = ["ariel-os-macros/max-sample-min-count-3"]
+max-sample-min-count-4 = ["ariel-os-macros/max-sample-min-count-4"]
+max-sample-min-count-6 = ["ariel-os-macros/max-sample-min-count-6"]
+max-sample-min-count-7 = ["ariel-os-macros/max-sample-min-count-7"]
+max-sample-min-count-9 = ["ariel-os-macros/max-sample-min-count-9"]
+max-sample-min-count-12 = ["ariel-os-macros/max-sample-min-count-12"]

--- a/src/ariel-os-sensors/src/category.rs
+++ b/src/ariel-os-sensors/src/category.rs
@@ -1,0 +1,54 @@
+/// Categories a sensor driver can be part of.
+///
+/// A sensor driver can be part of multiple categories.
+///
+/// # For sensor driver implementors
+///
+/// Many mechanical sensor devices (e.g., accelerometers) include a temperature sensor as
+/// temperature may slightly affect the measurement results.
+/// If temperature readings are not exposed by the sensor driver, the sensor driver must not be
+/// considered part of a category that includes temperature ([`Category::Temperature`] or
+/// [`Category::AccelerometerTemperature`] in the case of an accelerometer).
+///
+/// Missing variants can be added when required.
+/// Please open an issue to discuss it.
+// Built upon https://doc.riot-os.org/group__drivers__saul.html#ga8f2dfec7e99562dbe5d785467bb71bbb
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Category {
+    /// Accelerometer.
+    Accelerometer,
+    /// Accelerometer & temperature sensor.
+    AccelerometerTemperature,
+    /// Accelerometer & magnetometer & temperature sensor.
+    AccelerometerMagnetometerTemperature,
+    /// Ammeter (ampere meter).
+    Ammeter,
+    /// CO₂ gas sensor.
+    Co2Gas,
+    /// Color sensor.
+    Color,
+    /// Gyroscope.
+    Gyroscope,
+    /// Humidity sensor.
+    Humidity,
+    /// Humidity & temperature sensor.
+    HumidityTemperature,
+    /// Light sensor.
+    Light,
+    /// Magnetometer.
+    Magnetometer,
+    /// pH sensor.
+    Ph,
+    /// Pressure sensor.
+    Pressure,
+    /// Push button.
+    PushButton,
+    /// Temperature sensor.
+    Temperature,
+    /// TVOC sensor.
+    Tvoc,
+    /// Voltage sensor.
+    Voltage,
+}

--- a/src/ariel-os-sensors/src/label.rs
+++ b/src/ariel-os-sensors/src/label.rs
@@ -1,0 +1,44 @@
+/// Label of a [`Sample`](crate::sensor::Sample) part of a
+/// [`Samples`](crate::sensor::Samples) tuple.
+///
+/// # For sensor driver implementors
+///
+/// Missing variants can be added when required.
+/// Please open an issue to discuss it.
+///
+/// [`Label::Main`] must be used for sensor drivers returning a single
+/// [`Sample`](crate::sensor::Sample), even if a more specific label exists for the
+/// physical quantity.
+/// This allows consumers displaying the label to ignore it for sensor drivers returning a single
+/// [`Sample`](crate::sensor::Sample).
+/// Other labels are reserved for sensor drivers returning multiple physical quantities.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Label {
+    /// Used for sensor drivers returning a single [`Sample`](crate::sensor::Sample).
+    Main,
+    /// Humidity.
+    Humidity,
+    /// Temperature.
+    Temperature,
+    /// X axis.
+    X,
+    /// Y axis.
+    Y,
+    /// Z axis.
+    Z,
+}
+
+impl core::fmt::Display for Label {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Main => write!(f, ""),
+            Self::Humidity => write!(f, "Humidity"),
+            Self::Temperature => write!(f, "Temperature"),
+            Self::X => write!(f, "X"),
+            Self::Y => write!(f, "Y"),
+            Self::Z => write!(f, "Z"),
+        }
+    }
+}

--- a/src/ariel-os-sensors/src/lib.rs
+++ b/src/ariel-os-sensors/src/lib.rs
@@ -1,0 +1,68 @@
+//! Provides a sensor abstraction layer.
+//!
+//! # Definitions
+//!
+//! In the context of this abstraction:
+//!
+//! - A *sensor device* is a device measuring one or multiple physical quantities and reporting
+//!   them as one or more digital values—we call these values *samples*.
+//! - Sensor devices measuring the same physical quantity are said to be part of the same *sensor
+//!   category*.
+//!   A sensor device may be part of multiple sensor categories.
+//! - A *measurement* is the physical operation of measuring one or several physical quantities.
+//! - A *reading* is the digital result returned by a sensor device after carrying out a
+//!   measurement.
+//!   Samples of different physical quantities can therefore be part of the same reading.
+//! - A *sensor driver* refers to a sensor device as exposed by the sensor abstraction layer.
+//! - A *sensor driver instance* is an instance of a sensor driver.
+//!
+//! # Accessing sensor driver instances
+//!
+//! Registered sensor driver instances can be accessed using
+//! [`REGISTRY::sensors()`](registry::Registry::sensors).
+//! Sensor drivers implement the [`Sensor`] trait, which allows to trigger measurements and obtain
+//! the resulting readings.
+//!
+//! # Obtaining a sensor reading
+//!
+//! After triggering a measurement with [`Sensor::trigger_measurement()`], a reading can be
+//! obtained using [`Sensor::wait_for_reading()`].
+//! It is additionally necessary to use [`Sensor::reading_channels()`] to make sense of the obtained
+//! reading:
+//!
+//! - [`Sensor::wait_for_reading()`] returns a [`Samples`](sensor::Samples), a data "tuple"
+//!   containing values returned by the sensor driver.
+//! - [`Sensor::reading_channels()`] returns a [`ReadingChannels`](sensor::ReadingChannels) which
+//!   indicates which physical quantity each [`Sample`](sample::Sample) from that tuple corresponds
+//!   to, using a [`Label`].
+//!   For instance, this allows to disambiguate the values provided by a temperature & humidity
+//!   sensor.
+//!
+//! To avoid handling floats, [`Sample`](sample::Sample)s returned by [`Sensor::wait_for_reading()`]
+//! are integers, and a fixed scaling value is provided in
+//! [`ReadingChannel`](sensor::ReadingChannel), for each [`Sample`](sample::Sample) returned.
+//! See [`Sample`](sample::Sample) for more details.
+//!
+//! # For implementors
+//!
+//! Sensor drivers must implement the [`Sensor`] trait.
+//!
+#![no_std]
+// Required by linkme
+#![feature(used_with_arg)]
+#![deny(clippy::pedantic)]
+#![deny(missing_docs)]
+
+mod category;
+mod label;
+mod measurement_unit;
+pub mod registry;
+mod sample;
+pub mod sensor;
+
+pub use category::Category;
+pub use label::Label;
+pub use measurement_unit::MeasurementUnit;
+pub use registry::{REGISTRY, SENSOR_REFS};
+pub use sample::Reading;
+pub use sensor::Sensor;

--- a/src/ariel-os-sensors/src/measurement_unit.rs
+++ b/src/ariel-os-sensors/src/measurement_unit.rs
@@ -1,0 +1,125 @@
+/// Represents a unit of measurement.
+///
+/// # For sensor driver implementors
+///
+/// Missing variants can be added when required.
+/// Please open an issue to discuss it.
+// Built upon https://doc.riot-os.org/phydat_8h_source.html
+// and https://bthome.io/format/#sensor-data
+// and https://www.iana.org/assignments/senml/senml.xhtml
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum MeasurementUnit {
+    /// [Acceleration *g*](https://en.wikipedia.org/wiki/G-force#Unit_and_measurement).
+    AccelG,
+    /// Ampere (A).
+    Ampere,
+    /// Becquerel (Bq).
+    Becquerel,
+    /// Logic boolean: `0` means `false` and `1` means `true`.
+    Bool,
+    /// Candela (cd).
+    Candela,
+    /// Degrees Celsius (°C).
+    Celsius,
+    /// Coulomb (C).
+    Coulomb,
+    /// Decibel (dB).
+    Decibel,
+    /// Farad (F).
+    Farad,
+    // FIXME: Kilogram as well?
+    /// Gram (g).
+    Gram,
+    /// Gray (Gy).
+    Gray,
+    /// Henry (H).
+    Henry,
+    /// Hertz (Hz).
+    Hertz,
+    /// Joule (J).
+    Joule,
+    /// Katal (kat).
+    Katal,
+    /// Kelvin (K).
+    Kelvin,
+    /// Lumen (lm).
+    Lumen,
+    /// Lux (lx).
+    Lux,
+    /// Meter (m)
+    Meter,
+    /// Mole (mol).
+    Mole,
+    /// Newton (N).
+    Newton,
+    /// Ohm (Ω).
+    Ohm,
+    /// Pascal (Pa).
+    Pascal,
+    /// Percent (%).
+    Percent,
+    /// %RH.
+    PercentageRelativeHumidity,
+    /// Radian (rad).
+    Radian,
+    /// Second (s).
+    Second,
+    /// Siemens (S).
+    Siemens,
+    /// Sievert (Sv).
+    Sievert,
+    /// Steradian (sr).
+    Steradian,
+    /// Tesla (T).
+    Tesla,
+    /// Volt (V).
+    Volt,
+    /// Watt (W).
+    Watt,
+    /// Weber (Wb).
+    Weber,
+}
+
+impl core::fmt::Display for MeasurementUnit {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[expect(clippy::match_same_arms)]
+        match self {
+            Self::AccelG => write!(f, "g"),
+            Self::Ampere => write!(f, "A"),
+            Self::Becquerel => write!(f, "Bq"),
+            Self::Bool => write!(f, ""),
+            Self::Candela => write!(f, "cd"),
+            Self::Celsius => write!(f, "°C"), // The Unicode Standard v15 recommends using U+00B0 + U+0043.
+            Self::Coulomb => write!(f, "C"),
+            Self::Decibel => write!(f, "dB"),
+            Self::Farad => write!(f, "F"),
+            Self::Gram => write!(f, "g"),
+            Self::Gray => write!(f, "Gy"),
+            Self::Henry => write!(f, "H"),
+            Self::Hertz => write!(f, "Hz"),
+            Self::Joule => write!(f, "J"),
+            Self::Katal => write!(f, "kat"),
+            Self::Kelvin => write!(f, "K"),
+            Self::Lumen => write!(f, "lm"),
+            Self::Lux => write!(f, "lx"),
+            Self::Meter => write!(f, "m"),
+            Self::Mole => write!(f, "mol"),
+            Self::Newton => write!(f, "N"),
+            Self::Ohm => write!(f, "Ω"),
+            Self::Pascal => write!(f, "Pa"),
+            Self::Percent => write!(f, "%"),
+            Self::PercentageRelativeHumidity => write!(f, "%RH"),
+            Self::Radian => write!(f, "rad"),
+            Self::Second => write!(f, "s"),
+            Self::Siemens => write!(f, "S"),
+            Self::Sievert => write!(f, "Sv"),
+            Self::Steradian => write!(f, "sr"),
+            Self::Tesla => write!(f, "T"),
+            Self::Volt => write!(f, "V"),
+            Self::Watt => write!(f, "W"),
+            Self::Weber => write!(f, "Wb"),
+        }
+    }
+}

--- a/src/ariel-os-sensors/src/registry.rs
+++ b/src/ariel-os-sensors/src/registry.rs
@@ -1,0 +1,42 @@
+//! Provides a sensor driver instance registry, allowing to register sensor driver instances and
+//! access them in a centralized location.
+
+use crate::Sensor;
+
+/// Stores references to registered sensor driver instances.
+///
+/// To register a sensor driver instance, insert a `&'static` into this [distributed
+/// slice](linkme).
+/// The sensor driver will therefore need to be statically allocated, to be able to obtain a
+/// `&'static`.
+// Exclude this from the users' documentation, to force users to use `Registry::sensors()` instead,
+// for easier forward compatibility with possibly non-static references.
+#[doc(hidden)]
+#[linkme::distributed_slice]
+pub static SENSOR_REFS: [&'static dyn Sensor] = [..];
+
+/// The global registry instance.
+pub static REGISTRY: Registry = Registry::new();
+
+/// The sensor driver instance registry.
+///
+/// This is exposed as [`REGISTRY`].
+pub struct Registry {
+    // Prevents instantiation from outside this module.
+    _private: (),
+}
+
+impl Registry {
+    // The constructor is private to make the registry a singleton.
+    const fn new() -> Self {
+        Self { _private: () }
+    }
+
+    /// Returns an iterator over registered sensor driver instances.
+    pub fn sensors(&self) -> impl Iterator<Item = &'static dyn Sensor> {
+        // Returning an iterator instead of the distributed slice directly would allow us to chain
+        // another source of sensor driver instances in the future, if we decided to support
+        // dynamically-allocated sensor driver instances.
+        SENSOR_REFS.iter().copied()
+    }
+}

--- a/src/ariel-os-sensors/src/sample.rs
+++ b/src/ariel-os-sensors/src/sample.rs
@@ -1,0 +1,130 @@
+#[expect(clippy::doc_markdown)]
+/// Represents a value obtained from a sensor device, along with its accuracy.
+///
+/// # Scaling
+///
+/// The [scaling value](crate::sensor::ReadingChannel::scaling()) obtained from the sensor driver with
+/// [`Sensor::reading_channels()`](crate::Sensor::reading_channels) must be taken into account using the
+/// following formula:
+///
+/// <math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mi mathvariant="monospace">Sample::value()</mi></mrow><mo>·</mo><msup><mn>10</mn><mrow><mi mathvariant="monospace">scaling</mi></mrow></msup></math>
+///
+/// For instance, in the case of a temperature sensor, if [`Self::value()`] returns `2225` and the
+/// scaling value is `-2`, this means that the temperature measured and returned by the sensor
+/// device is `22.25` (the [measurement error](Accuracy) must additionally be taken into
+/// account).
+/// This is required to avoid handling floats.
+///
+/// # Unit of measurement
+///
+/// The unit of measurement can be obtained using
+/// [`ReadingChannel::unit()`](crate::sensor::ReadingChannel::unit).
+///
+/// # Accuracy
+///
+/// The accuracy can be obtained with [`Self::accuracy()`].
+// NOTE(derive): we do not implement `Eq` or `PartialOrd` on purpose: `Eq` would prevent us from
+// possibly adding floats in the future and `PartialOrd` does not make sense because interpreting
+// the sample requires the `ReadingChannel` associated with this `Sample`.
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Sample {
+    value: i32,
+    accuracy: Accuracy,
+}
+
+impl Sample {
+    /// Creates a new sample.
+    ///
+    /// This constructor is intended for sensor driver implementors only.
+    #[must_use]
+    pub const fn new(value: i32, accuracy: Accuracy) -> Self {
+        Self { value, accuracy }
+    }
+
+    /// Returns the sample value.
+    #[must_use]
+    pub fn value(&self) -> i32 {
+        self.value
+    }
+
+    /// Returns the measurement accuracy.
+    #[must_use]
+    pub fn accuracy(&self) -> Accuracy {
+        self.accuracy
+    }
+}
+
+/// Specifies the accuracy of a measurement.
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Accuracy {
+    /// Unknown accuracy.
+    Unknown,
+    /// No measurement error (e.g., boolean values from a push button).
+    NoError,
+    /// Measurement error symmetrical around the [`bias`](Accuracy::SymmetricalError::bias).
+    ///
+    /// The unit of measurement is provided by the [`ReadingChannel`](crate::sensor::ReadingChannel)
+    /// associated to the [`Sample`].
+    /// The `scaling` value is used for both `deviation` and `bias`.
+    /// The accuracy error is thus given by the following formulas:
+    ///
+    /// <math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mo>+</mo><mo>(</mo><mrow><mi mathvariant="monospace">bias</mi></mrow><mo>+</mo><mrow><mi mathvariant="monospace">deviation</mi></mrow><mo>)</mo><mo>·</mo><msup><mn>10</mn><mrow><mi mathvariant="monospace">scaling</mi></mrow></msup>/<mo>-</mo><mo>(</mo><mrow><mi mathvariant="monospace">bias</mi></mrow><mo>-</mo><mrow><mi mathvariant="monospace">deviation</mi></mrow><mo>)</mo><mo>·</mo><msup><mn>10</mn><mrow><mi mathvariant="monospace">scaling</mi></mrow></msup></math>
+    ///
+    /// # Examples
+    ///
+    /// The DS18B20 temperature sensor accuracy error is <mo>+</mo><mn>0.05</mn>/<mo>-</mo><mn>0.45</mn>
+    /// at 20 °C (see Figure 1 of its datasheet).
+    /// [`Accuracy`] would thus be the following:
+    ///
+    /// ```
+    /// # use ariel_os_sensors::sensor::Accuracy;
+    /// Accuracy::SymmetricalError {
+    ///     deviation: 25,
+    ///     bias: -20,
+    ///     scaling: -2,
+    /// }
+    /// # ;
+    /// ```
+    SymmetricalError {
+        /// Deviation around the bias value.
+        deviation: i8,
+        /// Bias (mean accuracy error).
+        bias: i8,
+        /// Scaling of [`deviation`](Accuracy::SymmetricalError::deviation) and
+        /// [`bias`](Accuracy::SymmetricalError::bias).
+        scaling: i8,
+    },
+}
+
+/// Implemented on [`Samples`](crate::sensor::Samples), returned by
+/// [`Sensor::wait_for_reading()`](crate::Sensor::wait_for_reading).
+pub trait Reading: core::fmt::Debug {
+    /// Returns the first value returned by [`Reading::samples()`].
+    fn sample(&self) -> Sample;
+
+    /// Returns an iterator over [`Sample`]s of a sensor reading.
+    ///
+    /// The order of [`Sample`]s is not significant, but is fixed.
+    ///
+    /// # For implementors
+    ///
+    /// The default implementation must be overridden on types containing multiple
+    /// [`Sample`]s.
+    fn samples(&self) -> impl ExactSizeIterator<Item = Sample> {
+        [self.sample()].into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn assert_type_sizes() {
+        assert!(size_of::<Accuracy>() <= size_of::<u32>());
+        // Make sure the type is small enough.
+        assert!(size_of::<Sample>() <= 2 * size_of::<u32>());
+    }
+}

--- a/src/ariel-os-sensors/src/sensor.rs
+++ b/src/ariel-os-sensors/src/sensor.rs
@@ -1,0 +1,326 @@
+//! Provides a [`Sensor`] trait abstracting over implementation details of a sensor driver.
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::ReceiveFuture};
+
+use crate::{Category, Label, MeasurementUnit};
+
+pub use crate::{
+    Reading,
+    sample::{Accuracy, Sample},
+};
+
+ariel_os_macros::define_count_adjusted_sensor_enums!();
+
+/// This trait must be implemented by sensor drivers.
+///
+/// See [the module level documentation](crate) for more.
+pub trait Sensor: Send + Sync {
+    /// Triggers a measurement.
+    /// Clears the previous reading.
+    ///
+    /// To obtain readings from every sensor drivers this method can be called in a loop over all
+    /// sensors returned by [`Registry::sensors()`](crate::registry::Registry::sensors), before
+    /// obtaining the readings with [`Self::wait_for_reading()`] in a second loop, so that the
+    /// measurements happen concurrently.
+    ///
+    /// # For implementors
+    ///
+    /// This method should return quickly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TriggerMeasurementError::NonEnabled`] if the sensor driver is not enabled.
+    fn trigger_measurement(&self) -> Result<(), TriggerMeasurementError>;
+
+    /// Waits for the reading and returns it asynchronously.
+    /// Depending on the sensor device and the sensor driver, this may use a sensor interrupt or
+    /// data polling.
+    /// Interpretation of the reading requires data from [`Sensor::reading_channels()`] as well.
+    /// See [the module level documentation](crate) for more.
+    ///
+    /// # Note
+    ///
+    /// It is necessary to trigger a measurement by calling [`Sensor::trigger_measurement()`]
+    /// beforehand, even if the sensor device carries out periodic measurements on its own.
+    ///
+    /// # Errors
+    ///
+    /// - Quickly returns [`ReadingError::NonEnabled`] if the sensor driver is not enabled.
+    /// - Quickly returns [`ReadingError::NotMeasuring`] if no measurement has been triggered
+    ///   beforehand using [`Sensor::trigger_measurement()`].
+    /// - Returns [`ReadingError::SensorAccess`] if the sensor device cannot be accessed.
+    fn wait_for_reading(&'static self) -> ReadingWaiter;
+
+    /// Provides information about the reading returned by [`Sensor::wait_for_reading()`].
+    #[must_use]
+    fn reading_channels(&self) -> ReadingChannels;
+
+    /// Sets the sensor driver mode and returns the previous state.
+    /// Allows to put the sensor device to sleep if supported.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SetModeError::Uninitialized`] if the sensor driver is not initialized.
+    fn set_mode(&self, mode: Mode) -> Result<State, SetModeError>;
+
+    /// Returns the current sensor driver state.
+    #[must_use]
+    fn state(&self) -> State;
+
+    /// Returns the categories the sensor device is part of.
+    #[must_use]
+    fn categories(&self) -> &'static [Category];
+
+    /// String label of the sensor driver *instance*.
+    /// For instance, in the case of a temperature sensor, this allows to specify whether this
+    /// specific sensor device is placed indoor or outdoor.
+    #[must_use]
+    fn label(&self) -> Option<&'static str>;
+
+    /// Returns a human-readable name of the *sensor driver*.
+    /// For instance, "push button" and "3-axis accelerometer" are appropriate display names.
+    ///
+    /// # Note
+    ///
+    /// Different sensor drivers for the same sensor device may have different display names.
+    #[must_use]
+    fn display_name(&self) -> Option<&'static str>;
+
+    /// Returns the sensor device part number.
+    /// Returns `None` when the sensor device does not have a part number.
+    /// For instance, "DS18B20" is a valid part number.
+    #[must_use]
+    fn part_number(&self) -> Option<&'static str>;
+
+    /// Returns the sensor driver version number.
+    #[must_use]
+    fn version(&self) -> u8;
+}
+
+/// Future returned by [`Sensor::wait_for_reading()`].
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[pin_project::pin_project(project = ReadingWaiterProj)]
+pub enum ReadingWaiter {
+    #[doc(hidden)]
+    Waiter {
+        #[pin]
+        waiter: ReceiveFuture<'static, CriticalSectionRawMutex, ReadingResult<Samples>, 1>,
+    },
+    #[doc(hidden)]
+    Err(ReadingError),
+    #[doc(hidden)]
+    Resolved,
+}
+
+impl Future for ReadingWaiter {
+    type Output = ReadingResult<Samples>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().project();
+        match this {
+            ReadingWaiterProj::Waiter { waiter } => waiter.poll(cx),
+            ReadingWaiterProj::Err(err) => {
+                // Replace the error with a dummy error value, crafted from thin air, and mark the
+                // future as resolved, so that we do not take this dummy value into account later.
+                // This avoids requiring `Clone` on `ReadingError`.
+                let err = core::mem::replace(err, ReadingError::NonEnabled);
+                *self = ReadingWaiter::Resolved;
+
+                Poll::Ready(Err(err))
+            }
+            ReadingWaiterProj::Resolved => unreachable!(),
+        }
+    }
+}
+
+/// Mode of a sensor driver.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Mode {
+    /// The sensor driver is disabled.
+    Disabled,
+    /// The sensor driver is enabled.
+    Enabled,
+    /// The sensor driver is sleeping.
+    /// The sensor device may be in a low-power mode.
+    Sleeping,
+}
+
+/// Possible errors when attempting to set the mode of a sensor driver.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SetModeError {
+    /// The sensor driver is uninitialized.
+    /// It has not been initialized yet, or initialization could not succeed.
+    Uninitialized,
+}
+
+impl core::fmt::Display for SetModeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Uninitialized => write!(f, "sensor driver is not initialized"),
+        }
+    }
+}
+
+impl core::error::Error for SetModeError {}
+
+/// State of a sensor driver.
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum State {
+    /// The sensor driver is uninitialized.
+    /// It has not been initialized yet, or initialization could not succeed.
+    #[default]
+    Uninitialized = 0,
+    /// The sensor driver is disabled.
+    Disabled = 1,
+    /// The sensor driver is enabled.
+    Enabled = 2,
+    /// The sensor driver is enabled and a measurement has been triggered.
+    Measuring = 3,
+    /// The sensor driver is sleeping.
+    Sleeping = 4,
+}
+
+impl From<Mode> for State {
+    fn from(mode: Mode) -> Self {
+        match mode {
+            Mode::Disabled => Self::Disabled,
+            Mode::Enabled => Self::Enabled,
+            Mode::Sleeping => Self::Sleeping,
+        }
+    }
+}
+
+impl TryFrom<u8> for State {
+    type Error = TryFromIntError;
+
+    fn try_from(int: u8) -> Result<Self, Self::Error> {
+        match int {
+            0 => Ok(Self::Uninitialized),
+            1 => Ok(Self::Disabled),
+            2 => Ok(Self::Enabled),
+            3 => Ok(Self::Measuring),
+            4 => Ok(Self::Sleeping),
+            _ => Err(TryFromIntError),
+        }
+    }
+}
+
+/// The error type returned when a checked integral type conversion fails.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TryFromIntError;
+
+impl core::fmt::Display for TryFromIntError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "out of range integral type conversion attempted")
+    }
+}
+
+impl core::error::Error for TryFromIntError {}
+
+/// Provides metadata about a [`Sample`].
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+// NOTE(derive): we do not implement `Eq` on purpose: its would prevent us from possibly adding
+// floats in the future.
+pub struct ReadingChannel {
+    label: Label,
+    scaling: i8,
+    unit: MeasurementUnit,
+}
+
+impl ReadingChannel {
+    /// Creates a new [`ReadingChannel`].
+    ///
+    /// This constructor is intended for sensor driver implementors only.
+    #[must_use]
+    pub fn new(label: Label, scaling: i8, unit: MeasurementUnit) -> Self {
+        Self {
+            label,
+            scaling,
+            unit,
+        }
+    }
+
+    /// Returns the [`Label`] for this channel.
+    #[must_use]
+    pub fn label(&self) -> Label {
+        self.label
+    }
+
+    /// Returns the [scaling](Sample) for this channel.
+    #[must_use]
+    pub fn scaling(&self) -> i8 {
+        self.scaling
+    }
+
+    /// Returns the unit of measurement for this channel.
+    #[must_use]
+    pub fn unit(&self) -> MeasurementUnit {
+        self.unit
+    }
+}
+
+/// Represents errors happening when *triggering* a sensor measurement.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TriggerMeasurementError {
+    /// The sensor driver is not enabled (e.g., it may be disabled or sleeping).
+    NonEnabled,
+}
+
+impl core::fmt::Display for TriggerMeasurementError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NonEnabled => write!(f, "sensor driver is not enabled"),
+        }
+    }
+}
+
+impl core::error::Error for TriggerMeasurementError {}
+
+/// Represents errors happening when accessing a sensor reading.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ReadingError {
+    /// The sensor driver is not enabled (e.g., it may be disabled or sleeping).
+    NonEnabled,
+    /// Cannot access the sensor device (e.g., because of a bus error).
+    SensorAccess,
+    /// No measurement has been triggered before waiting for a reading.
+    /// It is necessary to call [`Sensor::trigger_measurement()`] before calling
+    /// [`Sensor::wait_for_reading()`].
+    NotMeasuring,
+}
+
+impl core::fmt::Display for ReadingError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NonEnabled => write!(f, "sensor driver is not enabled"),
+            Self::SensorAccess => write!(f, "sensor device could not be accessed"),
+            Self::NotMeasuring => write!(f, "no measurement has been triggered"),
+        }
+    }
+}
+
+impl core::error::Error for ReadingError {}
+
+/// A specialized [`Result`] type for [`Reading`] operations.
+pub type ReadingResult<R> = Result<R, ReadingError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Assert that the Sensor trait is object-safe
+    static _SENSOR_REFS: &[&dyn Sensor] = &[];
+}

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -36,6 +36,7 @@ ariel-os-macros = { path = "../ariel-os-macros" }
 ariel-os-power = { path = "../ariel-os-power" }
 ariel-os-random = { workspace = true, optional = true }
 ariel-os-rt = { path = "../ariel-os-rt" }
+ariel-os-sensors = { workspace = true, optional = true }
 ariel-os-storage = { workspace = true, optional = true }
 ariel-os-threads = { path = "../ariel-os-threads", optional = true }
 ariel-os-utils = { workspace = true }
@@ -65,6 +66,9 @@ random = ["dep:ariel-os-random", "ariel-os-embassy/random"]
 csprng = ["dep:ariel-os-random", "ariel-os-random?/csprng"]
 # Enables seeding the random number generator from hardware.
 hwrng = ["ariel-os-embassy/hwrng"]
+# Enables support for sensors.
+# *Currently experimental and undocumented.*
+sensors = ["dep:ariel-os-sensors"]
 
 #! ## Network protocols
 ## Enables support for TCP.

--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -42,6 +42,9 @@ pub use ariel_os_power as power;
 pub use ariel_os_random as random;
 #[doc(hidden)]
 pub use ariel_os_rt as rt;
+#[cfg(feature = "sensors")]
+#[doc(inline)]
+pub use ariel_os_sensors as sensors;
 #[cfg(feature = "storage")]
 #[doc(inline)]
 pub use ariel_os_storage as storage;


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This is the first step in providing a sensor abstraction/API whose goal is to provide consistent access to sensor drivers and their readings, abstracting over implementation details of specific sensor devices. It is a (partial) implementation of RFC #201 (handling of thresholds and sensor interrupts will come later and is expected to be relatively orthogonal).

The main change is the introduction of a `ariel-os-sensors` crate, which is re-exported in `ariel-os` as the `sensors` module, which is feature-gated behind the `sensors` Cargo feature. Until this API and the first sensor drivers are landed, this feature is considered experimental/unstable and breaking changes will therefore not be reflected on the version number of the `ariel-os` crate.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Partial implementation of RFC #201.
Closes #334.

## Open Questions

<!-- Unresolved questions, if any. -->
- Should we derive `serde::Serialize` on the relevant items?
- Are floats completely out of the question, even as helpers? Integers should stay at the core of the API, but maybe we could have additional (feature-gated?) helpers on `Value`+`ReadingAxis`+`Accuracy` which would return floats taking into account everything required to make sense of the reading (in particular the scaling value)?
- The `Reading` trait was initially introduced when it was thought it would be possible to return different concrete types from `Sensor::wait_for_reading()` (it now always return a `Values`); should the trait be removed and its methods implemented on `Values` itself, slightly simplifying the API (it is not *impossible* that Rust would allow returning different concrete types from `Sensor::wait_for_reading()` in the far future)?
- Open for bikeshedding:
  - We should agree on names for what is currently called:
    - Sensor category: could be renamed to sensor class to match SAUL naming, but "class" is a reserved keyword in many languages.
    - Scaling (value): could be "scaling", "prescaler", something else?
  - Some of the documentation is split between the top module, the `Value` and the `Accuracy` types, in an attempt to keep it close to its associated implementation. Should we instead group (some of) it in the top-level module?
  - The set of items we re-export at root level could use some refinement (or err on the side of caution and not re-export much for now).

## Future work

The following steps would be:

- Adding support for external interrupts triggered by sensor devices: *physical event* interrupts and *data available* interrupts are to be treated differently even though they use the same pins.
- Adding the first sensor drivers provided by Ariel OS (the current API does also allow to provide and use third-party sensor drivers developed for this sensor API): drivers for push buttons, some temperature sensors and 3-axis accelerometers exist in a preliminary state but are not part of this PR.
- Introducing codegen for automating the instantiating and configuration of sensor drivers based on static, structured configuration files.

## How to review this PR

I think this PR is better reviewed by generating the rustdoc docs locally and starting from there, before glancing at the implementation.

## TODO

- [x] The `Category`, `Label`, and `MeasurementUnit` enums should be expanded with more variants, even though these can (and will) be expanded later.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
