### PR TITLE
docs(thread-macro): add a missing param in the doc examples

### DIFF
--- a/src/riot-rs-macros/src/thread.rs
+++ b/src/riot-rs-macros/src/thread.rs
@@ -13,7 +13,7 @@
 /// This starts a thread with default values:
 ///
 /// ```ignore
-/// #[riot_rs::thread]
+/// #[riot_rs::thread(autostart)]
 /// fn print_hello_world() {
 ///     println!("Hello world!");
 /// }
@@ -23,7 +23,7 @@
 ///
 /// ```ignore
 /// // `stacksize` and `priority` can be arbitrary expressions.
-/// #[riot_rs::thread(stacksize = 1024, priority = 2)]
+/// #[riot_rs::thread(autostart, stacksize = 1024, priority = 2)]
 /// fn print_hello_world() {
 ///     println!("Hello world!");
 /// }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The `autostart` parameter was missing from the doc examples, this PR adds it back.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
