### PR TITLE
fix(boards): replace println with debug

### DIFF
--- a/src/ariel-os-boards/espressif-esp32-devkitc/src/lib.rs
+++ b/src/ariel-os-boards/espressif-esp32-devkitc/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use ariel_os_debug::println;
+use ariel_os_debug::log::debug;
 
 pub fn init() {
-    println!("espressif-esp32-devkitc::init()");
+    debug!("espressif-esp32-devkitc::init()");
 }

--- a/src/ariel-os-boards/st-nucleo-f401re/src/lib.rs
+++ b/src/ariel-os-boards/st-nucleo-f401re/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
 
 pub fn init() {
-    ariel_os_debug::println!("boards::st-nucleo-f401re::init()");
+    ariel_os_debug::log::debug!("boards::st-nucleo-f401re::init()");
 }

--- a/src/ariel-os-boards/st-nucleo-h755zi-q/src/lib.rs
+++ b/src/ariel-os-boards/st-nucleo-h755zi-q/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use ariel_os_debug::println;
+use ariel_os_debug::log::debug;
 
 pub fn init() {
-    println!("st-nucleo-h755zi-q::init()");
+    debug!("st-nucleo-h755zi-q::init()");
 }

--- a/src/ariel-os-boards/st-nucleo-wb55/src/lib.rs
+++ b/src/ariel-os-boards/st-nucleo-wb55/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
 
 pub fn init() {
-    ariel_os_debug::println!("boards::st-nucleo-wb55::init()");
+    ariel_os_debug::log::debug!("boards::st-nucleo-wb55::init()");
 }

--- a/src/ariel-os-boards/st-nucleo-wba55/src/lib.rs
+++ b/src/ariel-os-boards/st-nucleo-wba55/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
 
 pub fn init() {
-    ariel_os_debug::println!("boards::st-nucleo-wba55::init()");
+    ariel_os_debug::log::debug!("boards::st-nucleo-wba55::init()");
 }


### PR DESCRIPTION
# Description

A fix in probe-rs (https://github.com/probe-rs/probe-rs/pull/3140) shows both terminal and defmt data -- which showed me on stm32wb55 that there's a bit of both being printed.

AIU, we generally switched to send all library output to go through the log facade, so this should just be missing snips from that. (That is *all* println from src/ariel-os* that is not in build.rs, debug or tests).

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.