### PR TITLE
ci(commited): restrict the subject length to a more conventional length

### DIFF
--- a/committed.toml
+++ b/committed.toml
@@ -1,6 +1,6 @@
 style = "conventional"
 ignore_author_re = "(dependabot|renovate)"
-subject_length = 80
+subject_length = 72
 line_length = 80
 subject_capitalized = false
 allowed_types = [


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This is also the length after which GitHub starts eliding the subject line.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
