### PR TITLE
refactor(gpio)!: replace the `UnsupportedByHardware` variant with a note

### DIFF
--- a/src/ariel-os-embassy-common/src/gpio.rs
+++ b/src/ariel-os-embassy-common/src/gpio.rs
@@ -191,3 +191,46 @@ pub mod input {
         NoIntChannelAvailable,
     }
 }
+
+/// Available output speed/slew rate settings.
+///
+/// *Note: configuring the speed of outputs is not supported on this MCU family.*
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum UnsupportedSpeed {
+    #[doc(hidden)]
+    UnsupportedByHardware,
+}
+
+impl FromSpeed for UnsupportedSpeed {
+    fn from(_speed: Speed<Self>) -> Self {
+        Self::UnsupportedByHardware
+    }
+}
+
+/// Available drive strength settings.
+///
+/// *Note: configuring the drive strength of outputs is not supported on this MCU family.*
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum UnsupportedDriveStrength {
+    #[doc(hidden)]
+    UnsupportedByHardware,
+}
+
+impl Default for UnsupportedDriveStrength {
+    fn default() -> Self {
+        Self::UnsupportedByHardware
+    }
+}
+
+impl FromDriveStrength for UnsupportedDriveStrength {
+    fn from(drive_strength: DriveStrength<Self>) -> Self {
+        match drive_strength {
+            DriveStrength::Hal(drive_strength) => drive_strength,
+            DriveStrength::Lowest
+            | DriveStrength::Medium
+            | DriveStrength::High
+            | DriveStrength::Highest => UnsupportedDriveStrength::UnsupportedByHardware,
+            DriveStrength::Standard => UnsupportedDriveStrength::default(),
+        }
+    }
+}

--- a/src/ariel-os-esp/src/gpio.rs
+++ b/src/ariel-os-esp/src/gpio.rs
@@ -118,9 +118,10 @@ pub mod input {
 pub mod output {
     //! Output-specific types.
 
-    use ariel_os_embassy_common::gpio::{FromDriveStrength, FromSpeed};
-
+    use ariel_os_embassy_common::gpio::FromDriveStrength;
     use esp_hal::{gpio::Level, peripheral::Peripheral};
+
+    pub use ariel_os_embassy_common::gpio::UnsupportedSpeed as Speed;
 
     #[doc(hidden)]
     pub use esp_hal::gpio::{Output, OutputPin};
@@ -184,19 +185,6 @@ pub mod output {
                 High => DriveStrength::_20mA,
                 Highest => DriveStrength::_40mA,
             }
-        }
-    }
-
-    /// Available output speed/slew rate settings.
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    pub enum Speed {
-        /// Configuring the speed of outputs is not supported.
-        UnsupportedByHardware,
-    }
-
-    impl FromSpeed for Speed {
-        fn from(_speed: ariel_os_embassy_common::gpio::Speed<Self>) -> Self {
-            Self::UnsupportedByHardware
         }
     }
 }

--- a/src/ariel-os-nrf/src/gpio.rs
+++ b/src/ariel-os-nrf/src/gpio.rs
@@ -49,11 +49,13 @@ pub mod input {
 pub mod output {
     //! Output-specific types.
 
-    use ariel_os_embassy_common::gpio::{FromDriveStrength, FromSpeed};
+    use ariel_os_embassy_common::gpio::FromDriveStrength;
     use embassy_nrf::{
         gpio::{Level, OutputDrive},
         Peripheral,
     };
+
+    pub use ariel_os_embassy_common::gpio::UnsupportedSpeed as Speed;
 
     #[doc(hidden)]
     pub use embassy_nrf::gpio::{Output, Pin as OutputPin};
@@ -109,19 +111,6 @@ pub mod output {
                 High => DriveStrength::High,
                 Highest => DriveStrength::High,
             }
-        }
-    }
-
-    /// Available output speed/slew rate settings.
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    pub enum Speed {
-        /// Configuring the speed of outputs is not supported.
-        UnsupportedByHardware,
-    }
-
-    impl FromSpeed for Speed {
-        fn from(_speed: ariel_os_embassy_common::gpio::Speed<Self>) -> Self {
-            Self::UnsupportedByHardware
         }
     }
 }

--- a/src/ariel-os-stm32/src/gpio.rs
+++ b/src/ariel-os-stm32/src/gpio.rs
@@ -49,12 +49,13 @@ pub mod input {
 pub mod output {
     //! Output-specific types.
 
+    use ariel_os_embassy_common::gpio::FromSpeed;
     use embassy_stm32::{
         gpio::{Level, Speed as StmSpeed},
         Peripheral,
     };
 
-    use ariel_os_embassy_common::gpio::{FromDriveStrength, FromSpeed};
+    pub use ariel_os_embassy_common::gpio::UnsupportedDriveStrength as DriveStrength;
 
     #[doc(hidden)]
     pub use embassy_stm32::gpio::{Output, Pin as OutputPin};
@@ -76,34 +77,6 @@ pub mod output {
             ariel_os_embassy_common::gpio::Level::High => Level::High,
         };
         Output::new(pin, initial_level, speed.into())
-    }
-
-    /// Available drive strength settings.
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    pub enum DriveStrength {
-        /// Configuring the speed of outputs is not supported.
-        UnsupportedByHardware,
-    }
-
-    impl Default for DriveStrength {
-        fn default() -> Self {
-            Self::UnsupportedByHardware
-        }
-    }
-
-    impl FromDriveStrength for DriveStrength {
-        fn from(drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
-            use ariel_os_embassy_common::gpio::DriveStrength::*;
-
-            match drive_strength {
-                Hal(drive_strength) => drive_strength,
-                Lowest => DriveStrength::UnsupportedByHardware,
-                Standard => DriveStrength::default(),
-                Medium => DriveStrength::UnsupportedByHardware,
-                High => DriveStrength::UnsupportedByHardware,
-                Highest => DriveStrength::UnsupportedByHardware,
-            }
-        }
     }
 
     /// Available output speed/slew rate settings.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The name of this enum variant was rather arbitrary and not useful for users.
We use `#[doc(hidden)]` instead of `#[non_exhaustive]` for consistency with other Ariel OS HAL crates.

BREAKING CHANGE: this is arguably a breaking change as it removes/hides a variant from a public enum. However code using this enum variant was prevented from compiling in the first place, on purpose, using const asserts.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
