### PR TITLE
docs(hwrng): fix the support matrix to reflect the current state

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -82,7 +82,7 @@ chips:
     support:
       gpio: supported
       debug_output: supported
-      hwrng: supported
+      hwrng: not_currently_supported
       i2c_controller: supported
       spi_main: supported
       logging: supported


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This updates the support matrix to reflect that the HWRNG is not currently supported.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
