### PR TITLE
fix(thread): seal `Arguable` so users cannot impl it

### DIFF
--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -522,11 +522,16 @@ pub unsafe fn start_threading() {
     Cpu::start_threading();
 }
 
+trait Sealed {}
+
 /// Trait for types that fit into a single register.
-pub trait Arguable {
+#[expect(private_bounds, reason = "sealed trait")]
+pub trait Arguable: Sealed {
     #[doc(hidden)]
     fn into_arg(self) -> usize;
 }
+
+impl Sealed for usize {}
 
 impl Arguable for usize {
     fn into_arg(self) -> usize {
@@ -534,11 +539,15 @@ impl Arguable for usize {
     }
 }
 
+impl Sealed for () {}
+
 impl Arguable for () {
     fn into_arg(self) -> usize {
         0
     }
 }
+
+impl<T> Sealed for &'static T {}
 
 /// [`Arguable`] is only implemented on *static* references because the references passed to a
 /// thread must be valid for its entire lifetime.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Otherwise users would be able to pass any type they want to functions that create threads (e.g., `thread_create`), which we cannot guarantee to be sound.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
