### PR TITLE
 docs(rp-hal): document the `riot-rs-rp` HAL crate

### DIFF
--- a/src/riot-rs-embassy-common/src/spi/main/mod.rs
+++ b/src/riot-rs-embassy-common/src/spi/main/mod.rs
@@ -60,6 +60,7 @@ macro_rules! impl_spi_from_frequency {
 #[macro_export]
 macro_rules! impl_spi_frequency_const_functions {
     ($MAX_FREQUENCY:ident) => {
+        #[doc(hidden)]
         impl Frequency {
             pub const fn first() -> Self {
                 Self::F(Kilohertz::kHz(1))

--- a/src/riot-rs-rp/src/gpio.rs
+++ b/src/riot-rs-rp/src/gpio.rs
@@ -1,4 +1,8 @@
+//! Provides GPIO access.
+
 pub mod input {
+    //! Input-specific types.
+
     use embassy_rp::{
         gpio::{Level, Pull},
         Peripheral,
@@ -15,6 +19,7 @@ pub mod input {
     #[doc(hidden)]
     pub use embassy_rp::gpio::Input as IntEnabledInput;
 
+    /// Whether inputs support configuring whether a Schmitt trigger is enabled.
     pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = true;
 
     #[doc(hidden)]
@@ -52,6 +57,8 @@ pub mod input {
 }
 
 pub mod output {
+    //! Output-specific types.
+
     use embassy_rp::{
         gpio::{Drive, Level, SlewRate},
         Peripheral,
@@ -61,7 +68,9 @@ pub mod output {
     #[doc(hidden)]
     pub use embassy_rp::gpio::{Output, Pin as OutputPin};
 
+    /// Whether outputs support configuring their drive strength.
     pub const DRIVE_STRENGTH_CONFIGURABLE: bool = true;
+    /// Whether outputs support configuring their speed/slew rate.
     pub const SPEED_CONFIGURABLE: bool = true;
 
     #[doc(hidden)]
@@ -81,12 +90,17 @@ pub mod output {
         output
     }
 
+    /// Available drive strength settings.
     // We provide our own type because the upstream type is not `Copy` and has no `Default` impl.
     #[derive(Copy, Clone, PartialEq, Eq)]
     pub enum DriveStrength {
+        /// 2 mA.
         _2mA,
+        /// 4 mA.
         _4mA,
+        /// 8 mA.
         _8mA,
+        /// 12 mA.
         _12mA,
     }
 
@@ -124,12 +138,15 @@ pub mod output {
         }
     }
 
+    /// Available output speed/slew rate settings.
     // These values do not seem to be quantitatively defined on the RP2040.
     // We provide our own type because the `SlewRate` upstream type is not `Copy` and has no
     // `Default` impl.
     #[derive(Copy, Clone, PartialEq, Eq)]
     pub enum Speed {
+        /// Low.
         Low,
+        /// High.
         High,
     }
 

--- a/src/riot-rs-rp/src/gpio.rs
+++ b/src/riot-rs-rp/src/gpio.rs
@@ -7,14 +7,17 @@ pub mod input {
     #[cfg(feature = "external-interrupts")]
     use riot_rs_embassy_common::gpio::input::InterruptError;
 
+    #[doc(hidden)]
     pub use embassy_rp::gpio::{Input, Pin as InputPin};
 
     // Re-export `Input` as `IntEnabledInput` as they are interrupt-enabled.
     #[cfg(feature = "external-interrupts")]
+    #[doc(hidden)]
     pub use embassy_rp::gpio::Input as IntEnabledInput;
 
     pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = true;
 
+    #[doc(hidden)]
     pub fn new(
         pin: impl Peripheral<P: InputPin> + 'static,
         pull: riot_rs_embassy_common::gpio::Pull,
@@ -29,6 +32,7 @@ pub mod input {
     }
 
     #[cfg(feature = "external-interrupts")]
+    #[doc(hidden)]
     pub fn new_int_enabled(
         pin: impl Peripheral<P: InputPin> + 'static,
         pull: riot_rs_embassy_common::gpio::Pull,
@@ -54,11 +58,13 @@ pub mod output {
     };
     use riot_rs_embassy_common::gpio::{FromDriveStrength, FromSpeed};
 
+    #[doc(hidden)]
     pub use embassy_rp::gpio::{Output, Pin as OutputPin};
 
     pub const DRIVE_STRENGTH_CONFIGURABLE: bool = true;
     pub const SPEED_CONFIGURABLE: bool = true;
 
+    #[doc(hidden)]
     pub fn new(
         pin: impl Peripheral<P: OutputPin> + 'static,
         initial_level: riot_rs_embassy_common::gpio::Level,

--- a/src/riot-rs-rp/src/i2c/controller/mod.rs
+++ b/src/riot-rs-rp/src/i2c/controller/mod.rs
@@ -1,3 +1,5 @@
+//! Provides support for the I2C communication bus in controller mode.
+
 use embassy_rp::{
     bind_interrupts,
     i2c::{InterruptHandler, SclPin, SdaPin},
@@ -13,6 +15,7 @@ const KHZ_TO_HZ: u32 = 1000;
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct Config {
+    /// The frequency at which the bus should operate.
     pub frequency: Frequency,
 }
 
@@ -37,6 +40,7 @@ pub enum Frequency {
     UpTo400k(Kilohertz), // FIXME: use a ranged integer?
 }
 
+#[doc(hidden)]
 impl Frequency {
     pub const fn first() -> Self {
         Self::UpTo100k(Kilohertz::kHz(1))
@@ -106,6 +110,8 @@ macro_rules! define_i2c_drivers {
             }
 
             impl $peripheral {
+                /// Returns a driver implementing [`embedded_hal_async::i2c::I2c`] for this
+                /// I2C peripheral.
                 #[expect(clippy::new_ret_no_self)]
                 #[must_use]
                 pub fn new(
@@ -151,7 +157,10 @@ macro_rules! define_i2c_drivers {
 
         /// Peripheral-agnostic driver.
         pub enum I2c {
-            $( $peripheral($peripheral), )*
+            $(
+                #[doc = concat!(stringify!($peripheral), " peripheral.")]
+                $peripheral($peripheral),
+            )*
         }
 
         impl embedded_hal_async::i2c::ErrorType for I2c {

--- a/src/riot-rs-rp/src/i2c/mod.rs
+++ b/src/riot-rs-rp/src/i2c/mod.rs
@@ -1,3 +1,5 @@
+//! Provides support for the I2C communication bus.
+
 #[doc(alias = "master")]
 pub mod controller;
 

--- a/src/riot-rs-rp/src/i2c/mod.rs
+++ b/src/riot-rs-rp/src/i2c/mod.rs
@@ -1,6 +1,7 @@
 #[doc(alias = "master")]
 pub mod controller;
 
+#[doc(hidden)]
 pub fn init(peripherals: &mut crate::OptionalPeripherals) {
     // Take all I2C peripherals and do nothing with them.
     cfg_if::cfg_if! {

--- a/src/riot-rs-rp/src/lib.rs
+++ b/src/riot-rs-rp/src/lib.rs
@@ -1,7 +1,10 @@
+//! Items specific to the Raspberry Pi RP MCUs.
+
 #![no_std]
 #![feature(doc_auto_cfg)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(type_alias_impl_trait)]
+#![deny(missing_docs)]
 
 pub mod gpio;
 

--- a/src/riot-rs-rp/src/lib.rs
+++ b/src/riot-rs-rp/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod gpio;
 
+#[doc(hidden)]
 pub mod peripheral {
     pub use embassy_rp::Peripheral;
 }
@@ -13,14 +14,17 @@ pub mod peripheral {
 mod wifi;
 
 #[cfg(feature = "wifi-cyw43")]
+#[doc(hidden)]
 pub mod cyw43;
 
 #[cfg(feature = "hwrng")]
+#[doc(hidden)]
 pub mod hwrng;
 
 #[cfg(feature = "i2c")]
 pub mod i2c;
 
+#[doc(hidden)]
 pub mod identity {
     use riot_rs_embassy_common::identity;
 
@@ -31,24 +35,33 @@ pub mod identity {
 pub mod spi;
 
 #[cfg(feature = "storage")]
+#[doc(hidden)]
 pub mod storage;
 
 #[cfg(feature = "usb")]
+#[doc(hidden)]
 pub mod usb;
 
-pub use embassy_rp::{peripherals, OptionalPeripherals};
+#[doc(hidden)]
+pub use embassy_rp::OptionalPeripherals;
+
+pub use embassy_rp::peripherals;
 
 #[cfg(feature = "executor-interrupt")]
+#[doc(hidden)]
 pub use embassy_executor::InterruptExecutor as Executor;
 #[cfg(feature = "executor-interrupt")]
+#[doc(hidden)]
 pub use embassy_rp::interrupt;
 
 #[cfg(feature = "executor-interrupt")]
 riot_rs_embassy_common::executor_swi!(SWI_IRQ_1);
 
 #[cfg(feature = "executor-interrupt")]
+#[doc(hidden)]
 pub static EXECUTOR: Executor = Executor::new();
 
+#[doc(hidden)]
 pub fn init() -> OptionalPeripherals {
     #[cfg(feature = "executor-interrupt")]
     {

--- a/src/riot-rs-rp/src/spi/main/mod.rs
+++ b/src/riot-rs-rp/src/spi/main/mod.rs
@@ -1,3 +1,5 @@
+//! Provides support for the SPI communication bus in main mode.
+
 use embassy_embedded_hal::adapter::{BlockingAsync, YieldingAsync};
 use embassy_rp::{
     peripherals,
@@ -14,10 +16,13 @@ use riot_rs_embassy_common::{
 #[cfg(context = "rp2040")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::kHz(62_500);
 
+/// SPI bus configuration.
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct Config {
+    /// The frequency at which the bus should operate.
     pub frequency: Frequency,
+    /// The SPI mode to use.
     pub mode: Mode,
 }
 
@@ -30,10 +35,12 @@ impl Default for Config {
     }
 }
 
+/// SPI bus frequency.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(u32)]
 pub enum Frequency {
+    /// Arbitrary frequency.
     F(Kilohertz),
 }
 
@@ -57,6 +64,8 @@ macro_rules! define_spi_drivers {
             }
 
             impl $peripheral {
+                /// Returns a driver implementing [`embedded_hal_async::spi::SpiBus`] for this SPI
+                /// peripheral.
                 #[expect(clippy::new_ret_no_self)]
                 #[must_use]
                 pub fn new(
@@ -100,7 +109,10 @@ macro_rules! define_spi_drivers {
 
         /// Peripheral-agnostic driver.
         pub enum Spi {
-            $( $peripheral($peripheral) ),*
+            $(
+                #[doc = concat!(stringify!($peripheral), " peripheral.")]
+                $peripheral($peripheral)
+            ),*
         }
 
         impl embedded_hal_async::spi::ErrorType for Spi {

--- a/src/riot-rs-rp/src/spi/mod.rs
+++ b/src/riot-rs-rp/src/spi/mod.rs
@@ -1,3 +1,5 @@
+//! Provides support for the SPI communication bus.
+
 #[doc(alias = "master")]
 pub mod main;
 

--- a/src/riot-rs-rp/src/spi/mod.rs
+++ b/src/riot-rs-rp/src/spi/mod.rs
@@ -13,6 +13,7 @@ fn from_mode(mode: Mode) -> (Polarity, Phase) {
     }
 }
 
+#[doc(hidden)]
 pub fn init(peripherals: &mut crate::OptionalPeripherals) {
     // Take all SPI peripherals and do nothing with them.
     cfg_if::cfg_if! {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This documents items relevant for users, and hides the others from documentation, to prepare for them being rendered in #531. 
Documentation for the `riot-rs-rp` crate can be rendered locally using the following:

https://github.com/future-proof-iot/RIOT-rs/blob/291e47ee2a3f66f3b167c2242255e812dff7582c/.github/workflows/main.yml#L405-L412

## Future work

- PRs will follow to do the same for other HAL crates.
- **This PR hides the `OptionalPeripherals` type, and only exposes the `peripherals` module.** The documentation of the `define_peripherals!` macro will be updated in a future PR to not refer to `OptionalPeripherals` anymore, as it's not necessary and I think it would be better to treat it as an implementation detail.
- The relationship between the generic types (e.g., in `riot_rs::gpio`) and the HAL-specific types (in `riot_rs::hal`) will be clarified in a future PR, after #531 allows rendering the docs as part of CI.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
