### PR TITLE
fix(defmt-esp): enable `defmt` on `esp-hal` when requested

### DIFF
--- a/src/riot-rs-esp/Cargo.toml
+++ b/src/riot-rs-esp/Cargo.toml
@@ -79,7 +79,7 @@ i2c = [
 spi = ["dep:fugit", "riot-rs-embassy-common/spi"]
 
 ## Enables defmt support.
-defmt = ["dep:defmt", "esp-wifi?/defmt", "fugit?/defmt"]
+defmt = ["dep:defmt", "esp-hal/defmt", "esp-wifi?/defmt", "fugit?/defmt"]
 
 ## Enables Wi-Fi support.
 wifi = []


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This propagates the `defmt` feature to the `esp-hal` crate; it's a follow-up to https://github.com/future-proof-iot/RIOT-rs/pull/392#discussion_r1738319808.
@kaspar030 Do you see a reason *not* to enable it?

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
