### PR TITLE
docs(network)!: document items from the `network` module

### DIFF
--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -41,13 +41,13 @@ pub mod api {
 
     #[cfg(feature = "threading")]
     pub use crate::blocker;
+    #[cfg(feature = "net")]
+    pub use crate::network;
     #[cfg(feature = "usb")]
     pub use crate::usb;
     pub use crate::{
         arch, define_peripherals, delegate, gpio, group_peripherals, Spawner, EMBASSY_TASKS,
     };
-    #[cfg(feature = "net")]
-    pub use crate::{network, NetworkStack};
 
     #[cfg(feature = "executor-interrupt")]
     pub use crate::arch::EXECUTOR;

--- a/src/riot-rs-embassy/src/network.rs
+++ b/src/riot-rs-embassy/src/network.rs
@@ -1,4 +1,10 @@
-//! To provide a custom network configuration, use the `riot_rs::config` attribute macro.
+//! Provides network access.
+//!
+//! The network link to use is selected through Cargo features.
+//! Additionally, the [`riot_rs::config`](riot_rs_macros::config) attribute macro allows to provide
+//! custom network configuration.
+
+#![deny(missing_docs)]
 
 use embassy_net::{Runner, Stack};
 use embassy_sync::once_lock::OnceLock;
@@ -6,12 +12,18 @@ use embassy_sync::once_lock::OnceLock;
 use crate::{sendcell::SendCell, NetworkDevice};
 
 #[allow(dead_code)]
-pub const ETHERNET_MTU: usize = 1514;
+pub(crate) const ETHERNET_MTU: usize = 1514;
 
+/// A network stack.
+///
+/// Required to create a UDP or TCP socket.
 pub type NetworkStack = Stack<'static>;
 
 pub(crate) static STACK: OnceLock<SendCell<NetworkStack>> = OnceLock::new();
 
+/// Returns a new [`NetworkStack`].
+///
+/// Returns [`None`] if networking is not yet initialized.
 pub async fn network_stack() -> Option<NetworkStack> {
     STACK.get().await.get_async().await.copied()
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
BREAKING CHANGE: stop re-exporting `NetworkStack` from `riot_rs`'s root.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
