### PR TITLE
fix(CI): Keep Xtensa clang environment variables off the general system

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,19 @@ jobs:
         with:
           buildtargets: esp32s3
 
+      - name: Keep general build environment clean of Xtensa peculiarities
+        # The Xtensa setup unconditionally sets LIBCLANG_PATH in GITHUB_ENV --
+        # we can't undo that. (It also sets it in ~/exports, but that is just
+        # what it uses internally to get that data around into the action
+        # script)
+        #
+        # As the shell apparently does not source any files, and until
+        # https://github.com/actions/runner/issues/1126 is fixed by GitHub, the
+        # best remedy is to stow the workaround and source it wherever we can.
+        run: |
+          set -x
+          echo 'unset LIBCLANG_PATH' >> ~/fix-environment-after-xtensa-setup
+
       - name: rust cache
         if: steps.result-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
@@ -78,6 +91,7 @@ jobs:
       - name: "installing prerequisites"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
+          source ~/fix-environment-after-xtensa-setup
           git config --global init.defaultBranch main
           git config --global user.email "ci@riot-labs.de"
           git config --global user.name "CI"
@@ -88,11 +102,13 @@ jobs:
       - name: "limit build unless nightly build"
         if: github.event_name != 'schedule'
         run: |
+          source ~/fix-environment-after-xtensa-setup
           echo "LAZE_BUILDERS=ai-c3,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-wroom-1,microbit-v2,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"
 
       - name: "riot-rs compilation test"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
+          source ~/fix-environment-after-xtensa-setup
           sccache --start-server || true # work around https://github.com/ninja-build/ninja/issues/2052
 
           CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build --global --partition hash:${{ matrix.partition }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
         # best remedy is to stow the workaround and source it wherever we can.
         run: |
           set -x
-          echo 'unset LIBCLANG_PATH' >> ~/fix-environment-after-xtensa-setup
+          echo 'unset LIBCLANG_PATH' >> ~/source-this-first.sh
 
       - name: rust cache
         if: steps.result-cache.outputs.cache-hit != 'true'
@@ -91,7 +91,7 @@ jobs:
       - name: "installing prerequisites"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
-          source ~/fix-environment-after-xtensa-setup
+          source ~/source-this-first.sh
           git config --global init.defaultBranch main
           git config --global user.email "ci@riot-labs.de"
           git config --global user.name "CI"
@@ -102,13 +102,13 @@ jobs:
       - name: "limit build unless nightly build"
         if: github.event_name != 'schedule'
         run: |
-          source ~/fix-environment-after-xtensa-setup
+          source ~/source-this-first.sh
           echo "LAZE_BUILDERS=ai-c3,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-wroom-1,microbit-v2,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"
 
       - name: "riot-rs compilation test"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
-          source ~/fix-environment-after-xtensa-setup
+          source ~/source-this-first.sh
           sccache --start-server || true # work around https://github.com/ninja-build/ninja/issues/2052
 
           CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build --global --partition hash:${{ matrix.partition }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       SCCACHE_GHA_ENABLED: "true"


### PR DESCRIPTION
# Description

The Xtensa toolchain sets a general `LIBCLANG_PATH`, which is part of what causes the clang troubles for libOSCORE (to be fixed in https://github.com/future-proof-iot/RIOT-rs/pull/443).

This approach <del>unsets it from the GitHub action environment</del>, and </del>will later set it specifically for the ESP builds on demand</del>.

[edit: added] Now we can't *unset* it from the GitHub actions because that just doesn't work, but we prepare a sourceable .profile style file that is then sourced by all relevant run scripts.

## Open Questions

* [x] Will it build?\
  [edit, added:] … and it didn't even need that environment variable anywhere else 🤦

* [x] Were alternatives considered?
  Yes: The alternative is to fork the Xtensa script and make it optional to export the variable.
  Or fork GitHub runners and fix https://github.com/actions/runner/issues/1126 so that we can just unset what the action sets.
  But those would all be way more effort than maintaining this workaround.

## PR dependencies

Depended on https://github.com/future-proof-iot/RIOT-rs/pull/492

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
