### PR TITLE
chore(CI): Update Ubuntu environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     env:
       SCCACHE_GHA_ENABLED: "true"


### PR DESCRIPTION
# Description

The approach in #491 to making Xtensa get off my lawn is to undo some of its environment tampering.

Instead, this goes a different route and makes the tampering less bad by ensuring that at least a clang-17 is installed. Turned out this needs nothing more than an Ubuntu update.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
