### PR TITLE
feat(embassy): refactor async API, introduce `spawner()`

### DIFF
--- a/examples/embassy-http-server/src/main.rs
+++ b/examples/embassy-http-server/src/main.rs
@@ -7,7 +7,9 @@
 mod pins;
 mod routes;
 
-use riot_rs::{debug::log::*, network, time::Duration, ConstStaticCell, Spawner, StaticCell};
+use riot_rs::{
+    asynch::Spawner, debug::log::*, network, time::Duration, ConstStaticCell, StaticCell,
+};
 
 use embassy_net::tcp::TcpSocket;
 use picoserve::io::Error;

--- a/examples/thread-async-interop/src/main.rs
+++ b/examples/thread-async-interop/src/main.rs
@@ -6,10 +6,10 @@
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 
 use riot_rs::{
+    asynch::spawner,
     blocker,
     debug::{exit, log::*},
     time::{Duration, Instant, Timer},
-    EXECUTOR,
 };
 
 static SIGNAL: Signal<CriticalSectionRawMutex, u32> = Signal::new();
@@ -34,8 +34,7 @@ fn main() {
     info!("main(): starting");
 
     // Here we spawn our task.
-    let spawner = EXECUTOR.spawner();
-    spawner.spawn(async_task()).unwrap();
+    spawner().spawn(async_task()).unwrap();
 
     for _ in 0..10 {
         // With `block_on()`, async functions can be called from a thread.

--- a/examples/thread-async-interop/src/main.rs
+++ b/examples/thread-async-interop/src/main.rs
@@ -6,8 +6,7 @@
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 
 use riot_rs::{
-    asynch::spawner,
-    blocker,
+    asynch::{blocker, spawner},
     debug::{exit, log::*},
     time::{Duration, Instant, Timer},
 };

--- a/src/riot-rs-embassy/src/asynch.rs
+++ b/src/riot-rs-embassy/src/asynch.rs
@@ -10,6 +10,9 @@ use core::cell::OnceCell;
 
 use embassy_sync::blocking_mutex::CriticalSectionMutex;
 
+#[cfg(feature = "threading")]
+pub mod blocker;
+
 pub use embassy_executor::{SendSpawner, Spawner};
 
 #[cfg(feature = "executor-thread")]

--- a/src/riot-rs-embassy/src/asynch.rs
+++ b/src/riot-rs-embassy/src/asynch.rs
@@ -1,0 +1,37 @@
+//! Provides async functionality.
+//!
+//! This module bundles RIOT-rs async functionality. It also wraps
+//! some [Embassy](https://github.com/embassy-rs/embassy) types.
+
+#![deny(missing_docs)]
+#![deny(clippy::pedantic)]
+
+use core::cell::OnceCell;
+
+use embassy_sync::blocking_mutex::CriticalSectionMutex;
+
+pub use embassy_executor::{SendSpawner, Spawner};
+
+#[cfg(feature = "executor-thread")]
+pub use crate::thread_executor;
+
+pub(crate) static SPAWNER: CriticalSectionMutex<OnceCell<SendSpawner>> =
+    CriticalSectionMutex::new(OnceCell::new());
+
+/// Gets a spawner for the system executor.
+///
+/// # Panics
+///
+/// Panics when called before the system has finished initializing.
+pub fn spawner() -> SendSpawner {
+    SPAWNER.lock(|x| *x.get().unwrap())
+}
+
+/// Sets what `spawner()` returns.
+///
+/// May only be called once. Basically only in `super::init_task()`. That's why
+/// we get away with ignoring the result.
+#[allow(dead_code, reason = "actually used in `crate::init_task()`")]
+pub(crate) fn set_spawner(spawner: SendSpawner) {
+    let _ = SPAWNER.lock(|x| x.set(spawner));
+}

--- a/src/riot-rs-embassy/src/asynch/blocker.rs
+++ b/src/riot-rs-embassy/src/asynch/blocker.rs
@@ -1,3 +1,5 @@
+//! Provides a [`block_on()`] function to use futures from a thread.
+
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
@@ -6,7 +8,7 @@ use riot_rs_threads::{current_pid, flags, flags::ThreadFlags, ThreadId};
 const THREAD_FLAG_WAKER: ThreadFlags = 1; // TODO: find more appropriate value
 
 fn wake(ptr: *const ()) {
-    // wake
+    #[expect(clippy::cast_possible_truncation)]
     let thread_id = ThreadId::new(ptr as usize as u8);
     flags::set(thread_id, THREAD_FLAG_WAKER);
 }
@@ -19,7 +21,13 @@ static VTABLE: RawWakerVTable = RawWakerVTable::new(
     wake,
 );
 
-/// Run a future to completion, using thread_sleep()
+/// Runs a future to completion.
+///
+/// This runs the given future on the current thread, blocking until it is complete, and yielding its resolved result.
+///
+/// # Panics
+///
+/// Panics when not called from a thread.
 pub fn block_on<F: Future>(mut fut: F) -> F::Output {
     // safety: we don't move the future after this line.
     let mut fut = unsafe { Pin::new_unchecked(&mut fut) };

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -33,6 +33,10 @@ pub use static_cell::{ConstStaticCell, StaticCell};
 
 // All items of this module are re-exported at the root of `riot_rs`.
 pub mod api {
+    pub use crate::{
+        arch, asynch, define_peripherals, delegate, gpio, group_peripherals, EMBASSY_TASKS,
+    };
+
     #[cfg(feature = "time")]
     pub mod time {
         //! Provides time-related facilities.
@@ -53,15 +57,6 @@ pub mod api {
     pub use crate::network;
     #[cfg(feature = "usb")]
     pub use crate::usb;
-    pub use crate::{
-        arch, define_peripherals, delegate, gpio, group_peripherals, Spawner, EMBASSY_TASKS,
-    };
-
-    #[cfg(feature = "executor-interrupt")]
-    pub use crate::arch::EXECUTOR;
-
-    #[cfg(feature = "executor-thread")]
-    pub use crate::thread_executor;
 }
 
 // These are made available in `riot_rs::reexports`.
@@ -75,8 +70,6 @@ pub mod reexports {
     // Used by a macro we provide
     pub use embassy_executor;
 }
-
-pub use embassy_executor::Spawner;
 
 #[cfg(feature = "net")]
 cfg_if::cfg_if! {
@@ -94,6 +87,7 @@ cfg_if::cfg_if! {
 #[cfg(feature = "net")]
 pub use network::NetworkStack;
 
+pub mod asynch;
 #[cfg(feature = "threading")]
 pub mod blocker;
 pub mod delegate;
@@ -102,7 +96,7 @@ pub mod sendcell;
 #[cfg(feature = "executor-thread")]
 pub mod thread_executor;
 
-pub type Task = fn(Spawner, &mut arch::OptionalPeripherals);
+pub type Task = fn(asynch::Spawner, &mut arch::OptionalPeripherals);
 
 #[distributed_slice]
 pub static EMBASSY_TASKS: [Task] = [..];
@@ -177,6 +171,9 @@ fn init() {
 
 #[embassy_executor::task]
 async fn init_task(mut peripherals: arch::OptionalPeripherals) {
+    let spawner = asynch::Spawner::for_current_executor().await;
+    asynch::set_spawner(spawner.make_send());
+
     debug!("riot-rs-embassy::init_task()");
 
     #[cfg(all(context = "stm32", feature = "external-interrupts"))]
@@ -201,8 +198,6 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
 
     #[cfg(all(feature = "usb", context = "nrf"))]
     arch::usb::init();
-
-    let spawner = Spawner::for_current_executor().await;
 
     for task in EMBASSY_TASKS {
         task(spawner, &mut peripherals);

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -47,14 +47,10 @@ pub mod api {
 
     #[cfg(feature = "i2c")]
     pub use crate::i2c;
-
-    #[cfg(feature = "spi")]
-    pub use crate::spi;
-
-    #[cfg(feature = "threading")]
-    pub use crate::blocker;
     #[cfg(feature = "net")]
     pub use crate::network;
+    #[cfg(feature = "spi")]
+    pub use crate::spi;
     #[cfg(feature = "usb")]
     pub use crate::usb;
 }
@@ -88,8 +84,6 @@ cfg_if::cfg_if! {
 pub use network::NetworkStack;
 
 pub mod asynch;
-#[cfg(feature = "threading")]
-pub mod blocker;
 pub mod delegate;
 pub mod sendcell;
 

--- a/src/riot-rs-macros/src/spawner.rs
+++ b/src/riot-rs-macros/src/spawner.rs
@@ -18,7 +18,7 @@
 /// # Examples
 ///
 /// ```ignore
-/// use riot_rs::Spawner;
+/// use riot_rs::asynch::Spawner;
 ///
 /// #[riot_rs::spawner(autostart, peripherals)]
 /// fn spawner(spawner: Spawner, peripherals: /* your peripheral type */) {}
@@ -87,7 +87,7 @@ pub fn spawner(args: TokenStream, item: TokenStream) -> TokenStream {
         #[#riot_rs_crate::reexports::linkme::distributed_slice(#riot_rs_crate::EMBASSY_TASKS)]
         #[linkme(crate = #riot_rs_crate::reexports::linkme)]
         fn #new_function_name(
-            spawner: #riot_rs_crate::Spawner,
+            spawner: #riot_rs_crate::asynch::Spawner,
             mut peripherals: &mut #riot_rs_crate::arch::OptionalPeripherals,
         ) {
             use #riot_rs_crate::define_peripherals::TakePeripherals;

--- a/src/riot-rs-macros/src/task.rs
+++ b/src/riot-rs-macros/src/task.rs
@@ -99,7 +99,7 @@ pub fn task(args: TokenStream, item: TokenStream) -> TokenStream {
             #[#riot_rs_crate::reexports::linkme::distributed_slice(#riot_rs_crate::EMBASSY_TASKS)]
             #[linkme(crate = #riot_rs_crate::reexports::linkme)]
             fn #new_function_name(
-                spawner: #riot_rs_crate::Spawner,
+                spawner: #riot_rs_crate::asynch::Spawner,
                 mut peripherals: &mut #riot_rs_crate::arch::OptionalPeripherals,
             ) {
                 use #riot_rs_crate::define_peripherals::TakePeripherals;

--- a/src/riot-rs-macros/tests/ui/spawner/async_fn.rs
+++ b/src/riot-rs-macros/tests/ui/spawner/async_fn.rs
@@ -3,7 +3,7 @@
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]
-use riot_rs::Spawner;
+use riot_rs::asynch::Spawner;
 
 // FAIL: spawner functions cannot be async
 #[riot_rs::spawner(autostart)]

--- a/src/riot-rs-macros/tests/ui/spawner/missing_peripherals_param.rs
+++ b/src/riot-rs-macros/tests/ui/spawner/missing_peripherals_param.rs
@@ -3,7 +3,7 @@
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]
-use riot_rs::Spawner;
+use riot_rs::asynch::Spawner;
 
 // FAIL: the `peripherals` parameter is required in this case
 #[riot_rs::spawner(autostart)]

--- a/src/riot-rs-macros/tests/ui/spawner/no_autostart_param.rs
+++ b/src/riot-rs-macros/tests/ui/spawner/no_autostart_param.rs
@@ -3,7 +3,7 @@
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]
-use riot_rs::Spawner;
+use riot_rs::asynch::Spawner;
 
 // FAIL: the macro expects a mandatory `autostart` parameter
 #[riot_rs::spawner]


### PR DESCRIPTION
# Description

Previously, only when using the interrupt executor there was a way to get to a `Spawner` to spawn tasks from threads.
This PR makes the spawner available for all executors.

Also, refactors some previously global exports into `riot_rs::asynch`.

currently panics on dual core b/c the `spawner` is empty when the thread on the second core starts, thus draft.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

Depends on #526.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
