### PR TITLE
fix(rp235x): use the built-in TRNG as HWRNG instead of `RoscRng`

### DIFF
--- a/src/ariel-os-rp/src/hwrng.rs
+++ b/src/ariel-os-rp/src/hwrng.rs
@@ -1,3 +1,29 @@
-pub fn construct_rng(_peripherals: &mut crate::OptionalPeripherals) {
-    ariel_os_random::construct_rng(embassy_rp::clocks::RoscRng);
+pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {
+    #[cfg(context = "rp2040")]
+    let hwrng = {
+        let _ = peripherals; // Mark used
+
+        // NOTE(datasheet): The RP2040 RNG "does not meet the requirements of randomness for
+        // security systems because it can be compromised".
+        embassy_rp::clocks::RoscRng
+    };
+
+    #[cfg(context = "rp235xa")]
+    let hwrng = {
+        embassy_rp::bind_interrupts!(struct Irqs {
+            TRNG_IRQ => embassy_rp::trng::InterruptHandler<embassy_rp::peripherals::TRNG>;
+        });
+
+        let trng = peripherals.TRNG.take().unwrap();
+
+        // Enable all entropy checks to ensure acceptable results.
+        let mut config = embassy_rp::trng::Config::default();
+        config.disable_autocorrelation_test = false;
+        config.disable_crngt_test = false;
+        config.disable_von_neumann_balancer = false;
+
+        embassy_rp::trng::Trng::new(trng, Irqs, config)
+    };
+
+    ariel_os_random::construct_rng(hwrng);
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Unlike the RP2040, the RP235x does have a FIPS 140-compliant TRNG instead of a best-effort HWRNG relying on the ROSC.
This PR wires up that TRNG.

## Testing

Tested the `random` example on the rpi-pico2-w and the rpi-pico-w (to make sure it still works). Commenting out the RP2040-specific block when compiling for the RP235x and vice versa allows to make sure each block is properly used.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
(RP235x) The `ariel_os::random` module is now seeding its RNGs from the TRNG (which is not available on the RP2040), instead of relying on the `RoscRng`.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
