### PR TITLE
chore(manifests): remove version keys from tests and examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Check for leftover occurrences of the `authors` key in manifests
         run: set +e; grep -r '^authors\s*=' --line-number src examples tests; test $? -eq 1
 
+      - name: Forbid version keys in manifests of tests and examples
+        run: set +e; grep -r '^version\s*=\|^version\.workspace' --line-number examples tests; test $? -eq 1
+
       - id: get_toolchain
         run: echo "toolchain=$(scripts/rust-toolchain.sh)" >> $GITHUB_OUTPUT
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "bench_sched_flags"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "bench_sched_yield"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -669,7 +669,7 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "blinky"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "coap"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "coap-blinky"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "coap-client"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "coap-server"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "device-metadata"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2464,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "example-log"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "example-random"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2717,7 +2717,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gpio"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "gpio-interrupt-nrf"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "gpio-interrupt-stm32"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2903,7 +2903,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "hello-world-threading"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "http-server"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -2984,7 +2984,7 @@ checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "i2c-controller"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "minimal"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "spi-loopback"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "spi-main"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -4964,7 +4964,7 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tcp-echo"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5017,7 +5017,7 @@ dependencies = [
 
 [[package]]
 name = "tests_gpio"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "thread-async-interop"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "threading"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "threading-channel"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "threading-dynamic-prios"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "threading-event"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "threading-lock"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "threading-multicore"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "threading-mutex"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5275,7 +5275,7 @@ checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
 
 [[package]]
 name = "udp-echo"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "usb-keyboard"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "usb-serial"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",

--- a/examples/benchmark/Cargo.toml
+++ b/examples/benchmark/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "benchmark"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 

--- a/examples/blinky/Cargo.toml
+++ b/examples/blinky/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "blinky"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/coap-client/Cargo.toml
+++ b/examples/coap-client/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "coap-client"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/coap-server/Cargo.toml
+++ b/examples/coap-server/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "coap-server"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/device-metadata/Cargo.toml
+++ b/examples/device-metadata/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "device-metadata"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/gpio/Cargo.toml
+++ b/examples/gpio/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "gpio"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/hello-world-threading/Cargo.toml
+++ b/examples/hello-world-threading/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "hello-world-threading"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "hello-world"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/http-client/Cargo.toml
+++ b/examples/http-client/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "http-client"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/http-server/Cargo.toml
+++ b/examples/http-server/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "http-server"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "example-log"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "minimal"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 

--- a/examples/random/Cargo.toml
+++ b/examples/random/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "example-random"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/storage/Cargo.toml
+++ b/examples/storage/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "storage"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/tcp-echo/Cargo.toml
+++ b/examples/tcp-echo/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "tcp-echo"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "testing"
-version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/examples/thread-async-interop/Cargo.toml
+++ b/examples/thread-async-interop/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "thread-async-interop"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/threading-channel/Cargo.toml
+++ b/examples/threading-channel/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "threading-channel"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/threading-event/Cargo.toml
+++ b/examples/threading-event/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "threading-event"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/threading-multicore/Cargo.toml
+++ b/examples/threading-multicore/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "threading-multicore"
-version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/examples/threading/Cargo.toml
+++ b/examples/threading/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "threading"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/udp-echo/Cargo.toml
+++ b/examples/udp-echo/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "udp-echo"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/usb-keyboard/Cargo.toml
+++ b/examples/usb-keyboard/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "usb-keyboard"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/usb-serial/Cargo.toml
+++ b/examples/usb-serial/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "usb-serial"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/benchmarks/bench_sched_flags/Cargo.toml
+++ b/tests/benchmarks/bench_sched_flags/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "bench_sched_flags"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/benchmarks/bench_sched_yield/Cargo.toml
+++ b/tests/benchmarks/bench_sched_yield/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "bench_sched_yield"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/coap-blinky/Cargo.toml
+++ b/tests/coap-blinky/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "coap-blinky"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/coap/Cargo.toml
+++ b/tests/coap/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "coap"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/gpio-interrupt-nrf/Cargo.toml
+++ b/tests/gpio-interrupt-nrf/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "gpio-interrupt-nrf"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/gpio-interrupt-stm32/Cargo.toml
+++ b/tests/gpio-interrupt-stm32/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "gpio-interrupt-stm32"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/gpio/Cargo.toml
+++ b/tests/gpio/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "tests_gpio"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/i2c-controller/Cargo.toml
+++ b/tests/i2c-controller/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "i2c-controller"
-version.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/tests/spi-loopback/Cargo.toml
+++ b/tests/spi-loopback/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "spi-loopback"
-version.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/tests/spi-main/Cargo.toml
+++ b/tests/spi-main/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "spi-main"
-version.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/tests/threading-dynamic-prios/Cargo.toml
+++ b/tests/threading-dynamic-prios/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "threading-dynamic-prios"
-version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/tests/threading-lock/Cargo.toml
+++ b/tests/threading-lock/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "threading-lock"
-version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/tests/threading-mutex/Cargo.toml
+++ b/tests/threading-mutex/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "threading-mutex"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 publish = false


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The `version` key is not a required key anymore and these crates are not intended to be published.

[Documentation of the `version` key](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field)

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
