### PR TITLE
fix(laze): model bloat's requirement for nightly in laze

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -143,6 +143,8 @@ contexts:
         workdir: ${appdir}
         cmd:
           - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} expand ${FEATURES}
+        required_modules:
+          - nightly
 
       debug:
         workdir: ${appdir}
@@ -162,6 +164,8 @@ contexts:
         cmd:
           - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} bloat --${PROFILE} ${FEATURES}
         build: false
+        required_modules:
+          - nightly
 
       tree:
         workdir: ${appdir}


### PR DESCRIPTION
# Description

On main, running bloat gives an error:

```
$ laze build -C examples/device-metadata -b st-nucleo-wb55 -v bloat
[...]
Error: warning: please specify `--format-version` flag explicitly to avoid compatibility problems
    Updating crates.io index
error: failed to select a version for `embassy-rp`.
    ... required by package `ariel-os-threads v0.1.0 (/home/chrysn/git/crates/ariel-os/src/ariel-os-threads)`
    ... which satisfies path dependency `ariel-os-threads` (locked to 0.1.0) of package `ariel-os v0.1.0 (/home/chrysn/git/crates/ariel-os/src/ariel-os)`
    ... which satisfies path dependency `ariel-os` (locked to 0.1.0) of package `example-alloc v0.0.0 (/home/chrysn/git/crates/ariel-os/examples/alloc)`
versions that meet the requirements `^0.4` are: 0.4.0

the package `ariel-os-threads` depends on `embassy-rp`, with features: `fifo-handler` but `embassy-rp` does not have these features.


failed to select a version for `embassy-rp` which could resolve this conflict.
```

## Issues/PRs references

This probably came became more apparent with #987 but has been there ever since running on nightly is not a given any more.

## Open Questions

* [ ] Can we do better and run it on stable? Maybe, but that's for another PR, unless that is super easy to fix.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
