### PR TITLE
riot-rs-debug: bump rtt-target, drop defmt-rtt-target, make use of semihosting crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,17 +898,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defmt-rtt-target"
-version = "0.3.0"
-source = "git+https://github.com/kaspar030/defmt-rtt-target?rev=5668c92ac5a0689b165a6a07bb14e173fc47cd34#5668c92ac5a0689b165a6a07bb14e173fc47cd34"
-dependencies = [
- "cortex-m",
- "critical-section",
- "defmt",
- "rtt-target",
-]
-
-[[package]]
 name = "delegate"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3562,13 +3551,11 @@ dependencies = [
 name = "riot-rs-debug"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
- "cortex-m-semihosting",
  "defmt",
- "defmt-rtt-target",
  "esp-println",
  "log 0.4.22",
  "rtt-target",
+ "semihosting",
 ]
 
 [[package]]
@@ -3723,7 +3710,6 @@ dependencies = [
  "riot-rs-debug",
  "riot-rs-threads",
  "riot-rs-utils",
- "rtt-target",
 ]
 
 [[package]]
@@ -3867,11 +3853,12 @@ dependencies = [
 
 [[package]]
 name = "rtt-target"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b34c9e6832388e45f3c01f1bb60a016384a0a4ad80cdd7d34913bed25037f0"
+version = "0.6.0"
+source = "git+https://github.com/probe-rs/rtt-target?rev=5b7603b6114bb08385f71674b9d962471c221681#5b7603b6114bb08385f71674b9d962471c221681"
 dependencies = [
  "critical-section",
+ "defmt",
+ "portable-atomic",
  "ufmt-write",
 ]
 
@@ -3959,6 +3946,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semihosting"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5c5996e5d1dec34b0dff3285e27124e70964504e3fd361bce330dc476cebafd"
 
 [[package]]
 name = "semver"
@@ -4241,8 +4234,8 @@ dependencies = [
 name = "stm32"
 version = "0.1.0"
 dependencies = [
+ "riot-rs-debug",
  "riot-rs-embassy",
- "riot-rs-rt",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ once_cell = { version = "=1.19.0", default-features = false, features = [
   "critical-section",
 ] }
 paste = { version = "1.0" }
+rtt-target = { git = "https://github.com/probe-rs/rtt-target", rev = "5b7603b6114bb08385f71674b9d962471c221681" }
 
 rp-pac = { version = "6.0", default-features = false }
 serde = { version = "1.0.197", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -55,6 +55,7 @@ allow-git = [
   "https://github.com/twitchyliquid64/usbd-hid",
   "https://gitlab.com/oscore/liboscore",
   "https://github.com/seanmonstar/try-lock",
+  "https://github.com/probe-rs/rtt-target",
 ]
 
 [sources.allow-org]

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -11,6 +11,7 @@ contexts:
       - executor-default
       - ?critical-section
       - ?defmt
+      - ?semihosting
     env:
       RUSTFLAGS:
         - --cfg builder=\"${builder}\"
@@ -793,6 +794,13 @@ modules:
         CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
         FEATURES:
           - riot-rs/esp-println
+
+  - name: semihosting
+    help: enable semihosting in riot-rs-debug
+    env:
+      global:
+        FEATURES:
+          - riot-rs/semihosting
 
 builders:
   # host builder (for housekeeping tasks)

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -284,6 +284,7 @@ contexts:
     parent: riot-rs
     selects:
       - ?debug-console
+      - ?esp-println
     env:
       RUSTFLAGS:
         - --cfg context=\"esp\"
@@ -293,7 +294,6 @@ contexts:
         # - -C force-frame-pointers
       CARGO_ARGS:
         - -Zbuild-std=core,alloc
-      CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
 
   - name: esp32c3
     parent: esp
@@ -303,6 +303,8 @@ contexts:
       RUSTFLAGS:
         - --cfg context=\"esp32c3\"
       RUSTC_TARGET: riscv32imc-unknown-none-elf
+      PROBE_RS_CHIP: esp32c3
+      PROBE_RS_PROTOCOL: jtag
       CARGO_TARGET_PREFIX: CARGO_TARGET_RISCV32IMC_UNKNOWN_NONE_ELF
 
   - name: esp32c6
@@ -313,6 +315,8 @@ contexts:
       RUSTFLAGS:
         - --cfg context=\"esp32c6\"
       RUSTC_TARGET: riscv32imac-unknown-none-elf
+      PROBE_RS_CHIP: esp32c6
+      PROBE_RS_PROTOCOL: jtag
       CARGO_TARGET_PREFIX: CARGO_TARGET_RISCV32IMAC_UNKNOWN_NONE_ELF
 
   - name: esp32s3
@@ -324,6 +328,8 @@ contexts:
       RUSTFLAGS:
         - --cfg context=\"esp32s3\"
       RUSTC_TARGET: xtensa-esp32s3-none-elf
+      PROBE_RS_CHIP: esp32s3
+      PROBE_RS_PROTOCOL: jtag
       CARGO_TARGET_PREFIX: CARGO_TARGET_XTENSA_ESP32S3_NONE_ELF
 
   - name: stm32
@@ -580,6 +586,7 @@ modules:
     help: use probe-rs as runner
     selects:
       - ?debug-console
+      - rtt-target
     env:
       global:
         CARGO_RUNNER: "'probe-rs run ${PROBE_RS_PROTOCOL} --chip ${PROBE_RS_CHIP}'"
@@ -765,6 +772,27 @@ modules:
       global:
         FEATURES:
           - riot-rs/multi-core
+
+  - name: rtt-target
+    help: use rtt-target in riot-rs-debug
+    provides_unique:
+      - riot-rs-debug-backend
+    env:
+      global:
+        FEATURES:
+          - riot-rs/rtt-target
+
+  - name: esp-println
+    help: use esp-println in riot-rs-debug
+    context:
+      - esp
+    provides_unique:
+      - riot-rs-debug-backend
+    env:
+      global:
+        CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
+        FEATURES:
+          - riot-rs/esp-println
 
 builders:
   # host builder (for housekeeping tasks)

--- a/src/riot-rs-chips/stm32/Cargo.toml
+++ b/src/riot-rs-chips/stm32/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 
 [target.'cfg(context = "stm32h7b0")'.dependencies]
 riot-rs-embassy = { path = "../../riot-rs-embassy" }
-riot-rs-rt = { path = "../../riot-rs-rt", features = ["rtt-target"] }
+riot-rs-debug = { path = "../../riot-rs-debug", features = ["rtt-target"] }

--- a/src/riot-rs-debug/Cargo.toml
+++ b/src/riot-rs-debug/Cargo.toml
@@ -14,10 +14,13 @@ workspace = true
 [dependencies]
 defmt = { workspace = true, optional = true }
 rtt-target = { workspace = true, optional = true }
-semihosting = { version = "0.1.16" }
+
+semihosting = { version = "0.1.16", optional = true }
 
 [target.'cfg(context = "xtensa")'.dependencies]
-semihosting = { version = "0.1.16", features = ["openocd-semihosting"] }
+semihosting = { version = "0.1.16", optional = true, features = [
+  "openocd-semihosting",
+] }
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-println = { workspace = true, optional = true, features = ["log"] }

--- a/src/riot-rs-debug/Cargo.toml
+++ b/src/riot-rs-debug/Cargo.toml
@@ -13,29 +13,25 @@ workspace = true
 
 [dependencies]
 defmt = { workspace = true, optional = true }
+rtt-target = { workspace = true, optional = true }
+semihosting = { version = "0.1.16" }
 
-# listed here so they can enable its features conditionally
-esp-println = { workspace = true, optional = true }
-
-[target.'cfg(context = "cortex-m")'.dependencies]
-cortex-m = { workspace = true }
-cortex-m-semihosting = { workspace = true, optional = true }
-rtt-target = { version = "0.5.0", optional = true }
-defmt-rtt-target = { git = "https://github.com/kaspar030/defmt-rtt-target", rev = "5668c92ac5a0689b165a6a07bb14e173fc47cd34" }
+[target.'cfg(context = "xtensa")'.dependencies]
+semihosting = { version = "0.1.16", features = ["openocd-semihosting"] }
 
 [target.'cfg(context = "esp")'.dependencies]
-esp-println = { workspace = true, features = ["log"] }
+esp-println = { workspace = true, optional = true, features = ["log"] }
 log = { version = "0.4.20" }
 
 [target.'cfg(context = "esp32c3")'.dependencies]
-esp-println = { workspace = true, features = ["esp32c3"] }
+esp-println = { workspace = true, optional = true, features = ["esp32c3"] }
 
 [target.'cfg(context = "esp32c6")'.dependencies]
-esp-println = { workspace = true, features = ["esp32c6"] }
+esp-println = { workspace = true, optional = true, features = ["esp32c6"] }
 
 [target.'cfg(context = "esp32s3")'.dependencies]
-esp-println = { workspace = true, features = ["esp32s3"] }
+esp-println = { workspace = true, optional = true, features = ["esp32s3"] }
 
 [features]
 debug-console = []
-defmt = ["dep:defmt", "esp-println?/defmt-espflash"]
+defmt = ["dep:defmt", "esp-println?/defmt-espflash", "rtt-target?/defmt"]

--- a/src/riot-rs-rt/Cargo.toml
+++ b/src/riot-rs-rt/Cargo.toml
@@ -14,7 +14,6 @@ linkme.workspace = true
 riot-rs-debug.workspace = true
 riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 riot-rs-utils = { workspace = true }
-rtt-target = { version = "0.5.0", optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 cortex-m = { workspace = true }

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -118,6 +118,7 @@ no-boards = ["riot-rs-boards/no-boards", "executor-none"]
 # These are selected by laze
 rtt-target = ["riot-rs-debug/rtt-target"]
 esp-println = ["riot-rs-debug/esp-println"]
+semihosting = ["riot-rs-debug/semihosting"]
 
 net = ["riot-rs-embassy/net"]
 

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -115,6 +115,10 @@ silent-panic = ["riot-rs-rt/silent-panic"]
 ## Allows to have no boards selected, useful to run target-independent tooling.
 no-boards = ["riot-rs-boards/no-boards", "executor-none"]
 
+# These are selected by laze
+rtt-target = ["riot-rs-debug/rtt-target"]
+esp-println = ["riot-rs-debug/esp-println"]
+
 net = ["riot-rs-embassy/net"]
 
 #! ## Executor type selection for the (autostarted) main executor


### PR DESCRIPTION
# Description

This PR overhauls `riot-rs-debug` a bit:

- make use of rtt-target's internal defmt support, drop use of our `defmt-rtt-target` fork
- use the semihosting crate instead of cortex-m::semihosting_syscall for `exit()`

Apart from dropping one self-managed fork, this enables `rtt-target` and `probe-rs` use on esp. This is a prerequisite for using `embedded-test`.
The previous `esp-println` backend is kept and still default on esp.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
