### PR TITLE
Wire up `ESP32-Sx` USB support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,6 +3593,7 @@ dependencies = [
  "riot-rs-debug",
  "riot-rs-embassy-common",
  "riot-rs-utils",
+ "static_cell",
 ]
 
 [[package]]

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -638,6 +638,9 @@ modules:
       - network_device
     selects:
       - hw/usb-device-port
+    conflicts:
+      # there is an issue on esp32s3, the only esp32 that we have usb support for.
+      - xtensa
     env:
       global:
         FEATURES:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -646,6 +646,7 @@ modules:
   - name: hw/usb-device-port
     help: provided if a device has a USB device port wired up
     context:
+      - espressif-esp32-s3-wroom-1
       - nrf5340dk
       - nrf52840dk
       - rpi-pico

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -68,8 +68,11 @@ spi = [
   "riot-rs-embassy-common/spi",
   "riot-rs-hal/spi",
 ]
+
+## Enables USB support.
 usb = ["dep:embassy-usb", "riot-rs-hal/usb"]
 usb-hid = ["dep:usbd-hid", "embassy-usb?/usbd-hid", "usb"]
+
 # embassy-net requires embassy-time and support for timeouts in the executor
 net = ["dep:embassy-net", "time"]
 usb-ethernet = ["usb", "net"]

--- a/src/riot-rs-esp/Cargo.toml
+++ b/src/riot-rs-esp/Cargo.toml
@@ -31,6 +31,7 @@ paste = { workspace = true }
 riot-rs-debug = { workspace = true }
 riot-rs-embassy-common = { workspace = true }
 riot-rs-utils = { workspace = true }
+static_cell = { workspace = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 embassy-executor = { workspace = true, default-features = false, features = [
@@ -80,6 +81,9 @@ spi = ["dep:fugit", "riot-rs-embassy-common/spi"]
 
 ## Enables defmt support.
 defmt = ["dep:defmt", "esp-hal/defmt", "esp-wifi?/defmt", "fugit?/defmt"]
+
+# Enables USB support.
+usb = []
 
 ## Enables Wi-Fi support.
 wifi = []

--- a/src/riot-rs-esp/src/lib.rs
+++ b/src/riot-rs-esp/src/lib.rs
@@ -17,6 +17,9 @@ pub mod identity {
 #[cfg(feature = "spi")]
 pub mod spi;
 
+#[cfg(feature = "usb")]
+pub mod usb;
+
 #[cfg(feature = "wifi")]
 pub mod wifi;
 

--- a/src/riot-rs-esp/src/usb/mod.rs
+++ b/src/riot-rs-esp/src/usb/mod.rs
@@ -1,0 +1,22 @@
+use esp_hal::otg_fs::asynch::Driver;
+use static_cell::ConstStaticCell;
+
+pub type UsbDriver = Driver<'static>;
+
+pub fn driver(peripherals: &mut crate::OptionalPeripherals) -> UsbDriver {
+    use esp_hal::otg_fs::{asynch::Config, Usb};
+
+    let usb = Usb::new(
+        peripherals.USB0.take().unwrap(),
+        peripherals.GPIO_20.take().unwrap(),
+        peripherals.GPIO_19.take().unwrap(),
+    );
+
+    // Buffer size copied from upstream. There's no hint about sizing.
+    static EP_OUT_BUFFER: ConstStaticCell<[u8; 1024]> = ConstStaticCell::new([0u8; 1024]);
+    let ep_out_buffer = EP_OUT_BUFFER.take();
+
+    let config = Config::default();
+
+    Driver::new(usb, ep_out_buffer, config)
+}

--- a/src/riot-rs-esp/src/usb/mod.rs
+++ b/src/riot-rs-esp/src/usb/mod.rs
@@ -1,16 +1,30 @@
 use esp_hal::otg_fs::asynch::Driver;
 use static_cell::ConstStaticCell;
 
+use crate::peripherals;
+
 pub type UsbDriver = Driver<'static>;
 
-pub fn driver(peripherals: &mut crate::OptionalPeripherals) -> UsbDriver {
+pub struct Peripherals {
+    usb: peripherals::USB0,
+    usbdp: peripherals::GPIO_20,
+    usbdm: peripherals::GPIO_19,
+}
+
+impl Peripherals {
+    #[must_use]
+    pub fn new(peripherals: &mut crate::OptionalPeripherals) -> Self {
+        Self {
+            usb: peripherals.USB0.take().unwrap(),
+            usbdp: peripherals.GPIO_20.take().unwrap(),
+            usbdm: peripherals.GPIO_19.take().unwrap(),
+        }
+    }
+}
+pub fn driver(peripherals: Peripherals) -> UsbDriver {
     use esp_hal::otg_fs::{asynch::Config, Usb};
 
-    let usb = Usb::new(
-        peripherals.USB0.take().unwrap(),
-        peripherals.GPIO_20.take().unwrap(),
-        peripherals.GPIO_19.take().unwrap(),
-    );
+    let usb = Usb::new(peripherals.usb, peripherals.usbdp, peripherals.usbdm);
 
     // Buffer size copied from upstream. There's no hint about sizing.
     static EP_OUT_BUFFER: ConstStaticCell<[u8; 1024]> = ConstStaticCell::new([0u8; 1024]);

--- a/src/riot-rs-hal/Cargo.toml
+++ b/src/riot-rs-hal/Cargo.toml
@@ -56,7 +56,7 @@ spi = [
 ]
 
 usb = [
-  #"riot-rs-esp/usb",
+  "riot-rs-esp/usb",
   "riot-rs-nrf/usb",
   "riot-rs-rp/usb",
   "riot-rs-stm32/usb",


### PR DESCRIPTION
# Description

This PR wires up USB support for the esp-hal based devices.
IIUC, only `esp32-s2` and `esp32-s3` have the needed peripheral, of which we only support the latter.

`usb-ethernet` is not working though. It is disabled via laze in this PR.
I tested `usb-serial`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
