### PR TITLE
docs(rand): use `rand_core` instead of `rand` when possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2975,7 +2975,7 @@ dependencies = [
  "ariel-os",
  "ariel-os-boards",
  "heapless 0.8.0",
- "rand",
+ "rand_core",
  "reqwless",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ once_cell = { version = "=1.19.0", default-features = false, features = [
 ] }
 paste = { version = "1.0" }
 rand = { version = "0.8.5", default-features = false }
+rand_core = { version = "0.6.4", default-features = false }
 rtt-target = { version = "0.6.0" }
 
 rp-pac = { version = "7.0", default-features = false }

--- a/examples/http-client/Cargo.toml
+++ b/examples/http-client/Cargo.toml
@@ -17,7 +17,7 @@ ariel-os = { path = "../../src/ariel-os", features = [
 ] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 heapless = { workspace = true }
-rand = { workspace = true }
+rand_core = { workspace = true }
 reqwless = { version = "0.13.0", default-features = true, features = [
   "embedded-tls",
 ] }

--- a/examples/http-client/src/main.rs
+++ b/examples/http-client/src/main.rs
@@ -47,7 +47,7 @@ async fn main() {
     let tcp_client = TcpClient::new(stack, &tcp_client_state);
     let dns_client = DnsSocket::new(stack);
 
-    let tls_seed: u64 = rand::Rng::gen(&mut ariel_os::random::crypto_rng());
+    let tls_seed: u64 = rand_core::RngCore::next_u64(&mut ariel_os::random::crypto_rng());
 
     let mut tls_rx_buffer = [0; TLS_READ_BUFFER_SIZE];
     let mut tls_tx_buffer = [0; TLS_WRITE_BUFFER_SIZE];

--- a/src/ariel-os-random/Cargo.toml
+++ b/src/ariel-os-random/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-rand_core = "0.6.4"
+rand_core = { workspace = true }
 
 embassy-sync.workspace = true
 

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 coap-handler = "0.2.0"
 coap-message = "0.3.2"
 lakers = { version = "0.7.2", default-features = false }
-rand_core = "0.6.4"
+rand_core = { workspace = true }
 
 # private
 arrayvec = { version = "0.7.4", default-features = false }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Following the [policy change/clarification of `rand`](https://github.com/rust-random/rand/blob/master/CHANGELOG.md#security-and-unsafe) regarding whether it is a "crypto library", this makes sure to use `rand_core` instead of `rand` to reduce the moving pieces where possible.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
