### PR TITLE
chore(attr-macros): allow internal, macro-generated non-snake fn names

### DIFF
--- a/src/ariel-os-macros/src/spawner.rs
+++ b/src/ariel-os-macros/src/spawner.rs
@@ -84,6 +84,7 @@ pub fn spawner(args: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let expanded = quote! {
+        #[allow(non_snake_case)]
         #[#ariel_os_crate::reexports::linkme::distributed_slice(#ariel_os_crate::EMBASSY_TASKS)]
         #[linkme(crate = #ariel_os_crate::reexports::linkme)]
         fn #new_function_name(

--- a/src/ariel-os-macros/src/task.rs
+++ b/src/ariel-os-macros/src/task.rs
@@ -96,6 +96,7 @@ pub fn task(args: TokenStream, item: TokenStream) -> TokenStream {
         quote! {
             #delegates
 
+            #[allow(non_snake_case)]
             #[#ariel_os_crate::reexports::linkme::distributed_slice(#ariel_os_crate::EMBASSY_TASKS)]
             #[linkme(crate = #ariel_os_crate::reexports::linkme)]
             fn #new_function_name(

--- a/src/ariel-os-macros/src/thread.rs
+++ b/src/ariel-os-macros/src/thread.rs
@@ -82,6 +82,7 @@ pub fn thread(args: TokenStream, item: TokenStream) -> TokenStream {
         #[inline(always)]
         #thread_function
 
+        #[allow(non_snake_case)]
         fn #trampoline_function_name() {
             #maybe_wait_for_start_event;
             #fn_name()

--- a/src/ariel-os-threads/src/autostart_thread.rs
+++ b/src/ariel-os-threads/src/autostart_thread.rs
@@ -5,6 +5,7 @@
 macro_rules! autostart_thread {
     ($fn_name:ident, stacksize = $stacksize:expr, priority = $priority:expr, affinity = $affinity:expr) => {
         $crate::macro_reexports::paste::paste! {
+            #[allow(non_snake_case)]
             #[$crate::macro_reexports::linkme::distributed_slice($crate::THREAD_FNS)]
             #[linkme(crate = $crate::macro_reexports::linkme)]
             fn [<__start_thread_ $fn_name>] () {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This seems to made necessary by our recent nightly version bump in #476.

The `threading`, `hello-world`, and `http-server` examples can be used to test the effect of this (with the `#[thread]`, `#[task]`, and `#[spawner]` attribute macros respectively): before, the `threading` raised warnings OOTB when inspected by rust-analyzer, and the three macros raised duplicate warnings when the function names were not snake case (e.g., containing two consecutive underscores `__`).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
