### PR TITLE
ci(lint): work around yamllint and prettier disagreeing

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,4 @@
 ---
-
 extends: default
 
 # Documentation of rules:
@@ -9,3 +8,5 @@ rules:
   line-length: disable
   truthy:
     check-keys: false
+  comments:
+    min-spaces-from-content: 1 # Changed this to stop a mess between linters from Prettier (vscode) to yamllint - https://github.com/prettier/prettier/pull/10926


### PR DESCRIPTION
# Description

`prettier` (my yaml formatter and IIUC, the vscode default) removes the extra (2nd) whitespace
between content and `#` when formatting yaml files.
I don't know how to make it not do that or even add those.
So, relax yamllint so it doesn't fail those files.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

Split out from #534.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
