### PR TITLE
docs(coap): fix `coap_run()` and polish `coap-server` docs

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -777,7 +777,7 @@ modules:
   - name: coap-server
     help: Support for applications to set up CoAP server handlers.
 
-      When an application selects this, it needs to run `ariel_os::coap_run()`
+      When an application selects this, it needs to run `ariel_os::coap::coap_run()`
       in a task; otherwise, other components (eg. system components that also
       run on the CoAP server, or the CoAP client that depends on the server
       loop to run) get stalled.

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -62,7 +62,14 @@ mod demo_setup {
 
 /// Runs a CoAP server with the given handler on the system's CoAP transports.
 ///
-/// As the CoAP stack gets ready, it also unblocks [`coap_client`].
+/// # Note
+///
+/// The application needs to run this in a task; otherwise, other components (e.g., system
+/// components that also run on the CoAP server, or the CoAP client that depends on the server
+/// loop to run) get stalled.
+///
+/// As the CoAP stack gets ready (which may take some time if the network is not ready yet), it also
+/// unblocks [`coap_client()`].
 ///
 /// # Panics
 ///
@@ -168,7 +175,7 @@ async fn coap_run_impl(handler: impl coap_handler::Handler + coap_handler::Repor
 
 /// Returns a CoAP client requester.
 ///
-/// This asynchronously blocks until [`coap_run`] has been called (which happens at startup
+/// This asynchronously blocks until [`coap_run()`] has been called (which happens at startup
 /// when the corresponding feature `coap-server` is not active), and the CoAP stack is operational.
 ///
 /// # Panics

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -59,12 +59,8 @@ dns = ["ariel-os-embassy/dns"]
 mdns = ["ariel-os-embassy/mdns"]
 ## Enables support for [CoAP](https://ariel-os.github.io/ariel-os/dev/docs/book/tooling/coap.html).
 coap = ["dep:ariel-os-coap", "random"]
-## Support for applications to set up CoAP server handlers.
-##
-## When an application selects this, it needs to run `ariel_os::coap_run()`
-## in a task; otherwise, other components (eg. system components that also
-## run on the CoAP server, or the CoAP client that depends on the server
-## loop to run) get stalled.
+## Enables applications to set up CoAP server handlers.
+## See [`coap::coap_run()`].
 coap-server = ["coap", "ariel-os-coap/coap-server"]
 ## Selects static IP configuration.
 network-config-static = ["ariel-os-embassy/network-config-static"]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Follow-up to #755.
This fixes the path to `coap_run()` and moves the note about it into the function documentation so as to keep the Cargo feature description down to one line.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
