### PR TITLE
refactor(coapcore): avoid using Copy on types that should not be

### DIFF
--- a/src/lib/coapcore/src/seccfg.rs
+++ b/src/lib/coapcore/src/seccfg.rs
@@ -351,6 +351,10 @@ impl ServerSecurityConfig for ConfigBuilder {
     }
 
     fn own_edhoc_credential(&self) -> Option<(lakers::Credential, lakers::BytesP256ElemLen)> {
+        #[expect(
+            clippy::clone_on_copy,
+            reason = "the type should not be clone, and will not be in future lakers versions"
+        )]
         self.own_edhoc_credential.clone()
     }
 


### PR DESCRIPTION
# Description

These minimal changes ensure that even when using a main-branch lakers version (that dropped a bunch of unfortunate Copy implementations), our code can run (with a few warnings that'll be for another PR -- some changes can only go in if we make the switch to 0.9).

## Issues/PRs references

See-Also: https://github.com/openwsn-berkeley/lakers/pull/361

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
