### PR TITLE
chore(rt): remove outdated ESP-specific features

### DIFF
--- a/src/ariel-os-boards/ai-c3/Cargo.toml
+++ b/src/ariel-os-boards/ai-c3/Cargo.toml
@@ -5,5 +5,5 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-ariel-os-rt = { workspace = true, features = ["_esp32c3"] }
+ariel-os-rt = { workspace = true }
 ariel-os-debug.workspace = true

--- a/src/ariel-os-boards/espressif-esp32-c6-devkitc-1/Cargo.toml
+++ b/src/ariel-os-boards/espressif-esp32-c6-devkitc-1/Cargo.toml
@@ -5,5 +5,5 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-ariel-os-rt = { workspace = true, features = ["_esp32c6"] }
+ariel-os-rt = { workspace = true }
 ariel-os-debug.workspace = true

--- a/src/ariel-os-boards/espressif-esp32-devkitc/Cargo.toml
+++ b/src/ariel-os-boards/espressif-esp32-devkitc/Cargo.toml
@@ -5,5 +5,5 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-ariel-os-rt = { workspace = true, features = ["_esp32"] }
+ariel-os-rt = { workspace = true }
 ariel-os-debug = { workspace = true }

--- a/src/ariel-os-boards/espressif-esp32-s3-devkitc-1/Cargo.toml
+++ b/src/ariel-os-boards/espressif-esp32-s3-devkitc-1/Cargo.toml
@@ -5,5 +5,5 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-ariel-os-rt = { workspace = true, features = ["_esp32s3"] }
+ariel-os-rt = { workspace = true }
 ariel-os-debug.workspace = true

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -46,11 +46,3 @@ panic-printing = []
 _panic-handler = []
 single-core = ["cortex-m/critical-section-single-core"]
 multi-core = ["embassy-rp/critical-section-impl"]
-
-# internal
-# These features are used by `build.rs`, which doesn't "see" context
-# variables.
-_esp32 = []
-_esp32c3 = []
-_esp32c6 = []
-_esp32s3 = []


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Removes ESP-specific features which do not seem to be needed anymore.
These were introduced in [#181 (`Cargo.toml`)](https://github.com/ariel-os/ariel-os/pull/181/files#diff-607098e7c7df838cfd2203385125b0d69c973346fa19b519289bd73dc51b1068) and are unneeded since [#399 (`build.rs`)](https://github.com/ariel-os/ariel-os/pull/399/files#diff-f829c93c311d58f25382752534aa7c3d744823f3efd26d62553beb96cc7220ed).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
