### PR TITLE
chore(clippy): remove upstreamed `doc-valid-idents`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
 # Require SAFETY docs, as well as a few other lints, for private items
 check-private-items = true
 
-doc-valid-idents = ["CoAP", "MHz", "GHz", "THz", "STMicroelectronics", ".."]
+doc-valid-idents = ["STMicroelectronics", ".."]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
We've upstreamed these and they have [landed in Clippy 1.84](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#enhancements-1).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Follows #861, which bumped the toolchain.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
