### PR TITLE
ci(hax): disable the hax workflow for now as it is always failing

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -1,8 +1,8 @@
 name: hax
 
-on:
-  pull_request:
-  push:
+# on:
+#   pull_request:
+#   push:
 
 jobs:
   hax:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The hax workflow has been failing since #460 when we purposefully decided to not require it to pass for merging PRs.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
