### PR TITLE
feat(coap): Access storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "coap-handler-implementations",
  "coap-message",
  "coap-message-demos",
+ "coap-numbers",
  "coap-request",
  "coap-request-implementations",
  "coap-scroll-ring-server",
@@ -458,6 +459,7 @@ dependencies = [
  "riot-rs-boards",
  "riot-rs-coap",
  "scroll-ring",
+ "serde",
  "static-alloc",
 ]
 

--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -14,10 +14,11 @@ embassy-executor = { workspace = true, default-features = false }
 embassy-net = { workspace = true, features = ["udp"] }
 embassy-sync = { workspace = true }
 embassy-time = { workspace = true, default-features = false }
-heapless = { workspace = true }
+heapless = { workspace = true, features = ["serde"] }
 riot-rs = { path = "../../src/riot-rs", features = [
   "override-network-config",
   "coap",
+  "storage",
 ] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }
 embassy-futures = "0.1.1"
@@ -34,3 +35,5 @@ coap-scroll-ring-server = "0.2.0"
 scroll-ring = "0.1.1"
 
 riot-rs-coap = { workspace = true }
+coap-numbers = "0.2.4"
+serde = { workspace = true, default-features = false }

--- a/examples/coap/README.md
+++ b/examples/coap/README.md
@@ -19,6 +19,16 @@ This application is a work in progress demo of running CoAP with OSCORE/EDHOC se
   up to the maximum number of security contexts that are stored (currently 4).
 * There is also `./fauxhoc.py`, which did EDHOC manually before it was integrated in aiocoap.
 
+You can access some storage:
+
+```sh
+$ pipx run --spec 'aiocoap[all]' aiocoap-client coap://10.42.0.61/complex --credentials client.diag
+# CBOR message shown in Diagnostic Notation
+{"re": 4, "i": -3}
+$ pipx run --spec 'aiocoap[all]' aiocoap-client coap://10.42.0.61/config --credentials client.diag -m PUT --payload '"Fjord"' --content-format application/cbor
+$ pipx run --spec 'aiocoap[all]' aiocoap-client coap://10.42.0.61/counter --credentials client.diag -m DELETE
+```
+
 ## Roadmap
 
 Eventually, this should be a 20 line demo.

--- a/examples/coap/laze.yml
+++ b/examples/coap/laze.yml
@@ -8,6 +8,7 @@ apps:
       - ?release
       - network
       - random
+      - sw/storage
     conflicts:
       # see https://github.com/future-proof-iot/RIOT-rs/issues/418
       - thumbv6m-none-eabi


### PR DESCRIPTION
# Description

This is a demonstrator for storage access through CoAP.

Quoting the updated README:

```sh
$ pipx run --spec 'aiocoap[all]' aiocoap-client coap://10.42.0.61/complex --credentials client.diag
# CBOR message shown in Diagnostic Notation
{"re": 4, "i": -3}
$ pipx run --spec 'aiocoap[all]' aiocoap-client coap://10.42.0.61/config --credentials client.diag -m PUT --payload '"Fjord"' --content-format application/cbor
$ pipx run --spec 'aiocoap[all]' aiocoap-client coap://10.42.0.61/counter --credentials client.diag -m DELETE
```

## Issues/PRs references

Replaces https://github.com/future-proof-iot/RIOT-rs/pull/350.

## Open Questions

* [ ] How do we want to have that in the code base?

## Change checklist

- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
