### PR TITLE
refactor!: lower stacksize defaults to 1KiB for ISRs, 3KiB for executor

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -63,9 +63,9 @@ contexts:
         # These defines the defaults. Other modules can append their needs,
         # the maximum value will be chosen.
         # Note: make sure to append to the list, not set single value!
-        - "8192"
+        - "3072"
       isr_stacksize_required:
-        - "2048"
+        - "1024"
       CONFIG_EXECUTOR_STACKSIZE: $(max (0, ${executor_stacksize_required}))
       CONFIG_ISR_STACKSIZE: $(max (0, ${isr_stacksize_required}))
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This lowers the stacksize defaults, looking at #838.

## Issues/PRs references

Required by #838.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

This needs proper testing at lease on all platforms unfortunately, for all examples and tests that don't already increase the stacksizes. And, test with defmt and log, isr executor and stack executor.

- [ ] nrf52xxx
- [ ] rpi-pico
- [ ] esp32
- [ ] esp32s3
- [ ] esp32c3
- [ ] esp32c6
- [ ] stm32

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
