### PR TITLE
refactor(threads): use CPU INTR0 for scheduler on esp

### DIFF
--- a/src/riot-rs-esp/src/lib.rs
+++ b/src/riot-rs-esp/src/lib.rs
@@ -74,9 +74,9 @@ pub fn init() -> OptionalPeripherals {
         // in `riot_rs_threads::arch::xtensa`.
         // So, re-enable it here.
 
-        // Panics if `FROM_CPU_INTR1` is among `esp_hal::interrupt::RESERVED_INTERRUPTS`,
+        // Panics if `FROM_CPU_INTR0` is among `esp_hal::interrupt::RESERVED_INTERRUPTS`,
         // which isn't the case.
-        interrupt::enable(Interrupt::FROM_CPU_INTR1, interrupt::Priority::min()).unwrap();
+        interrupt::enable(Interrupt::FROM_CPU_INTR0, interrupt::Priority::min()).unwrap();
     }
 
     #[cfg(feature = "wifi-esp")]

--- a/src/riot-rs-threads/src/arch/riscv.rs
+++ b/src/riot-rs-threads/src/arch/riscv.rs
@@ -19,8 +19,8 @@ impl Arch for Cpu {
     fn schedule() {
         unsafe {
             (&*SYSTEM::PTR)
-                .cpu_intr_from_cpu_1()
-                .modify(|_, w| w.cpu_intr_from_cpu_1().set_bit());
+                .cpu_intr_from_cpu_0()
+                .modify(|_, w| w.cpu_intr_from_cpu_0().set_bit());
         }
     }
 
@@ -40,11 +40,11 @@ impl Arch for Cpu {
 
     /// Enable and trigger the appropriate software interrupt.
     fn start_threading() {
-        interrupt::disable(EspHalCpu::ProCpu, Interrupt::FROM_CPU_INTR1);
+        interrupt::disable(EspHalCpu::ProCpu, Interrupt::FROM_CPU_INTR0);
         Self::schedule();
-        // Panics if `FROM_CPU_INTR1` is among `esp_hal::interrupt::RESERVED_INTERRUPTS`,
+        // Panics if `FROM_CPU_INTR0` is among `esp_hal::interrupt::RESERVED_INTERRUPTS`,
         // which isn't the case.
-        interrupt::enable(Interrupt::FROM_CPU_INTR1, interrupt::Priority::min()).unwrap();
+        interrupt::enable(Interrupt::FROM_CPU_INTR0, interrupt::Priority::min()).unwrap();
     }
 }
 
@@ -103,12 +103,12 @@ fn copy_registers(src: &TrapFrame, dst: &mut TrapFrame) {
 /// Handler for software interrupt 0, which we use for context switching.
 #[allow(non_snake_case)]
 #[no_mangle]
-extern "C" fn FROM_CPU_INTR1(trap_frame: &mut TrapFrame) {
+extern "C" fn FROM_CPU_INTR0(trap_frame: &mut TrapFrame) {
     unsafe {
-        // clear FROM_CPU_INTR1
+        // clear FROM_CPU_INTR0
         (&*SYSTEM::PTR)
-            .cpu_intr_from_cpu_1()
-            .modify(|_, w| w.cpu_intr_from_cpu_1().clear_bit());
+            .cpu_intr_from_cpu_0()
+            .modify(|_, w| w.cpu_intr_from_cpu_0().clear_bit());
 
         sched(trap_frame)
     }

--- a/src/riot-rs-threads/src/arch/xtensa.rs
+++ b/src/riot-rs-threads/src/arch/xtensa.rs
@@ -15,8 +15,8 @@ impl Arch for Cpu {
     fn schedule() {
         unsafe {
             (&*SYSTEM::PTR)
-                .cpu_intr_from_cpu_1()
-                .modify(|_, w| w.cpu_intr_from_cpu_1().set_bit());
+                .cpu_intr_from_cpu_0()
+                .modify(|_, w| w.cpu_intr_from_cpu_0().set_bit());
         }
     }
 
@@ -45,11 +45,11 @@ impl Arch for Cpu {
     }
 
     fn start_threading() {
-        interrupt::disable(esp_hal::Cpu::ProCpu, Interrupt::FROM_CPU_INTR1);
+        interrupt::disable(esp_hal::Cpu::ProCpu, Interrupt::FROM_CPU_INTR0);
         Self::schedule();
-        // Panics if `FROM_CPU_INTR1` is among `esp_hal::interrupt::RESERVED_INTERRUPTS`,
+        // Panics if `FROM_CPU_INTR0` is among `esp_hal::interrupt::RESERVED_INTERRUPTS`,
         // which isn't the case.
-        interrupt::enable(Interrupt::FROM_CPU_INTR1, interrupt::Priority::min()).unwrap();
+        interrupt::enable(Interrupt::FROM_CPU_INTR0, interrupt::Priority::min()).unwrap();
     }
 }
 
@@ -60,12 +60,12 @@ const fn default_trap_frame() -> TrapFrame {
 /// Handler for software interrupt 0, which we use for context switching.
 #[allow(non_snake_case)]
 #[no_mangle]
-extern "C" fn FROM_CPU_INTR1(trap_frame: &mut TrapFrame) {
+extern "C" fn FROM_CPU_INTR0(trap_frame: &mut TrapFrame) {
     unsafe {
-        // clear FROM_CPU_INTR1
+        // clear FROM_CPU_INTR0
         (&*SYSTEM::PTR)
-            .cpu_intr_from_cpu_1()
-            .modify(|_, w| w.cpu_intr_from_cpu_1().clear_bit());
+            .cpu_intr_from_cpu_0()
+            .modify(|_, w| w.cpu_intr_from_cpu_0().clear_bit());
 
         sched(trap_frame)
     }


### PR DESCRIPTION
# Description

Required for #397, because there the xtensa implementation is changed to use CPU Intr0 for single-core, and this should be unified for both RISC-V and Xtensa.

## Issues/PRs references

Required for #397.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
