### PR TITLE
test(gpio): assert that the GPIO types are zero cost memory-wise

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
       # TODO: we'll eventually want to enable relevant features
       - name: Run crate tests
         run: |
-            cargo test --no-default-features --features i2c,no-boards -p riot-rs -p riot-rs-embassy -p riot-rs-embassy-common -p riot-rs-runqueue -p riot-rs-threads -p riot-rs-macros
+            cargo test --no-default-features --features external-interrupts,i2c,no-boards -p riot-rs -p riot-rs-embassy -p riot-rs-embassy-common -p riot-rs-runqueue -p riot-rs-threads -p riot-rs-macros
             cargo test -p rbi -p ringbuffer -p coapcore
 
       # We need to set `RUSTDOCFLAGS` as well in the following jobs, because it

--- a/src/riot-rs-embassy/src/gpio.rs
+++ b/src/riot-rs-embassy/src/gpio.rs
@@ -477,3 +477,16 @@ macro_rules! impl_embedded_hal_output_traits {
 }
 
 impl_embedded_hal_output_traits!(Output, ArchOutput);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_gpio_type_sizes() {
+        // Assert that the GPIO types are zero cost memory-wise.
+        assert_eq!(size_of::<Input>(), size_of::<()>());
+        assert_eq!(size_of::<IntEnabledInput>(), size_of::<()>());
+        assert_eq!(size_of::<Output>(), size_of::<()>());
+    }
+}


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This doubles as an example of how to test types for size.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
