### PR TITLE
feat(spi-main): add support for SPI main on nRF52833

### DIFF
--- a/src/riot-rs-nrf/src/spi/main/mod.rs
+++ b/src/riot-rs-nrf/src/spi/main/mod.rs
@@ -42,9 +42,9 @@ pub enum Frequency {
     _8M,
     // FIXME(embassy): these frequencies are supported by hardware but do not seem supported by
     // Embassy.
-    // #[cfg(context = "nrf5340")]
+    // #[cfg(any(context = "nrf52833", context = "nrf5340"))]
     // _16M,
-    // #[cfg(context = "nrf5340")]
+    // #[cfg(any(context = "nrf52833", context = "nrf5340"))]
     // _32M,
 }
 
@@ -190,6 +190,14 @@ macro_rules! define_spi_drivers {
 }
 
 // Define a driver per peripheral
+#[cfg(context = "nrf52833")]
+define_spi_drivers!(
+    // FIXME: arbitrary selected peripherals
+    // SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0 => TWISPI0,
+    // SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1 => TWISPI1,
+    // SPIM2_SPIS2_SPI2 => SPI2,
+    SPIM3 => SPI3,
+);
 #[cfg(context = "nrf52840")]
 define_spi_drivers!(
     // FIXME: arbitrary selected peripherals

--- a/src/riot-rs-nrf/src/spi/mod.rs
+++ b/src/riot-rs-nrf/src/spi/mod.rs
@@ -22,7 +22,9 @@ fn from_bit_order(bit_order: BitOrder) -> embassy_nrf::spim::BitOrder {
 pub fn init(peripherals: &mut crate::OptionalPeripherals) {
     // Take all SPI peripherals and do nothing with them.
     cfg_if::cfg_if! {
-        if #[cfg(context = "nrf52840")] {
+        if #[cfg(context = "nrf52833")] {
+            let _ = peripherals.SPI3.take().unwrap();
+        } else if #[cfg(context = "nrf52840")] {
             let _ = peripherals.SPI2.take().unwrap();
             let _ = peripherals.SPI3.take().unwrap();
         } else if #[cfg(context = "nrf5340")] {

--- a/tests/spi-loopback/laze.yml
+++ b/tests/spi-loopback/laze.yml
@@ -6,6 +6,7 @@ apps:
           - CONFIG_ISR_STACKSIZE=16384
     context:
       - espressif-esp32-c6-devkitc-1
+      - microbit-v2
       - nrf52840
       - nrf5340
       - rp2040

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -10,6 +10,16 @@ riot_rs::define_peripherals!(Peripherals {
     spi_cs: GPIO_3,
 });
 
+#[cfg(context = "nrf52833")]
+pub type SensorSpi = spi::main::SPI3;
+#[cfg(context = "nrf52833")]
+riot_rs::define_peripherals!(Peripherals {
+    spi_sck: P0_17,  // SPI_EXT_SCK on the microbit-v2
+    spi_miso: P0_01, // SPI_EXT_MISO on the microbit-v2
+    spi_mosi: P0_13, // SPI_EXT_MOSI on the microbit-v2
+    spi_cs: P0_04,   // RING2 on the microbit-v2
+});
+
 // Side SPI of Arduino v3 connector
 #[cfg(context = "nrf52840")]
 pub type SensorSpi = spi::main::SPI3;


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds support for SPI in main mode on the nRF52833, which we support since #463.

The `spi-loopback` test was successfully tested on a micro:bit V2. The `spi-main` test would later need to be updated when we get an easier access to the required pins on that board.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
