### PR TITLE
feat(nrf): use NFC pins as normal GPIOs

### DIFF
--- a/src/riot-rs-nrf/Cargo.toml
+++ b/src/riot-rs-nrf/Cargo.toml
@@ -30,17 +30,23 @@ riot-rs-embassy-common = { workspace = true }
 riot-rs-random = { workspace = true, optional = true }
 
 [target.'cfg(context = "nrf52832")'.dependencies]
-embassy-nrf = { workspace = true, features = ["nrf52832"] }
+# Disable NFC support for now, as we do not support it yet.
+embassy-nrf = { workspace = true, features = ["nfc-pins-as-gpio", "nrf52832"] }
 
 [target.'cfg(context = "nrf52833")'.dependencies]
 # Disable NFC support for now, as we do not support it yet.
 embassy-nrf = { workspace = true, features = ["nfc-pins-as-gpio", "nrf52833"] }
 
 [target.'cfg(context = "nrf52840")'.dependencies]
-embassy-nrf = { workspace = true, features = ["nrf52840"] }
+# Disable NFC support for now, as we do not support it yet.
+embassy-nrf = { workspace = true, features = ["nfc-pins-as-gpio", "nrf52840"] }
 
 [target.'cfg(context = "nrf5340")'.dependencies]
-embassy-nrf = { workspace = true, features = ["nrf5340-app-s"] }
+# Disable NFC support for now, as we do not support it yet.
+embassy-nrf = { workspace = true, features = [
+  "nfc-pins-as-gpio",
+  "nrf5340-app-s",
+] }
 
 [features]
 ## Enables GPIO interrupt support.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
On nRF MCUs, some pins are by default reserved for NFC. This PR allows to use them as normal GPIOs as we don't currently support NFC. This was already done for the nRF52833 as part of #463.

This fixes the following probe-rs warning:

```
WARN  You have requested to use P0.09 and P0.10 pins for NFC, by not enabling the Cargo feature `nfc-pins-as-gpio`.
However, UICR is already programmed to some other setting, and can't be changed without erasing it.
To fix this, erase UICR manually, for example using `probe-rs erase` or `nrfjprog --eraseuicr`.
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #506.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
