### PR TITLE
docs(debug): clean up the documentation

### DIFF
--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -1,5 +1,9 @@
+//! Provides debug interface facilities.
+
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(test, no_main)]
+#![deny(missing_docs)]
+#![deny(clippy::pedantic)]
 
 #[cfg(all(feature = "rtt-target", feature = "esp-println"))]
 compile_error!(
@@ -41,6 +45,11 @@ impl ExitCode {
     }
 }
 
+/// Terminates the debug output session.
+///
+/// # Note
+///
+/// This may or may not stop the MCU.
 pub fn exit(code: ExitCode) {
     #[cfg(feature = "semihosting")]
     semihosting::process::exit(code.to_semihosting_code());
@@ -58,6 +67,7 @@ pub fn exit(code: ExitCode) {
 mod backend {
     pub use rtt_target::{rprint as print, rprintln as println};
 
+    #[doc(hidden)]
     pub fn init() {
         #[cfg(not(feature = "defmt"))]
         {
@@ -98,6 +108,7 @@ mod backend {
 mod backend {
     pub use esp_println::{print, println};
 
+    #[doc(hidden)]
     pub fn init() {
         #[cfg(feature = "log")]
         crate::logger::init();
@@ -106,26 +117,28 @@ mod backend {
 
 #[cfg(not(feature = "debug-console"))]
 mod backend {
+    #[doc(hidden)]
     pub fn init() {}
 
+    /// Prints to the debug output, with a newline.
     #[macro_export]
-    macro_rules! nop_println {
+    macro_rules! println {
         ($($arg:tt)*) => {{
             let _ = ($($arg)*);
             // Do nothing
         }};
     }
 
+    /// Prints to the debug output.
+    ///
+    /// Equivalent to the [`println!`] macro except that a newline is not printed at the end of the message.
     #[macro_export]
-    macro_rules! nop_print {
+    macro_rules! print {
         ($($arg:tt)*) => {{
             let _ = ($($arg)*);
             // Do nothing
         }};
     }
-
-    pub use nop_print as print;
-    pub use nop_println as println;
 }
 
 pub use backend::*;


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This completes the documentation of the `debug` module.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #615.
Depends on #629.

## Open Questions

<!-- Unresolved questions, if any. -->
I'm not sure about the correct terminology here; I'm currently using the following:

- "debug facilities": general term for the module
- "debug logging": `defmt` macros and helpers
- "debug output" and "debug output session": semihosting's `println!` and `exit()` ("session" sounds too much like a GDB session to me)

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
