### PR TITLE
build: make laze use Cargo's dependency info

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -15,6 +15,7 @@ contexts:
       - ?defmt
       - ?lto
       - ?semihosting
+      - cargo-files
     env:
       RUSTFLAGS:
         - --cfg builder=\"${builder}\"
@@ -40,7 +41,6 @@ contexts:
           CARGO_TARGET_DIR=${relroot}/${build-dir}/bin/${builder}/cargo
       BOARD: ${builder}
       PROFILE: release
-      riot_binary: ${app}
       QEMU_SYSTEM_ARM: >-
         qemu-system-arm
         -machine ${QEMU_MACHINE}
@@ -49,6 +49,7 @@ contexts:
         -semihosting-config enable=on,target=native
         -kernel
       PROBE_RS_PROTOCOL: swd
+      outfile: ${build-dir}/bin/${builder}/cargo/${RUSTC_TARGET}/${PROFILE}/${app}
 
     var_options:
       # this turns ${FEATURES} from a list to "--features=feature1,feature2"
@@ -66,10 +67,9 @@ contexts:
       - name: LINK
         description: CARGO ${out}
         pool: console
-        always: true
         cmd: >-
-          cd ${relpath} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} build --${PROFILE} ${FEATURES}
-          && cp ${relroot}/${build-dir}/bin/${builder}/cargo/${RUSTC_TARGET}/${PROFILE}/${riot_binary} ${relroot}/${out}
+          cd ${relpath} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} build --${PROFILE} ${FEATURES} && cd - && touch ${out}
+        gcc_deps: ${out}.d
 
       - name: GIT_DOWNLOAD
         cmd: "D=$$(dirname ${out}); rm -rf $$D && git clone ${url} $$D -n && git -C $$D reset --hard ${commit} && touch ${out}"
@@ -837,6 +837,18 @@ modules:
       global:
         FEATURES:
           - ariel-os/semihosting
+
+  - name: cargo-files
+    help: dependency that's stale if any cargo file changes
+    is_global_build_dep: true
+    sources:
+      - Cargo.toml
+    build:
+      cmd:
+        - scripts/all-cargo-files.rs Cargo.toml ${out}
+      gcc_deps: ${out}.d
+      out:
+        - ${build-dir}/cargo-files
 
 builders:
   # host builder (for housekeeping tasks)

--- a/scripts/all-cargo-files.rs
+++ b/scripts/all-cargo-files.rs
@@ -1,0 +1,63 @@
+#!/usr/bin/env -S cargo -Zscript
+---cargo
+[package]
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.92"
+argh = { version = "0.1.12" }
+camino = { version = "1.1.9", features = ["serde"] }
+cargo_toml = { version = "0.21.0", features = ["features"] }
+glob = "0.3.1"
+---
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+
+#[derive(argh::FromArgs, Debug)]
+/// Generate a list of Cargo.toml files belonging to a workspace
+struct Args {
+    #[argh(positional)]
+    /// path of the input Cargo.toml
+    manifest_path: Utf8PathBuf,
+    #[argh(positional)]
+    /// where to store the deps
+    output_file: Utf8PathBuf,
+}
+
+fn main() -> Result<()> {
+    let args: Args = argh::from_env();
+
+    let mut files = Vec::new();
+
+    let manifest_path = args.manifest_path;
+
+    let manifest = cargo_toml::Manifest::from_path(&manifest_path)?;
+
+    if let Some(workspace) = manifest.workspace {
+        for member in workspace.members {
+            let glob = format!("{}/Cargo.toml", member);
+            for entry in glob::glob(&glob)? {
+                let entry = entry.unwrap();
+                files.push(Utf8PathBuf::from_path_buf(entry).unwrap());
+            }
+        }
+    }
+
+    let mut depstr = String::new();
+
+    depstr.push_str(&format!("{}:", args.output_file.canonicalize_utf8().unwrap()));
+    for file in files {
+        depstr.push(' ');
+        depstr.push_str(file.canonicalize_utf8().unwrap().as_str());
+    }
+
+    std::fs::File::create(&args.output_file).unwrap();
+
+    let depfile = args.output_file.with_extension("d");
+    std::fs::write(depfile, &depstr).unwrap();
+    let depfile = args.output_file.with_extension("dd");
+    std::fs::write(depfile, &depstr).unwrap();
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

This PR makes use of some dependency trickery so we're able to drop the `always: true` from our cargo rule. This extracts Cargo's source file deps for each application crate, and additionally adds a script to get a list of all Cargo.toml in the workspace.

## Issues/PRs references

Depends on https://github.com/kaspar030/laze/pull/599 to be in the used laze release.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

- [ ] .config/cargo.toml
- [ ] test oot builds
- [ ] integrate into laze? or is the added rust script fast enough?

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
