### PR TITLE
fix: remove defmt'isms

### DIFF
--- a/examples/http-client/src/main.rs
+++ b/examples/http-client/src/main.rs
@@ -63,7 +63,7 @@ async fn main() {
     if let Err(err) = send_http_get_request(&mut client, ENDPOINT_URL).await {
         error!(
             "Error while sending an HTTP request: {:?}",
-            defmt::Debug2Format(&err)
+            Debug2Format(&err)
         );
     }
 

--- a/examples/storage/src/main.rs
+++ b/examples/storage/src/main.rs
@@ -4,7 +4,7 @@
 
 use ariel_os::debug::{
     ExitCode, exit,
-    log::{Hex, defmt, info},
+    log::{Debug2Format, Hex, info},
 };
 
 // Imports for using [`ariel_os::storage`]
@@ -14,7 +14,9 @@ use serde::{Deserialize, Serialize};
 /// Example object.
 ///
 /// The serde Serialize / Deserialize traits are required for storage
-#[derive(Serialize, Deserialize, Debug, defmt::Format)]
+#[derive(Serialize, Deserialize, Debug)]
+// FIXME: How should a user's application that may or may not run on defmt but has a custom type
+// such as this derive Format?
 struct MyConfig {
     val_one: heapless::String<64>,
     val_two: u64,
@@ -83,14 +85,14 @@ async fn main() {
         val_one: heapless::String::<64>::try_from("some value").unwrap(),
         val_two: 99,
     };
-    info!("Storing cfg object {:?} as struct", cfg);
+    info!("Storing cfg object {:?} as struct", Debug2Format(&cfg));
     storage::insert("my_config", cfg).await.unwrap();
 
     // Getting an object
     // Type used for `get()` needs to match what was used for `insert()`.
     let cfg: Option<MyConfig> = storage::get("my_config").await.unwrap();
     if let Some(cfg) = cfg {
-        info!("got cfg object: {:?}", cfg);
+        info!("got cfg object: {:?}", Debug2Format(&cfg));
     }
 
     // Getting a value as raw bytes probably does not return what you want due

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -37,13 +37,38 @@ pub mod defmt {
     pub use defmt::{Formatter, Str, export, unreachable};
 }
 
+#[cfg(feature = "defmt")]
+pub use defmt::{Debug2Format, Display2Format};
+
 #[cfg(feature = "log")]
 #[doc(hidden)]
 pub mod log {
     // Re-export only the minimum set of items to minimize breaking changes in case `log`
     // adds/removes any items.
     pub use log::{debug, error, info, trace, warn};
+
+    /// Pass-through wrapper for the [`Debug`][core::fmt::Debug] trait that shims the like-named
+    /// type of `defmt`.
+    pub struct Debug2Format<T: core::fmt::Debug>(pub T);
+    /// Pass-through wrapper for the [`Display`][core::fmt::Display] trait that shims the
+    /// like-named type of `defmt`.
+    pub struct Display2Format<T: core::fmt::Display>(pub T);
+
+    impl<T: core::fmt::Debug> core::fmt::Debug for Debug2Format<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            core::fmt::Debug::fmt(&self.0, f)
+        }
+    }
+
+    impl<T: core::fmt::Display> core::fmt::Display for Display2Format<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            core::fmt::Display::fmt(&self.0, f)
+        }
+    }
 }
+
+#[cfg(feature = "log")]
+pub use log::{Debug2Format, Display2Format};
 
 // NOTE: log macros are defined within private modules so that `doc_auto_cfg` does not produce
 // "feature flairs" on them.


### PR DESCRIPTION
# Description

After #972, there were still examples left of defmt'isms -- just not in the format strings any more, but around them where #972 doesn't catch it.

## Testing

`laze build -g -b st-nucleo-wb55 -D LOG=debug -s log -d defmt`

(Or let's finally add support for boards where the default logging facade is not through defmt, or let's admit that defmt is the way to go and that even serial-out devices will produce defmt there.)

## Issues/PRs references

<del>Blocked by: #972 (so please just view the top 3 commits)</del>

## Open Questions

* [ ] The fix for the storage example is not pretty -- what *are* applications that desire to be portable but want to debug custom types supposed to do? Once more, I recommend we just make defmt a dependency (esp. now that it has a 1.0), and derive Format unconditionally, rather than having ifdef hell. Just b/c it's a dependency and we derive Format doesn't mean we have to emit any of its code.

  Depending on the outcome of this, we may want to pub use Format in the log module unconditionally top-level, and if they're transparent -- and then we can also drop my new types and just pub use defmt's, because they are already suitably transparent.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
