### PR TITLE
feat(thread): define `CORE_COUNT` on single core as well

### DIFF
--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -88,8 +88,13 @@ pub const SCHED_PRIO_LEVELS: usize = 12;
 /// The maximum number of concurrent threads that can be created.
 pub const THREAD_COUNT: usize = 16;
 
-#[cfg(feature = "multi-core")]
-pub const CORE_COUNT: usize = smp::Chip::CORES as usize;
+pub const CORE_COUNT: usize = {
+    #[cfg(not(feature = "multi-core"))]
+    const CORE_COUNT: usize = 1;
+    #[cfg(feature = "multi-core")]
+    const CORE_COUNT: usize = smp::Chip::CORES as usize;
+    CORE_COUNT
+};
 #[cfg(feature = "multi-core")]
 pub const IDLE_THREAD_STACK_SIZE: usize = smp::Chip::IDLE_THREAD_STACK_SIZE;
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Previously `CORE_COUNT` was only defined on multicore, but given it's a just constant, I believe it makes sense to have it always defined.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #661.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
