### PR TITLE
refactor(laze): introduce `cortex-m*` modules

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -181,7 +181,7 @@ contexts:
   - name: nrf51
     parent: nrf
     selects:
-      - thumbv6m-none-eabi
+      - cortex-m0
 
   - name: bbc-microbit-base
     # this is a context, not a builder, to be used as parent by  "bbc-microbit" and
@@ -195,8 +195,6 @@ contexts:
 
   - name: nrf52
     parent: nrf
-    selects:
-      - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
     env:
       CARGO_RUNNER:
         - ${SCRIPTS}/debug-openocd.sh
@@ -205,26 +203,32 @@ contexts:
 
   - name: nrf52832
     parent: nrf52
+    selects:
+      - cortex-m4f
     env:
       PROBE_RS_CHIP: nrf52832_xxAA
 
   - name: nrf52833
     parent: nrf52
+    selects:
+      - cortex-m4f
     env:
       PROBE_RS_CHIP: nrf52833_xxAA
 
   - name: nrf52840
     parent: nrf52
+    selects:
+      - cortex-m4f
     env:
       PROBE_RS_CHIP: nrf52840_xxAA
 
   - name: nrf53
     parent: nrf
-    selects:
-      - thumbv8m.main-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
 
   - name: nrf5340
     parent: nrf53
+    selects:
+      - cortex-m33f
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
 
@@ -237,8 +241,9 @@ contexts:
   - name: rp2040
     parent: rp
     selects:
+      # This module must stay before `cortex-m0-plus` to keep correct linker settings order.
       - rp-link-arg
-      - thumbv6m-none-eabi
+      - cortex-m0-plus
       - ?probe-rs
     env:
       PROBE_RS_CHIP: RP2040
@@ -254,7 +259,7 @@ contexts:
   - name: rp235xa
     parent: rp
     selects:
-      - thumbv8m.main-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+      - cortex-m33f
       - ?probe-rs
     env:
       PROBE_RS_CHIP: RP235x
@@ -349,7 +354,7 @@ contexts:
   - name: stm32f401retx
     parent: stm32
     selects:
-      - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+      - cortex-m4f
     provides:
       - has_swi
     env:
@@ -364,7 +369,8 @@ contexts:
   - name: stm32h755zitx
     parent: stm32
     selects:
-      - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+      # TODO: also has a cortex-m4f
+      - cortex-m7f
     provides:
       - has_swi
     env:
@@ -381,7 +387,7 @@ contexts:
   - name: stm32wb55rgvx
     parent: stm32
     selects:
-      - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+      - cortex-m4f
     provides:
       - has_swi
     env:
@@ -397,7 +403,7 @@ contexts:
   - name: stm32wba55cgux
     parent: stm32
     selects:
-      - thumbv8m.main-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+      - cortex-m33f
     provides:
       - has_swi
     env:
@@ -411,8 +417,6 @@ contexts:
 
 modules:
   - name: thumbv6m-none-eabi
-    selects:
-      - cortex-m
     env:
       global:
         RUSTC_TARGET: thumbv6m-none-eabi
@@ -421,8 +425,6 @@ modules:
           - --cfg armv6m
 
   - name: thumbv7m-none-eabi
-    selects:
-      - cortex-m
     env:
       global:
         RUSTC_TARGET: thumbv7m-none-eabi
@@ -431,8 +433,6 @@ modules:
           - --cfg armv7m
 
   - name: thumbv7em-none-eabi
-    selects:
-      - cortex-m
     env:
       global:
         RUSTC_TARGET: thumbv7em-none-eabi
@@ -441,8 +441,6 @@ modules:
           - --cfg armv7m
 
   - name: thumbv7em-none-eabihf
-    selects:
-      - cortex-m
     env:
       global:
         RUSTC_TARGET: thumbv7em-none-eabihf
@@ -451,8 +449,6 @@ modules:
           - --cfg armv7m
 
   - name: thumbv8m.main-none-eabi
-    selects:
-      - cortex-m
     env:
       global:
         RUSTC_TARGET: thumbv8m.main-none-eabi
@@ -461,8 +457,6 @@ modules:
           - --cfg armv8m
 
   - name: thumbv8m.main-none-eabihf
-    selects:
-      - cortex-m
     env:
       global:
         RUSTC_TARGET: thumbv8m.main-none-eabihf
@@ -485,6 +479,36 @@ modules:
           - -Clink-arg=-Tkeep-stack-sizes.x
           - --cfg context=\"cortex-m\"
           - -Z emit-stack-sizes
+
+  - name: cortex-m0
+    selects:
+      - cortex-m
+      - thumbv6m-none-eabi
+
+  - name: cortex-m0-plus
+    selects:
+      - cortex-m
+      - thumbv6m-none-eabi
+
+  - name: cortex-m4
+    selects:
+      - cortex-m
+      - thumbv7em-none-eabi
+
+  - name: cortex-m4f
+    selects:
+      - cortex-m
+      - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+
+  - name: cortex-m7f
+    selects:
+      - cortex-m
+      - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+
+  - name: cortex-m33f
+    selects:
+      - cortex-m
+      - thumbv8m.main-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
 
   - name: xtensa
     env:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This introduces new `cortex-m*` modules: this makes it a little bit easier to add support for new Arm-based MCUs, as datasheets often mention the Cortex-M variant of the processor, not directly the ISA it implements. This could also make it a bit simpler to model FPU support later.
In addition, this fixes the relationship between the `cortex-m` module and the `thumbv*` modules: the ISA modules should be "parents" of the processor implementation, not the other way around.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #881.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
