### PR TITLE
docs(tcp-example): clean up the TCP example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,17 +1144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-net-tcp"
-version = "0.1.0"
-dependencies = [
- "embassy-net",
- "embedded-io-async",
- "heapless 0.8.0",
- "riot-rs",
- "riot-rs-boards",
-]
-
-[[package]]
 name = "embassy-nrf"
 version = "0.2.0"
 source = "git+https://github.com/kaspar030/embassy?branch=for-riot-rs-2024-11-06#af2533fffdd50d35a1fdee682a1e7ed5ccc5e3d8"
@@ -4406,6 +4395,16 @@ name = "target-triple"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+
+[[package]]
+name = "tcp-echo"
+version = "0.1.0"
+dependencies = [
+ "embedded-io-async",
+ "heapless 0.8.0",
+ "riot-rs",
+ "riot-rs-boards",
+]
 
 [[package]]
 name = "tempfile"

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,12 +5,12 @@
 This directory contains example applications that showcase how to use RIOT-rs.
 
 - [benchmark/](./benchmark): how to use `benchmark()`
-- [embassy-net-tcp/](./embassy-net-tcp): TCP echo example
 - [embassy-http-server/](./embassy-http-server): HTTP server example
 - [embassy-usb-keyboard/](./embassy-usb-keyboard): USB HID example
 - [hello-world/](./hello-world): a classic, async version
 - [hello-world-threading/](./hello-world-threading): a classic, using a thread
 - [minimal/](./minimal): minimized to the max RIOT-rs config
+- [tcp-echo/](./tcp-echo): TCP echo example
 - [thread-async-interop/](./thread-async-interop): how to make async tasks and preemptively scheduled threads interoperate
 - [threading/](./threading): how to start and use preemptively scheduled threads
 - [threading-event/](./threading-event): how to use `riot_rs::thread::sync::Event`

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -10,7 +10,6 @@ subdirs:
   - coap
   - device-metadata
   - embassy-http-server
-  - embassy-net-tcp
   - embassy-usb-keyboard
   - gpio
   - hello-world
@@ -19,6 +18,7 @@ subdirs:
   - minimal
   - random
   - storage
+  - tcp-echo
   - thread-async-interop
   - threading
   - threading-channel

--- a/examples/tcp-echo/Cargo.toml
+++ b/examples/tcp-echo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "embassy-net-tcp"
+name = "tcp-echo"
 version = "0.1.0"
 authors.workspace = true
 license.workspace = true
@@ -10,11 +10,11 @@ publish = false
 workspace = true
 
 [dependencies]
-embassy-net = { workspace = true, features = ["tcp"] }
 embedded-io-async = "0.6.1"
 heapless = { workspace = true }
 riot-rs = { path = "../../src/riot-rs", features = [
   "override-network-config",
+  "tcp",
   "time",
 ] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/tcp-echo/README.md
+++ b/examples/tcp-echo/README.md
@@ -1,9 +1,9 @@
-# embassy-net-tcp
+# tcp-echo
 
 ## About
 
 This application is testing basic
-[embassy](https://github.com/embassy-rs/embassy) _networking_ usage with RIOT-rs.
+[Embassy](https://github.com/embassy-rs/embassy) _networking_ usage with RIOT-rs.
 
 ## How to run
 
@@ -11,8 +11,8 @@ In this folder, run
 
     laze build -b nrf52840dk run
 
-With the device USB cable connected, a USB ethernet device should pop up.
-RIOT-rs will reply to ping requests on 10.42.0.61 and host a tcp service on
+With the device USB cable connected, a USB Ethernet device should pop up.
+RIOT-rs will reply to ping requests on 10.42.0.61 and host a TCP service on
 port 1234 that will echo the input back to the client. It can be accessed with
 e.g., `telnet`:
 

--- a/examples/tcp-echo/laze.yml
+++ b/examples/tcp-echo/laze.yml
@@ -1,5 +1,5 @@
 apps:
-  - name: embassy-net-tcp
+  - name: tcp-echo
     selects:
       - ?release
       - network

--- a/examples/tcp-echo/src/main.rs
+++ b/examples/tcp-echo/src/main.rs
@@ -3,13 +3,11 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-use riot_rs::{debug::log::*, network, time::Duration};
-
 use embedded_io_async::Write;
+use riot_rs::{debug::log::*, network, reexports::embassy_net::tcp::TcpSocket, time::Duration};
 
 #[riot_rs::task(autostart)]
 async fn tcp_echo() {
-    use embassy_net::tcp::TcpSocket;
     let stack = network::network_stack().await.unwrap();
 
     let mut rx_buffer = [0; 4096];
@@ -41,8 +39,6 @@ async fn tcp_echo() {
                 }
             };
 
-            //info!("rxd {:02x}", &buf[..n]);
-
             match socket.write_all(&buf[..n]).await {
                 Ok(()) => {}
                 Err(e) => {
@@ -55,8 +51,8 @@ async fn tcp_echo() {
 }
 
 #[riot_rs::config(network)]
-fn network_config() -> embassy_net::Config {
-    use embassy_net::Ipv4Address;
+fn network_config() -> riot_rs::reexports::embassy_net::Config {
+    use riot_rs::reexports::embassy_net::{self, Ipv4Address};
 
     embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
         address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
As part of https://github.com/future-proof-iot/RIOT-rs/issues/410, and similarly to #521, this PR:

- renames the `embassy-tcp-echo` example to `tcp-echo`, as agreed
- leverages `riot_rs::reexports`
- contains other minor cleanups.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #521.
Depends on #525.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
