### PR TITLE
ci: split out `cargo fetch`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,12 @@ jobs:
         run: |
           echo "LAZE_BUILDERS=ai-c3,espressif-esp32-devkitc,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-devkitc-1,bbc-microbit-v2,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-c031c6,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"
 
+      - name: "cargo fetch"
+        if: steps.result-cache.outputs.cache-hit != 'true'
+        run: |
+            cargo fetch --config ariel-os-cargo.toml --locked
+            echo "CARGO_NET_OFFLINE=true" >> "$GITHUB_ENV"
+
       - name: "ariel-os compilation test (default toolchain)"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,8 @@ jobs:
       - name: "cargo fetch"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
-            cargo fetch --config ariel-os-cargo.toml --locked
+            cargo fetch --config ariel-os-cargo.toml
+            cargo fetch --config ariel-os-cargo.toml --target xtensa-esp32-none-elf
             echo "CARGO_NET_OFFLINE=true" >> "$GITHUB_ENV"
 
       - name: "ariel-os compilation test (default toolchain)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
             cargo fetch --config ariel-os-cargo.toml
-            cargo fetch --config ariel-os-cargo.toml --target xtensa-esp32-none-elf
+            cargo +esp fetch --config ariel-os-cargo.toml --target xtensa-esp32-none-elf
             echo "CARGO_NET_OFFLINE=true" >> "$GITHUB_ENV"
 
       - name: "ariel-os compilation test (default toolchain)"


### PR DESCRIPTION
# Description

For the CI build workflow, split out `cargo fetch` and make the following `cargo` calls use offline mode.

## Issues/PRs references

#1036 but only for CI.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
