### PR TITLE
refactor(threading)!: remove `PartialOrd` impl on some types

### DIFF
--- a/src/ariel-os-runqueue/src/runqueue.rs
+++ b/src/ariel-os-runqueue/src/runqueue.rs
@@ -24,7 +24,7 @@ impl From<RunqueueId> for usize {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ThreadId(u8);
 

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -470,7 +470,7 @@ impl Scheduler {
 }
 
 /// ID of a physical core.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct CoreId(pub(crate) u8);
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
There is no partial order on these types: they are only opaques types which can only be compared for equality.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
