### PR TITLE
docs(log): Clean up the log example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ This directory contains example applications that showcase how to use RIOT-rs.
 - [embassy-usb-keyboard/](./embassy-usb-keyboard): USB HID example
 - [hello-world/](./hello-world): a classic, async version
 - [hello-world-threading/](./hello-world-threading): a classic, using a thread
+- [log](./log): Example demonstrating different log levels for printing feedback messages.
 - [minimal/](./minimal): minimized to the max RIOT-rs config
 - [tcp-echo/](./tcp-echo): TCP echo example
 - [thread-async-interop/](./thread-async-interop): how to make async tasks and preemptively scheduled threads interoperate

--- a/examples/log/README.md
+++ b/examples/log/README.md
@@ -2,10 +2,37 @@
 
 ## About
 
-This application provides a simple tester for log output of the main application.
+This application provides a simple demonstrator for log output of the main
+application at different log levels.
+
+This application prints a log statement at every log level. Only the log
+statements which are enabled are printed.
+
+The log level can be provided on the command line as argument to laze via the
+`-DLOG` argument. The available log levels that can be configured are:
+
+- error
+- warn
+- info
+- debug
+- trace
 
 ## How to run
 
 In this folder, run
 
     laze build -b nrf52840dk -DLOG+=info -DLOG+=riot_rs_embassy=warn run
+
+## Expected output
+
+The output of this example depends on the enabled log level. With trace set as
+log level, the following output is expected from this example (RIOT-rs startup
+logging not shown):
+
+```
+TRACE -- trace log level enabled
+DEBUG -- debug log level enabled
+INFO  -- info log level enabled
+WARN  -- warn log level enabled
+ERROR -- error log level enabled (just testing)
+```

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -7,9 +7,9 @@ use riot_rs::debug::log::*;
 
 #[riot_rs::task(autostart)]
 async fn main() {
-    defmt::trace!("trace log level enabled");
-    defmt::debug!("debug log level enabled");
-    defmt::info!("info log level enabled");
-    defmt::warn!("warn log level enabled");
-    defmt::error!("error log level enabled (just testing)");
+    trace!("-- trace log level enabled");
+    debug!("-- debug log level enabled");
+    info!("-- info log level enabled");
+    warn!("-- warn log level enabled");
+    error!("-- error log level enabled (just testing)");
 }


### PR DESCRIPTION
# Description

As part of https://github.com/future-proof-iot/RIOT-rs/issues/410, this PR:

- Adds the log example to the examples readme
- Extend the readme with some clarification
- Remove the `defmt` from the example
- Adds dashes to the printed logging to increase the distinction between the common RIOT-rs logging and the logging from the example

## Issues/PRs references

Part of #410 

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
