### PR TITLE
fix(laze): Remove unsupported targets from context of coap-blinky test

### DIFF
--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -4,15 +4,12 @@ apps:
       - coap-server
       - ?coap-server-config-demokeys
     context:
-      # list of contexts that have an entry in `pins.rs`
-      - bbc-microbit-v2
       - esp
       - nrf52840dk
       - nrf5340dk
       - nrf9160dk-nrf9160
       - particle-xenon
       - rp
-      - st-nucleo-f401re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
       - stm32u083c-dk


### PR DESCRIPTION
# Description
Remove targets from the `coap-blinky` laze context that currently do not compile.

E.g. for `st-nucleo-f401re` I got:

```bash
 0: "coap-blinky" cannot resolve "coap-server"
    1: "coap-server" cannot resolve "coap"
    2: "coap" cannot resolve "random"
    3: "random" cannot resolve "hwrng"
    4: "hwrng" cannot resolve "has_hwrng"
    5: "has_hwrng" cannot resolve "doc-only"
    6: module "doc-only" not found
```

And for `stm32u083c-dk`

```bash
 0: "coap-blinky" cannot resolve "coap-server"
    1: "coap-server" cannot resolve "coap"
    2: "coap" cannot resolve "network"
```