### PR TITLE
refactor(laze): make the flash driver selection more generic

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -331,6 +331,8 @@ contexts:
     env:
       PROBE_RS_CHIP: STM32F401RETx
       PROBE_RS_PROTOCOL: swd
+      RUSTFLAGS:
+        - --cfg capability=\"async-flash-driver\"
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=USART2

--- a/src/ariel-os-stm32/src/storage.rs
+++ b/src/ariel-os-stm32/src/storage.rs
@@ -3,22 +3,22 @@
 
 use embassy_stm32::flash;
 
-#[cfg(context = "stm32f401retx")]
+#[cfg(capability = "async-flash-driver")]
 embassy_stm32::bind_interrupts!(struct Irqs {
     FLASH => flash::InterruptHandler;
 });
 
-#[cfg(context = "stm32f401retx")]
+#[cfg(capability = "async-flash-driver")]
 pub type Flash = flash::Flash<'static>;
-#[cfg(any(context = "stm32h755zitx", context = "stm32wb55rgvx",))]
+#[cfg(not(capability = "async-flash-driver"))]
 pub type Flash =
     embassy_embedded_hal::adapter::BlockingAsync<flash::Flash<'static, flash::Blocking>>;
 pub type FlashError = flash::Error;
 
 pub fn init(peripherals: &mut crate::OptionalPeripherals) -> Flash {
-    #[cfg(context = "stm32f401retx")]
+    #[cfg(capability = "async-flash-driver")]
     let flash = flash::Flash::new(peripherals.FLASH.take().unwrap(), Irqs);
-    #[cfg(any(context = "stm32h755zitx", context = "stm32wb55rgvx",))]
+    #[cfg(not(capability = "async-flash-driver"))]
     let flash = embassy_embedded_hal::adapter::BlockingAsync::new(flash::Flash::new_blocking(
         peripherals.FLASH.take().unwrap(),
     ));


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This introduces a capability (`sw/async-flash-driver`) representing whether to use the async-capable flash driver when available.
Even though this is currently only used in the STM32 HAL, the capability is not prefixed with `stm32` unlike other similar capabilities because:

- This concern is not STM32-specific unlike these similar capabilities (`stm32-usb`/`stm32-usb-synopsys` and `stm32-rng`/`stm32-hash-rng`), and could be used on other HALs if needed.
- It also acts as user configuration, because Embassy provides a blocking flash driver on all STM32 MCUs, so this "capability" actually is optional and only opts into using the (optional) *async* flash driver. Therefore this capability would be a candidate for user documentation, but this is not done in this PR because we don't want to commit to using laze capabilities for this just yet.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Follow-up to #772.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
