### PR TITLE
feat(embassy-time): re-export the crate and relevant items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,6 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 name = "blinky"
 version = "0.1.0"
 dependencies = [
- "embassy-time",
  "riot-rs",
  "riot-rs-boards",
 ]
@@ -449,7 +448,6 @@ dependencies = [
  "embassy-futures",
  "embassy-net",
  "embassy-sync 0.6.0",
- "embassy-time",
  "embedded-nal-coap",
  "heapless 0.8.0",
  "riot-rs",
@@ -1100,7 +1098,6 @@ dependencies = [
  "embassy-net",
  "embassy-nrf",
  "embassy-sync 0.6.0",
- "embassy-time",
  "embedded-io-async",
  "heapless 0.8.0",
  "httparse",
@@ -1151,7 +1148,6 @@ name = "embassy-net-tcp"
 version = "0.1.0"
 dependencies = [
  "embassy-net",
- "embassy-time",
  "embedded-io-async",
  "heapless 0.8.0",
  "riot-rs",
@@ -1163,7 +1159,6 @@ name = "embassy-net-udp"
 version = "0.1.0"
 dependencies = [
  "embassy-net",
- "embassy-time",
  "embedded-io-async",
  "heapless 0.8.0",
  "riot-rs",
@@ -1372,7 +1367,6 @@ version = "0.1.0"
 dependencies = [
  "embassy-nrf",
  "embassy-sync 0.6.0",
- "embassy-time",
  "embassy-usb",
  "riot-rs",
  "riot-rs-boards",
@@ -2140,7 +2134,6 @@ name = "gpio"
 version = "0.1.0"
 dependencies = [
  "embassy-futures",
- "embassy-time",
  "riot-rs",
  "riot-rs-boards",
 ]
@@ -2149,7 +2142,6 @@ dependencies = [
 name = "gpio-interrupt-nrf"
 version = "0.1.0"
 dependencies = [
- "embassy-time",
  "riot-rs",
  "riot-rs-boards",
 ]
@@ -2158,7 +2150,6 @@ dependencies = [
 name = "gpio-interrupt-stm32"
 version = "0.1.0"
 dependencies = [
- "embassy-time",
  "riot-rs",
  "riot-rs-boards",
 ]
@@ -4474,7 +4465,6 @@ name = "thread-async-interop"
 version = "0.1.0"
 dependencies = [
  "embassy-sync 0.6.0",
- "embassy-time",
  "riot-rs",
  "riot-rs-boards",
 ]
@@ -4691,7 +4681,6 @@ dependencies = [
 name = "usb-serial"
 version = "0.1.0"
 dependencies = [
- "embassy-time",
  "riot-rs",
  "riot-rs-boards",
 ]

--- a/examples/blinky/Cargo.toml
+++ b/examples/blinky/Cargo.toml
@@ -10,6 +10,5 @@ publish = false
 workspace = true
 
 [dependencies]
-embassy-time = { workspace = true }
 riot-rs = { path = "../../src/riot-rs", features = ["time"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/blinky/src/main.rs
+++ b/examples/blinky/src/main.rs
@@ -5,8 +5,10 @@
 
 mod pins;
 
-use embassy_time::{Duration, Timer};
-use riot_rs::gpio::{Level, Output};
+use riot_rs::{
+    gpio::{Level, Output},
+    time::{Duration, Timer},
+};
 
 #[riot_rs::task(autostart, peripherals)]
 async fn blinky(peripherals: pins::LedPeripherals) {

--- a/examples/coap/Cargo.toml
+++ b/examples/coap/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 embassy-net = { workspace = true, features = ["udp"] }
 embassy-sync = { workspace = true }
-embassy-time = { workspace = true, default-features = false }
 heapless = { workspace = true }
 riot-rs = { path = "../../src/riot-rs", features = [
   "override-network-config",

--- a/examples/embassy-http-server/Cargo.toml
+++ b/examples/embassy-http-server/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 embassy-net = { workspace = true, features = ["tcp"] }
 embassy-sync = { workspace = true }
-embassy-time = { workspace = true, default-features = false }
 embedded-io-async = { version = "0.6.0", features = ["defmt-03"] }
 heapless = { workspace = true }
 httparse = { version = "1.8.0", default-features = false }
@@ -20,7 +19,10 @@ picoserve = { version = "0.12.0", default-features = false, features = [
   "embassy",
   "embassy-stack-is-copy",
 ], git = "https://github.com/kaspar030/picoserve", branch = "update_embassy_stack_api" }
-riot-rs = { path = "../../src/riot-rs", features = ["override-network-config"] }
+riot-rs = { path = "../../src/riot-rs", features = [
+  "override-network-config",
+  "time",
+] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }
 serde = { version = "1.0", default-features = false }
 static_cell = { workspace = true }

--- a/examples/embassy-http-server/src/main.rs
+++ b/examples/embassy-http-server/src/main.rs
@@ -7,10 +7,9 @@
 mod pins;
 mod routes;
 
-use riot_rs::{debug::log::*, network, ConstStaticCell, Spawner, StaticCell};
+use riot_rs::{debug::log::*, network, time::Duration, ConstStaticCell, Spawner, StaticCell};
 
 use embassy_net::tcp::TcpSocket;
-use embassy_time::Duration;
 use picoserve::io::Error;
 
 #[cfg(feature = "button-readings")]

--- a/examples/embassy-net-tcp/Cargo.toml
+++ b/examples/embassy-net-tcp/Cargo.toml
@@ -11,8 +11,10 @@ workspace = true
 
 [dependencies]
 embassy-net = { workspace = true, features = ["tcp"] }
-embassy-time = { workspace = true, default-features = false }
 embedded-io-async = "0.6.1"
 heapless = { workspace = true }
-riot-rs = { path = "../../src/riot-rs", features = ["override-network-config"] }
+riot-rs = { path = "../../src/riot-rs", features = [
+  "override-network-config",
+  "time",
+] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/embassy-net-tcp/src/main.rs
+++ b/examples/embassy-net-tcp/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-use riot_rs::{debug::log::*, network};
+use riot_rs::{debug::log::*, network, time::Duration};
 
 use embedded_io_async::Write;
 
@@ -18,7 +18,7 @@ async fn tcp_echo() {
 
     loop {
         let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
-        socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
+        socket.set_timeout(Some(Duration::from_secs(10)));
 
         info!("Listening on TCP:1234...");
         if let Err(e) = socket.accept(1234).await {

--- a/examples/embassy-net-udp/Cargo.toml
+++ b/examples/embassy-net-udp/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 embassy-net = { workspace = true, features = ["udp"] }
-embassy-time = { workspace = true, default-features = false }
 embedded-io-async = "0.6.1"
 heapless = { workspace = true }
 riot-rs = { path = "../../src/riot-rs", features = ["override-network-config"] }

--- a/examples/embassy-usb-keyboard/Cargo.toml
+++ b/examples/embassy-usb-keyboard/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 embassy-nrf = { workspace = true, default-features = false }
 embassy-sync = { workspace = true }
-embassy-time = { workspace = true, default-features = false }
 embassy-usb = { workspace = true, features = ["usbd-hid"] }
 riot-rs = { path = "../../src/riot-rs", features = [
   "time",

--- a/examples/embassy-usb-keyboard/src/main.rs
+++ b/examples/embassy-usb-keyboard/src/main.rs
@@ -3,10 +3,10 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-use embassy_time::Duration;
 use embassy_usb::class::hid::{self, HidReaderWriter};
 use riot_rs::{
     debug::log::*,
+    time::{Duration, Timer},
     usb::{UsbBuilderHook, UsbDriver},
     ConstStaticCell,
 };
@@ -52,7 +52,7 @@ async fn usb_keyboard(button_peripherals: pins::Buttons) {
         }
 
         // Debounce events
-        embassy_time::Timer::after(Duration::from_millis(50)).await;
+        Timer::after(Duration::from_millis(50)).await;
     }
 }
 

--- a/examples/gpio/Cargo.toml
+++ b/examples/gpio/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 embassy-futures = { workspace = true }
-embassy-time = { workspace = true }
 riot-rs = { path = "../../src/riot-rs", features = [
   "external-interrupts",
   "time",

--- a/examples/gpio/src/main.rs
+++ b/examples/gpio/src/main.rs
@@ -5,8 +5,10 @@
 
 mod pins;
 
-use embassy_time::{Duration, Timer};
-use riot_rs::gpio::{Input, Level, Output, Pull};
+use riot_rs::{
+    gpio::{Input, Level, Output, Pull},
+    time::{Duration, Timer},
+};
 
 #[riot_rs::task(autostart, peripherals)]
 async fn blinky(peripherals: pins::Peripherals) {

--- a/examples/thread-async-interop/Cargo.toml
+++ b/examples/thread-async-interop/Cargo.toml
@@ -11,6 +11,5 @@ workspace = true
 
 [dependencies]
 embassy-sync = { workspace = true, default-features = false }
-embassy-time = { workspace = true, default-features = false }
 riot-rs = { path = "../../src/riot-rs", features = ["time"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/examples/thread-async-interop/src/main.rs
+++ b/examples/thread-async-interop/src/main.rs
@@ -4,11 +4,11 @@
 #![feature(used_with_arg)]
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
-use embassy_time::{Duration, Instant, Timer, TICK_HZ};
 
 use riot_rs::{
     blocker,
     debug::{exit, log::*},
+    time::{Duration, Instant, Timer},
     EXECUTOR,
 };
 
@@ -24,7 +24,7 @@ async fn async_task() {
     loop {
         info!("async_task(): signalling, counter={}", counter);
         SIGNAL.signal(counter);
-        Timer::after(Duration::from_ticks(TICK_HZ / 10)).await;
+        Timer::after(Duration::from_millis(100)).await;
         counter += 1;
     }
 }

--- a/examples/usb-serial/Cargo.toml
+++ b/examples/usb-serial/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 workspace = true
 
 [dependencies]
-embassy-time = { workspace = true, default-features = false }
 riot-rs = { path = "../../src/riot-rs", features = [
   "usb",
   "override-usb-config",

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -33,6 +33,14 @@ pub use static_cell::{ConstStaticCell, StaticCell};
 
 // All items of this module are re-exported at the root of `riot_rs`.
 pub mod api {
+    #[cfg(feature = "time")]
+    pub mod time {
+        //! Provides time-related facilities.
+        // NOTE: we may want to re-export more items in the future, but not re-export the whole
+        // crate.
+        pub use embassy_time::{Delay, Duration, Instant, Timer, TICK_HZ};
+    }
+
     #[cfg(feature = "i2c")]
     pub use crate::i2c;
 
@@ -60,6 +68,8 @@ pub mod api {
 pub mod reexports {
     #[cfg(feature = "net")]
     pub use embassy_net;
+    #[cfg(feature = "time")]
+    pub use embassy_time;
     #[cfg(feature = "usb")]
     pub use embassy_usb;
     // Used by a macro we provide

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -39,8 +39,7 @@ threading = [
   "riot-rs-rt/threading",
   "riot-rs-embassy/threading",
 ]
-## Enables support for timeouts in the internal executor---required to use
-## `embassy_time::Timer`.
+## Enables the internal executor's timer queue, required for timer support.
 time = ["riot-rs-embassy/time"]
 ## Enables the [`random`] module.
 random = ["riot-rs-random"]

--- a/tests/gpio-interrupt-nrf/Cargo.toml
+++ b/tests/gpio-interrupt-nrf/Cargo.toml
@@ -10,6 +10,5 @@ publish = false
 workspace = true
 
 [dependencies]
-embassy-time = { workspace = true }
 riot-rs = { path = "../../src/riot-rs", features = ["external-interrupts"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }

--- a/tests/gpio-interrupt-stm32/Cargo.toml
+++ b/tests/gpio-interrupt-stm32/Cargo.toml
@@ -10,6 +10,5 @@ publish = false
 workspace = true
 
 [dependencies]
-embassy-time = { workspace = true }
 riot-rs = { path = "../../src/riot-rs", features = ["external-interrupts"] }
 riot-rs-boards = { path = "../../src/riot-rs-boards" }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Re-export the `embassy-time` crate in two different ways: as a blanket re-export in `riot_rs::reexports`, and as cherry-picked items in the newly created `riot_rs::time` module.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Extracted from https://github.com/future-proof-iot/RIOT-rs/pull/521#discussion_r1841260697.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
