### PR TITLE
feat(embassy): add support for USB HID

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -66,6 +66,7 @@ jobs:
                   storage,
                   threading,
                   usb,
+                  usb-hid,
                   "
           echo "<meta http-equiv=\"refresh\" content=\"0; url=riot_rs\">" > target/doc/index.html
           mkdir -p ./_site/dev/docs/api && mv target/doc/* ./_site/dev/docs/api

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -384,6 +384,7 @@ jobs:
                     storage,
                     threading,
                     usb,
+                    usb-hid,
                     "
 
       - name: rustdoc for ESP32

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3600,6 +3600,7 @@ dependencies = [
  "riot-rs-threads",
  "riot-rs-utils",
  "static_cell",
+ "usbd-hid",
 ]
 
 [[package]]
@@ -4689,6 +4690,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
+ "defmt",
  "heapless 0.8.0",
  "portable-atomic",
 ]
@@ -4707,6 +4709,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f291ab53d428685cc780f08a2eb9d5d6ff58622db2b36e239a4f715f1e184c"
 dependencies = [
+ "defmt",
  "serde",
  "ssmarshal",
  "usb-device",

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -40,6 +40,7 @@ riot-rs-utils = { workspace = true }
 
 heapless = "0.8.0"
 once_cell = { workspace = true }
+usbd-hid = { version = "0.8.2", optional = true }
 
 # ISA-specific
 [target.'cfg(context = "cortex-m")'.dependencies]
@@ -68,6 +69,7 @@ spi = [
   "riot-rs-arch/spi",
 ]
 usb = ["dep:embassy-usb", "riot-rs-arch/usb"]
+usb-hid = ["dep:usbd-hid", "embassy-usb?/usbd-hid", "usb"]
 # embassy-net requires embassy-time and support for timeouts in the executor
 net = ["dep:embassy-net", "time"]
 usb-ethernet = ["usb", "net"]
@@ -104,4 +106,5 @@ defmt = [
   "embassy-usb?/defmt",
   "riot-rs-arch/defmt",
   "riot-rs-embassy-common/defmt",
+  "usbd-hid?/defmt",
 ]

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -63,6 +63,8 @@ pub mod reexports {
     pub use embassy_time;
     #[cfg(feature = "usb")]
     pub use embassy_usb;
+    #[cfg(feature = "usb-hid")]
+    pub use usbd_hid;
     // Used by a macro we provide
     pub use embassy_executor;
 }

--- a/src/riot-rs/Cargo.toml
+++ b/src/riot-rs/Cargo.toml
@@ -63,6 +63,8 @@ i2c = ["riot-rs-embassy/i2c"]
 spi = ["riot-rs-embassy/spi"]
 ## Enables USB support.
 usb = ["riot-rs-embassy/usb"]
+## Enables USB HID support.
+usb-hid = ["riot-rs-embassy/usb-hid"]
 
 #! ## System configuration
 #! The [`macro@config`] attribute macro allows to provide configuration for


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Introduces a `usb-hid` Cargo features, that:

- Enables the `usbd-hid` Cargo feature on the re-exported `embassy-usb` crate.
- Re-exports the [`usbd-hid` crate](https://docs.rs/usbd-hid/latest/usbd_hid/) in `riot_rs::reexports`.

Even though that crate is named usb**d**-hid, this new Cargo feature is named `usb-hid`, because I believe `usbd` refers to the [`usb-device` crate](https://docs.rs/usb-device/latest/usb_device/) and I think the feature's name should not refer to the implementation but to the USB HID concept itself.

## Testing

This can be tested though #538.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
