### PR TITLE
chore(rustc-lint): fix the new `mismatched_lifetime_syntaxes` warning

### DIFF
--- a/src/lib/ringbuffer/src/lib.rs
+++ b/src/lib/ringbuffer/src/lib.rs
@@ -27,7 +27,7 @@ where
         }
     }
 
-    pub const fn new_with(backing_array: &mut [MaybeUninit<T>]) -> RingBuffer<T> {
+    pub const fn new_with(backing_array: &mut [MaybeUninit<T>]) -> RingBuffer<'_, T> {
         RingBuffer {
             index: RingBufferIndex::new(backing_array.len() as u8),
             // this is basically MaybeUninit::slice_assume_init_mut().


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This fixes the one warning originating from the new [`mismatched-lifetime-syntaxes`](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#mismatched-lifetime-syntaxes) rustc lint which was [merged in nightly overnight](https://github.com/rust-lang/rust/pull/138677). This currently breaks our `cargo-test` CI check as (a) it uses nightly so that the `ariel-os-cargo.toml` file gets picked up and (b) we deny warnings in CI.

Addresses the following warning:

```rust
warning: lifetime flowing from input to output with different syntax can be confusing
  --> src/lib/ringbuffer/src/lib.rs:30:42
   |
30 |     pub const fn new_with(backing_array: &mut [MaybeUninit<T>]) -> RingBuffer<T> {
   |                                          ^^^^^^^^^^^^^^^^^^^^^     ------------- the lifetime gets resolved as `'_`
   |                                          |
   |                                          this lifetime flows to the output
   |
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
30 |     pub const fn new_with(backing_array: &mut [MaybeUninit<T>]) -> RingBuffer<'_, T> {
   |                                                                               +++
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
