### PR TITLE
fix(startup): move out peripherals required for USB drivers earlier

### DIFF
--- a/src/riot-rs-arch/src/dummy/usb.rs
+++ b/src/riot-rs-arch/src/dummy/usb.rs
@@ -33,7 +33,15 @@ impl<'a> Driver<'a> for UsbDriver {
     }
 }
 
-pub fn driver(_peripherals: &mut crate::OptionalPeripherals) -> UsbDriver {
+pub struct Peripherals {}
+
+impl Peripherals {
+    pub fn new(_peripherals: &mut crate::OptionalPeripherals) -> Self {
+        unimplemented!();
+    }
+}
+
+pub fn driver(_peripherals: Peripherals) -> UsbDriver {
     unimplemented!();
 }
 

--- a/src/riot-rs-nrf/src/usb.rs
+++ b/src/riot-rs-nrf/src/usb.rs
@@ -22,13 +22,25 @@ bind_interrupts!(struct Irqs {
 
 pub type UsbDriver = Driver<'static, peripherals::USBD, HardwareVbusDetect>;
 
+pub struct Peripherals {
+    usbd: peripherals::USBD,
+}
+
+impl Peripherals {
+    #[must_use]
+    pub fn new(peripherals: &mut crate::OptionalPeripherals) -> Self {
+        Self {
+            usbd: peripherals.USBD.take().unwrap(),
+        }
+    }
+}
+
 pub fn init() {
     debug!("nrf: enabling ext hfosc...");
     pac::CLOCK.tasks_hfclkstart().write_value(1);
     while pac::CLOCK.events_hfclkstarted().read() != 1 {}
 }
 
-pub fn driver(peripherals: &mut crate::OptionalPeripherals) -> UsbDriver {
-    let usbd = peripherals.USBD.take().unwrap();
-    Driver::new(usbd, Irqs, HardwareVbusDetect::new(Irqs))
+pub fn driver(peripherals: Peripherals) -> UsbDriver {
+    Driver::new(peripherals.usbd, Irqs, HardwareVbusDetect::new(Irqs))
 }

--- a/src/riot-rs-rp/src/usb.rs
+++ b/src/riot-rs-rp/src/usb.rs
@@ -9,7 +9,19 @@ bind_interrupts!(struct Irqs {
 
 pub type UsbDriver = Driver<'static, peripherals::USB>;
 
-pub fn driver(peripherals: &mut crate::OptionalPeripherals) -> UsbDriver {
-    let usb = peripherals.USB.take().unwrap();
-    Driver::new(usb, Irqs)
+pub struct Peripherals {
+    usb: peripherals::USB,
+}
+
+impl Peripherals {
+    #[must_use]
+    pub fn new(peripherals: &mut crate::OptionalPeripherals) -> Self {
+        Self {
+            usb: peripherals.USB.take().unwrap(),
+        }
+    }
+}
+
+pub fn driver(peripherals: Peripherals) -> UsbDriver {
+    Driver::new(peripherals.usb, Irqs)
 }

--- a/src/riot-rs-stm32/src/usb.rs
+++ b/src/riot-rs-stm32/src/usb.rs
@@ -6,10 +6,23 @@ bind_interrupts!(struct Irqs {
 
 pub type UsbDriver = Driver<'static, peripherals::USB>;
 
-pub fn driver(peripherals: &mut crate::OptionalPeripherals) -> UsbDriver {
-    let usb = peripherals.USB.take().unwrap();
-    let dp = peripherals.PA12.take().unwrap();
-    let dm = peripherals.PA11.take().unwrap();
+pub struct Peripherals {
+    usb: peripherals::USB,
+    dp: peripherals::PA12,
+    dm: peripherals::PA11,
+}
 
-    Driver::new(usb, Irqs, dp, dm)
+impl Peripherals {
+    #[must_use]
+    pub fn new(peripherals: &mut crate::OptionalPeripherals) -> Self {
+        Self {
+            usb: peripherals.USB.take().unwrap(),
+            dp: peripherals.PA12.take().unwrap(),
+            dm: peripherals.PA11.take().unwrap(),
+        }
+    }
+}
+
+pub fn driver(peripherals: Peripherals) -> UsbDriver {
+    Driver::new(peripherals.usb, Irqs, peripherals.dp, peripherals.dm)
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Previously, it would have been possible for user tasks to take peripherals out of `OptionalPeripherals` before the required peripherals had been extracted for USB drivers.
This now takes the peripherals required for USB before starting the user tasks, making this impossible for tasks.

## Hardware testing

I've successfully tested the `udp-echo` example on the nRF52840-DK, the RPi Pico and the ST NUCLEO WB55RG, and the `usb-serial` on the ST NUCLEO H755ZI-Q (because it doesn't currently support Ethernet over USB). These two ST NUCLEO boards use different USB modules of ours.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Extracted from #337. **This PR is only concerned with USB peripherals.** I'll update #337 later to do Wi-Fi peripherals after this one.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
