### PR TITLE
feat(esp): set default CPU speed to `CpuClock::max()`

### DIFF
--- a/src/riot-rs-esp/src/lib.rs
+++ b/src/riot-rs-esp/src/lib.rs
@@ -72,7 +72,10 @@ pub use esp_hal::peripherals::OptionalPeripherals;
 pub use esp_hal_embassy::Executor;
 
 pub fn init() -> OptionalPeripherals {
-    let mut peripherals = OptionalPeripherals::from(esp_hal::init(esp_hal::Config::default()));
+    let mut config = esp_hal::Config::default();
+    config.cpu_clock = esp_hal::clock::CpuClock::max();
+
+    let mut peripherals = OptionalPeripherals::from(esp_hal::init(config));
 
     #[cfg(feature = "wifi-esp")]
     {


### PR DESCRIPTION
# Description

This configures the `esp32*` CPU clock speed from the default (80MHz) to something more reasonable (`max()`).
 
## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
