### PR TITLE
refactor(threads): rename `Threads` -> `Scheduler`

### DIFF
--- a/src/riot-rs-threads/src/threadlist.rs
+++ b/src/riot-rs-threads/src/threadlist.rs
@@ -1,6 +1,6 @@
 use critical_section::CriticalSection;
 
-use crate::{thread::Thread, ThreadId, ThreadState, THREADS};
+use crate::{thread::Thread, ThreadId, ThreadState, SCHEDULER};
 
 /// Manages blocked [`super::Thread`]s for a resource, and triggering the scheduler when needed.
 #[derive(Debug, Default)]
@@ -21,25 +21,25 @@ impl ThreadList {
     ///
     /// Panics if this is called outside of a thread context.
     pub fn put_current(&mut self, cs: CriticalSection, state: ThreadState) {
-        THREADS.with_mut_cs(cs, |mut threads| {
-            let &mut Thread { pid, prio, .. } = threads
+        SCHEDULER.with_mut_cs(cs, |mut scheduler| {
+            let &mut Thread { pid, prio, .. } = scheduler
                 .current()
                 .expect("Function should be called inside a thread context.");
             let mut curr = None;
             let mut next = self.head;
             while let Some(n) = next {
-                if threads.get_unchecked_mut(n).prio < prio {
+                if scheduler.get_unchecked_mut(n).prio < prio {
                     break;
                 }
                 curr = next;
-                next = threads.thread_blocklist[usize::from(n)];
+                next = scheduler.thread_blocklist[usize::from(n)];
             }
-            threads.thread_blocklist[usize::from(pid)] = next;
+            scheduler.thread_blocklist[usize::from(pid)] = next;
             match curr {
-                Some(curr) => threads.thread_blocklist[usize::from(curr)] = Some(pid),
+                Some(curr) => scheduler.thread_blocklist[usize::from(curr)] = Some(pid),
                 _ => self.head = Some(pid),
             }
-            threads.set_state(pid, state);
+            scheduler.set_state(pid, state);
         });
     }
 
@@ -51,9 +51,9 @@ impl ThreadList {
     /// Returns the thread's [`ThreadId`] and its previous [`ThreadState`].
     pub fn pop(&mut self, cs: CriticalSection) -> Option<(ThreadId, ThreadState)> {
         let head = self.head?;
-        THREADS.with_mut_cs(cs, |mut threads| {
-            self.head = threads.thread_blocklist[usize::from(head)].take();
-            let old_state = threads.set_state(head, ThreadState::Running);
+        SCHEDULER.with_mut_cs(cs, |mut scheduler| {
+            self.head = scheduler.thread_blocklist[usize::from(head)].take();
+            let old_state = scheduler.set_state(head, ThreadState::Running);
             Some((head, old_state))
         })
     }


### PR DESCRIPTION
# Description

Rename the central  `Threads`/ `THREADS` structure in `riot_rs_threads` into `Scheduler`/ `SCHEDULER`.

IMO that's more intuitive given that the structure not just contains and implements the TCBs,  but instead all scheduling-related logic. And `threads` itself is again a property on this struct, so it  prevents confusion there (and having to write sth like `threads.threads`).

## Open Questions

Any objections?

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
