### PR TITLE
feat(log): make defmt re-exports available unconditionally

### DIFF
--- a/src/ariel-os-debug-log/Cargo.toml
+++ b/src/ariel-os-debug-log/Cargo.toml
@@ -12,13 +12,13 @@ workspace = true
 logging-facade.xor = { features = ["defmt", "log"] }
 
 [dependencies]
-defmt = { workspace = true, optional = true }
+defmt = { workspace = true }
 featurecomb = { workspace = true }
 log = { workspace = true, optional = true }
 
 [features]
 ## Enables `defmt` as logging facade.
-defmt = ["dep:defmt"]
+defmt = []
 ## Enables `log` as logging facade.
 log = ["dep:log"]
 

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -18,24 +18,14 @@
 #[featurecomb::comb]
 mod _featurecomb {}
 
-#[cfg(feature = "defmt")]
-pub mod defmt {
-    //! Selected [`defmt`] items.
+/// These re-exports can be used to satisfy the requirements of the `info!` and similar macros,
+/// either by deriving [`Format`] on your own data structures, or by falling back to [`Debug2Format`]
+/// or [`Display2Format`] to show third party data structures that do not have [`Format`] derived.
+pub use defmt::{Debug2Format, Display2Format, Format};
 
-    // This module is hidden in the docs, but would still be imported by a wildcard import of this
-    // crate's items.
-    #[doc(hidden)]
-    pub mod hidden {
-        // Required so the macros can access it.
-        #[doc(hidden)]
-        pub use defmt;
-    }
-
-    pub use defmt::{Debug2Format, Display2Format, Format};
-
-    // These are required "internally" by `defmt`.
-    pub use defmt::{Formatter, Str, export, unreachable};
-}
+/// This pub reexport is needed in addition to [`Format`] above because the generated
+/// implementation needs to have access to a `defmt` module.
+pub use defmt;
 
 #[cfg(feature = "log")]
 #[doc(hidden)]
@@ -58,7 +48,7 @@ mod log_macros {
     #[macro_export]
     macro_rules! trace {
         ($($arg:tt)*) => {{
-            use $crate::defmt::hidden::defmt;
+            use $crate::defmt;
             if true {
                 defmt::trace!($($arg)*);
             } else {
@@ -71,7 +61,7 @@ mod log_macros {
     #[macro_export]
     macro_rules! debug {
         ($($arg:tt)*) => {{
-            use $crate::defmt::hidden::defmt;
+            use $crate::defmt;
             if true {
                 defmt::debug!($($arg)*);
             } else {
@@ -84,7 +74,7 @@ mod log_macros {
     #[macro_export]
     macro_rules! info {
         ($($arg:tt)*) => {{
-            use $crate::defmt::hidden::defmt;
+            use $crate::defmt;
             if true {
                 defmt::info!($($arg)*);
             } else {
@@ -97,7 +87,7 @@ mod log_macros {
     #[macro_export]
     macro_rules! warn {
         ($($arg:tt)*) => {{
-            use $crate::defmt::hidden::defmt;
+            use $crate::defmt;
             if true {
                 defmt::warn!($($arg)*);
             } else {
@@ -110,7 +100,7 @@ mod log_macros {
     #[macro_export]
     macro_rules! error {
         ($($arg:tt)*) => {{
-            use $crate::defmt::hidden::defmt;
+            use $crate::defmt;
             if true {
                 defmt::error!($($arg)*);
             } else {


### PR DESCRIPTION
# Description

As discussed in today's weekly, let's go a step more toward defmt -- user applications that want to be portable and log any own data structure already need to depend on defmt to derive Format on it, and it's 1.0 now, and it allows us to get rid of a lot of "ifdef hell".

## Issues/PRs references

Replaces https://github.com/ariel-os/ariel-os/pull/1022 (that'd would have added workarounds)

## Open Questions

* [ ] Will it build? (It's a whack-a-mole right now)
* [ ] Did I file all cases right into "this upstream module does an own defmt-or-log and thus needs to know" vs "this upstream module provides defmt impls and thus will get defmt set all the time"? (Really we should set it anyway -- unless they do defmt-or-log in a non-additive way: logging to defmt without the logging turned on should be no-ops).

## Change checklist

- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
