### PR TITLE
ci(clippy): enable more Cargo features on `riot-rs-embassy`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -262,11 +262,16 @@ jobs:
             --verbose
             --locked
             --features "
+                csprng,
                 external-interrupts,
+                hwrng,
+                i2c,
                 net,
                 no-boards,
                 spi,
                 storage,
+                usb,
+                usb-ethernet,
                 "
             -p riot-rs
             -p riot-rs-arch

--- a/src/riot-rs-embassy/src/i2c/controller/mod.rs
+++ b/src/riot-rs-embassy/src/i2c/controller/mod.rs
@@ -91,7 +91,7 @@ pub const fn highest_freq_in(
         }
     }
 
-    return freq;
+    freq
 }
 
 #[cfg(test)]

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -234,7 +234,7 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
         static CDC_ECM_STATE: StaticCell<CdcNcmState> = StaticCell::new();
         let usb_cdc_ecm = CdcNcmClass::new(
             &mut usb_builder,
-            CDC_ECM_STATE.init_with(|| CdcNcmState::new()),
+            CDC_ECM_STATE.init_with(CdcNcmState::new),
             host_mac_addr,
             64,
         );
@@ -244,7 +244,7 @@ async fn init_task(mut peripherals: arch::OptionalPeripherals) {
         static NET_STATE: StaticCell<NetState<{ network::ETHERNET_MTU }, 4, 4>> = StaticCell::new();
         let (runner, device) = usb_cdc_ecm
             .into_embassy_net_device::<{ network::ETHERNET_MTU }, 4, 4>(
-                NET_STATE.init_with(|| NetState::new()),
+                NET_STATE.init_with(NetState::new),
                 our_mac_addr,
             );
 

--- a/src/riot-rs-embassy/src/usb.rs
+++ b/src/riot-rs-embassy/src/usb.rs
@@ -30,6 +30,7 @@ pub(crate) mod ethernet {
 
     use crate::{arch::usb::UsbDriver, network::ETHERNET_MTU};
 
+    #[allow(dead_code, reason = "use depends on enabled features")]
     pub type NetworkDevice = Device<'static, ETHERNET_MTU>;
 
     #[embassy_executor::task]
@@ -38,6 +39,7 @@ pub(crate) mod ethernet {
     }
 }
 
+#[allow(dead_code, reason = "false positive during builds outside of laze")]
 pub(crate) fn config() -> embassy_usb::Config<'static> {
     #[cfg(not(feature = "override-usb-config"))]
     {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Fix the few Clippy warnings that prevented enabling some more Cargo features on `riot-rs-embassy`, and enable them in CI. 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
