### PR TITLE
build(esp-boards): introduce laze contexts for ESP* HW modules

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -257,6 +257,12 @@ contexts:
       RUSTC_TARGET: xtensa-esp32-none-elf
       CARGO_TARGET_PREFIX: CARGO_TARGET_XTENSA_ESP32_NONE_ELF
 
+  - name: esp-wroom-32
+    parent: esp32
+    env:
+      RUSTFLAGS:
+        - --cfg context=\"esp-wroom-32\"
+
   - name: esp32c3
     parent: esp
     selects:
@@ -268,6 +274,12 @@ contexts:
       PROBE_RS_CHIP: esp32c3
       PROBE_RS_PROTOCOL: jtag
       CARGO_TARGET_PREFIX: CARGO_TARGET_RISCV32IMC_UNKNOWN_NONE_ELF
+
+  - name: esp-c3-01m
+    parent: esp32c3
+    env:
+      RUSTFLAGS:
+        - --cfg context=\"esp-c3-01m\"
 
   - name: esp32c6
     parent: esp
@@ -281,6 +293,12 @@ contexts:
       PROBE_RS_PROTOCOL: jtag
       CARGO_TARGET_PREFIX: CARGO_TARGET_RISCV32IMAC_UNKNOWN_NONE_ELF
 
+  - name: esp32-c6-wroom-1
+    parent: esp32c6
+    env:
+      RUSTFLAGS:
+        - --cfg context=\"esp32-c6-wroom-1\"
+
   - name: esp32s3
     parent: esp
     selects:
@@ -293,6 +311,12 @@ contexts:
       PROBE_RS_CHIP: esp32s3
       PROBE_RS_PROTOCOL: jtag
       CARGO_TARGET_PREFIX: CARGO_TARGET_XTENSA_ESP32S3_NONE_ELF
+
+  - name: esp32-s3-wroom-1
+    parent: esp32s3
+    env:
+      RUSTFLAGS:
+        - --cfg context=\"esp32-s3-wroom-1\"
 
   - name: stm32
     help: STM32 support (based on embassy-stm32)
@@ -996,16 +1020,16 @@ builders:
       BOARD: rpi-pico-w
 
   - name: ai-c3
-    parent: esp32c3
+    parent: esp-c3-01m
 
   - name: espressif-esp32-devkitc
-    parent: esp32
+    parent: esp-wroom-32
 
   - name: espressif-esp32-c6-devkitc-1
-    parent: esp32c6
+    parent: esp32-c6-wroom-1
 
   - name: espressif-esp32-s3-devkitc-1
-    parent: esp32s3
+    parent: esp32-s3-wroom-1
 
   - name: nrf5340dk
     parent: nrf5340


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This introduces intermediate laze contexts for ESP* *hardware modules* found on devkit boards. It's not concerned with renaming the *boards*.

---

I've went through existing usage of the esp* contexts, both in laze config files and Rust `#[cfg]` attributes, and I don't think any of these need to be updated to reference the modules instead of the board or MCU.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
