### PR TITLE
feat(nrf): Add basic support for nrf5340 network core

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -259,12 +259,22 @@ contexts:
 
   - name: nrf5340
     parent: nrf53
-    provides:
-      - has_storage_support
     selects:
       - cortex-m33f
+    provides:
+      - has_storage_support
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
+
+  - name: nrf5340-net
+    parent: nrf53
+    selects:
+      - cortex-m33
+    provides:
+      - has_storage_support
+    env:
+      PROBE_RS_CHIP: nrf5340_xxAA
+    help: nRF5340 Network Core support
 
   - name: nrf91
     parent: nrf
@@ -653,6 +663,15 @@ modules:
       global:
         RUSTFLAGS:
           - --cfg context=\"cortex-m7f\"
+
+  - name: cortex-m33
+    selects:
+      - cortex-m
+      - thumbv8m.main-none-eabi
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg context=\"cortex-m33\"
 
   - name: cortex-m33f
     selects:
@@ -1626,6 +1645,11 @@ builders:
 
   - name: nrf5340dk
     parent: nrf5340
+    provides:
+      - has_usb_device_port
+
+  - name: nrf5340dk-net
+    parent: nrf5340-net
     provides:
       - has_usb_device_port
 

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -52,6 +52,9 @@ embassy-nrf = { workspace = true, features = [
   "nrf5340-app-s",
 ] }
 
+[target.'cfg(context = "nrf5340-net")'.dependencies]
+embassy-nrf = { workspace = true, features = ["nrf5340-net"] }
+
 [target.'cfg(context = "nrf9151")'.dependencies]
 embassy-nrf = { workspace = true, features = ["nrf9151-s"] }
 

--- a/src/ariel-os-nrf/src/identity.rs
+++ b/src/ariel-os-nrf/src/identity.rs
@@ -6,9 +6,9 @@ impl ariel_os_embassy_common::identity::DeviceId for DeviceId {
         reason = "making this fallible would be a breaking API change for Ariel OS"
     )]
     fn get() -> Result<Self, core::convert::Infallible> {
-        #[cfg(not(any(context = "nrf5340", context = "nrf91")))]
+        #[cfg(not(any(context = "nrf53", context = "nrf91")))]
         let ficr = embassy_nrf::pac::FICR;
-        #[cfg(any(context = "nrf5340", context = "nrf91"))]
+        #[cfg(any(context = "nrf53", context = "nrf91"))]
         let ficr = embassy_nrf::pac::FICR.info();
 
         let low = ficr.deviceid(0).read();

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -49,7 +49,7 @@ ariel_os_embassy_common::executor_swi!(SWI0);
 ariel_os_embassy_common::executor_swi!(EGU0_SWI0);
 
 #[cfg(feature = "executor-interrupt")]
-#[cfg(any(context = "nrf5340", context = "nrf91"))]
+#[cfg(any(context = "nrf53", context = "nrf91"))]
 ariel_os_embassy_common::executor_swi!(EGU0);
 
 use embassy_nrf::config::Config;

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -72,18 +72,26 @@ fn write_memoryx() {
         (256, 1024)
     } else if context("nrf5340") {
         (512, 1024)
+    } else if context("nrf5340-net") {
+        (64, 256)
     } else if context_any(&["nrf9151", "nrf9160"]).is_some() {
         (256, 1024)
     } else {
         panic!("please set the MCU laze context");
     };
 
+    let (pagesize, ram_base, flash_base) = if context("nrf5340-net") {
+        (2048, 0x2100_0000, 0x0100_0000)
+    } else {
+        (4096, 0x2000_0000, 0)
+    };
+
     // generate linker script
     let memory = Memory::new()
-        .add_section(MemorySection::new("RAM", 0x2000_0000, ram * 1024))
+        .add_section(MemorySection::new("RAM", ram_base, ram * 1024))
         .add_section(
-            MemorySection::new("FLASH", 0x0, flash * 1024)
-                .pagesize(4096)
+            MemorySection::new("FLASH", flash_base, flash * 1024)
+                .pagesize(pagesize)
                 .from_env(),
         );
 


### PR DESCRIPTION
# Description
This PR introduces basic support for the network core of the `nrf5340`. Since the nrf5340 features a dual-core architecture—with each core having its own flash and RAM—Inter-Processor Communication (IPC) must be implemented to enable coordination between the application core and the network core.

I initially assumed the application core would be the default target, so I kept the name as `nrf5340`. However, it might be clearer to rename it to `nrf5340-app` to explicitly reflect that it targets the application core and avoid any ambiguity with the network core.

<!-- Please write a summary of your changes and why you made them.-->

## Testing
According to the documentation, the network core does not start automatically and must be explicitly released by the application core using [release_network_core](https://docs.embassy.dev/embassy-nrf/git/nrf5340-app-ns/reset/fn.release_network_core.html). That said, when flashing only the network core using `probe-rs`, it starts running immediately—allowing `examples/hello_world` to function without involvement from the application core.

`probe-rs` automatically determines which core to flash based on the memory layout of the firmware binary, so flashing a binary linked for the network core will target it automatically.

For other examples like `blinky`, the application core must assign GPIOs to the network core, as demonstrated [here](https://github.com/Ollrogge/ariel-os/blob/4d2e557d24e68c161ab2a77429fa4d03d358a63d/examples/blinky/src/main.rs#L22). Since these pin assignments are specific to the `nrf5340` and would introduce hardware-dependent configuration, I chose not to include them in this PR.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->


## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
