### PR TITLE
chore(runqueue): add `must_use` where relevant

### DIFF
--- a/src/ariel-os-runqueue/src/runqueue.rs
+++ b/src/ariel-os-runqueue/src/runqueue.rs
@@ -13,6 +13,7 @@ const USIZE_BITS: usize = mem::size_of::<usize>() * 8;
 pub struct RunqueueId(u8);
 
 impl RunqueueId {
+    #[must_use]
     pub const fn new(value: u8) -> Self {
         Self(value)
     }
@@ -29,6 +30,7 @@ impl From<RunqueueId> for usize {
 pub struct ThreadId(u8);
 
 impl ThreadId {
+    #[must_use]
     pub const fn new(value: u8) -> Self {
         Self(value)
     }
@@ -62,6 +64,7 @@ pub struct RunQueue<const N_QUEUES: usize, const N_THREADS: usize> {
 }
 
 impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_THREADS }> {
+    #[must_use]
     pub const fn new() -> RunQueue<{ N_QUEUES }, { N_THREADS }> {
         // unfortunately we cannot assert!() on N_QUEUES and N_THREADS,
         // as panics in const fn's are not (yet) implemented.
@@ -112,11 +115,13 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
     ///
     /// Returns the next runnable thread of
     /// the runqueue with the highest index.
+    #[must_use]
     pub fn get_next(&self) -> Option<ThreadId> {
         self.get_next_with_rq().map(|(tid, _)| tid)
     }
 
     /// Returns the tid that should run next and the runqueue it is in.
+    #[must_use]
     pub fn get_next_with_rq(&self) -> Option<(ThreadId, RunqueueId)> {
         let rq_ffs = ffs(self.bitcache);
         if rq_ffs == 0 {
@@ -177,6 +182,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
     /// Returns an iterator over the [`RunQueue`], starting after thread `start` in runqueue `rq`.
     ///
     /// The `start` is not included in the iterator.
+    #[must_use]
     pub fn iter_from(&self, start: ThreadId, rq: RunqueueId) -> RunQueueIter<N_QUEUES, N_THREADS> {
         RunQueueIter {
             prev: start.0,


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Add missing `must_use` attributes to runqueue functions.
See [the reference](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute) for more information about this attribute and maybe the [std developer guide](https://std-dev-guide.rust-lang.org/policy/must-use.html) for some additional guidelines.

Note that, even though the [`unused-must-use`](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-must-use) is warn-by-default, we do enforce it at workspace level:

https://github.com/ariel-os/ariel-os/blob/7e240c47e46cb5ce3cd79992ae4d22e2289eb363/Cargo.toml#L154

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This is to prepare updating #279.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
