### PR TITLE
refactor(delegate)!: enforce more safety requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "heapless 0.8.0",
  "linkme",
  "once_cell",
+ "portable-atomic",
  "rand_core",
  "static_cell",
  "usbd-hid",

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 const_panic.workspace = true
 critical-section.workspace = true
 linkme.workspace = true
+portable-atomic.workspace = true
 rand_core = { workspace = true, optional = true }
 static_cell.workspace = true
 cfg-if.workspace = true

--- a/src/ariel-os-embassy/src/delegate.rs
+++ b/src/ariel-os-embassy/src/delegate.rs
@@ -1,11 +1,12 @@
-//! Delegate or lend an object to another task
+//! Delegate or lend an object to another task.
 
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use portable_atomic::{AtomicBool, Ordering};
 
 use crate::sendcell::SendCell;
 
-/// [`Delegate`] or lend an object to another task.
+/// [`Delegate`]s or lends an object to another task.
 ///
 /// This struct can be used to lend a `&mut T` to another task on the same executor.
 /// The other task can then call a closure on it. After that, the `&mut T` is returned
@@ -14,14 +15,17 @@ use crate::sendcell::SendCell;
 /// Under the hood, [`Delegate`] leverages [`SendCell`] to ensure the delegated
 /// object stays on the same executor.
 ///
-/// Example:
-/// ```Rust
+/// # Example
+///
+/// ```
+/// # use ariel_os_embassy::delegate::Delegate;
 /// static SOME_VALUE: Delegate<u32> = Delegate::new();
 ///
 /// // in some task
 /// async fn foo() {
 ///   let mut my_val = 0u32;
-///   SOME_VALUE.lend(&mut my_val).await;
+///   // SAFETY: `lend` is only called once.
+///   unsafe { SOME_VALUE.lend(&mut my_val).await; }
 ///   assert_eq!(my_val, 1);
 /// }
 ///
@@ -30,18 +34,16 @@ use crate::sendcell::SendCell;
 ///   SOME_VALUE.with(|val| *val = 1).await;
 /// }
 /// ```
-///
-/// TODO: this is a PoC implementation.
-/// - takes 24b for each delegate (on arm), which seems too much.
-/// - doesn't protect at all against calling [`lend()`](Delegate::lend) or
-///   [`with()`](Delegate::with) multiple times
-///   each, breaking safety assumptions. So while the API seems OK, the implementation
-///   needs work.
+// TODO: this is a PoC implementation.
+// - Takes 28 B for each delegate (on arm), which seems too much.
 #[derive(Default)]
 pub struct Delegate<T> {
     send: Signal<CriticalSectionRawMutex, SendCell<*mut T>>,
     reply: Signal<CriticalSectionRawMutex, ()>,
+    was_exercised: AtomicBool,
 }
+
+impl<T> !Send for Delegate<T> {}
 
 impl<T> Delegate<T> {
     /// Creates a new [`Delegate`].
@@ -49,13 +51,18 @@ impl<T> Delegate<T> {
         Self {
             send: Signal::new(),
             reply: Signal::new(),
+            was_exercised: AtomicBool::new(false),
         }
     }
 
     /// Lends an object.
     ///
-    /// This blocks until another task called [`with()`](Delegate::with).
-    pub async fn lend<'a, 'b: 'a>(&'a self, something: &'b mut T) {
+    /// This blocks until [`Delegate::with()`] is called on the instance.
+    ///
+    /// # Safety
+    ///
+    /// This must only be called *once* per [`Delegate`] instance.
+    pub async unsafe fn lend<'a, 'b: 'a>(&'a self, something: &'b mut T) {
         let spawner = Spawner::for_current_executor().await;
         self.send
             .signal(SendCell::new(something as *mut T, spawner));
@@ -63,10 +70,17 @@ impl<T> Delegate<T> {
         self.reply.wait().await
     }
 
-    /// Calls a closure on a lended object.
+    /// Calls a closure on a lent object.
     ///
-    /// This blocks until another task called [`lend(something)`](Delegate::lend).
+    /// This blocks until [`Delegate::lend()`] is called on the instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called multiple times on the same [`Delegate`] instance.
     pub async fn with<U>(&self, func: impl FnOnce(&mut T) -> U) -> U {
+        // Enforce that the value be only populated once, panic otherwise.
+        assert!(!self.was_exercised.swap(true, Ordering::AcqRel));
+
         let data = self.send.wait().await;
         let spawner = Spawner::for_current_executor().await;
         // SAFETY:
@@ -78,7 +92,6 @@ impl<T> Delegate<T> {
         //   => the mutable reference is never used more than once
         // - the lifetime bound on `lend` enforces that the raw pointer outlives this `Delegate`
         //   instance
-        // TODO: it is actually possible to call `with()` twice, which breaks assumptions.
         let result = func(unsafe { data.get(spawner).unwrap().as_mut().unwrap() });
         self.reply.signal(());
         result

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 #![feature(doc_auto_cfg)]
+#![feature(negative_impls)]
 
 pub mod gpio;
 
@@ -277,7 +278,10 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     #[cfg(feature = "usb")]
     {
         for hook in usb::USB_BUILDER_HOOKS {
-            hook.lend(&mut usb_builder).await;
+            // SAFETY: `lend()` is only called once per hook instance, as required.
+            unsafe {
+                hook.lend(&mut usb_builder).await;
+            }
         }
         let usb = usb_builder.build();
         spawner.spawn(usb::usb_task(usb)).unwrap();


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
- Make sure that `with()` is only called once, panic otherwise. This costs one extra byte to store the required flag.
- Mark the `lend()` method as unsafe.
- Update and slightly polish the docs as a result of these changes.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
