### PR TITLE
feat(net): introduce Cargo features to enable TCP and UDP

### DIFF
--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -74,6 +74,11 @@ usb-ethernet = ["usb", "net"]
 ## Use a hardware RNG to seed into the riot-rs-random system-wide RNG
 hwrng = ["riot-rs-arch/hwrng"]
 
+## Enables support for TCP.
+tcp = ["embassy-net?/tcp"]
+## Enables support for UDP.
+udp = ["embassy-net?/udp"]
+
 ## Enable storage support [`riot-rs::storage`].
 storage = ["dep:riot-rs-storage", "riot-rs-arch/storage", "time"]
 

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -50,6 +50,10 @@ csprng = ["riot-rs-random/csprng"]
 hwrng = ["riot-rs-embassy/hwrng"]
 
 #! ## Network protocols
+## Enables support for TCP.
+tcp = ["riot-rs-embassy/tcp"]
+## Enables support for UDP.
+udp = ["riot-rs-embassy/udp"]
 ## Enables support for [CoAP](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/tooling/coap.html).
 coap = ["dep:riot-rs-coap", "random"]
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Introduce features on the root crate so that applications do not need to depend on `embassy-net` to enabled the `tcp` and `udp` features.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Extracted from https://github.com/future-proof-iot/RIOT-rs/pull/521#discussion_r1841260697.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
