### PR TITLE
fix(laze): provide the `hw/device-identity` capability

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -22,6 +22,7 @@ contexts:
     selects:
       - executor-default
       - ?critical-section
+      - ?hw/device-identity
       - ?lto
       - ?semihosting
     env:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Because no other modules were actually selecting this module, the capability was never exposed, as can be seen by enabling verbose mode of `laze build` with `-v`

Successfully tested:

- `device-metadata` on nrf52840dk, rpi-pico-w, espressif-esp32-c6-devkitc-1, and st-nucleo-wb55
- `ariel-os-identity` tests on nrf52840dk, rpi-pico-w, espressif-esp32-c6-devkitc-1, and st-nucleo-wb55

@kaspar030 Is there a better way of making sure this module is enabled when available?

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
