### PR TITLE
fix(panic-printing): print the panic message, even with `defmt`

### DIFF
--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -125,7 +125,7 @@ mod isr_stack {
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     #[cfg(feature = "panic-printing")]
-    ariel_os_debug::println!("panic: {}\n", _info);
+    ariel_os_debug::print_panic(_info);
 
     ariel_os_debug::exit(ariel_os_debug::ExitCode::FAILURE);
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This fixes #1083 by semi-manually implementing panic formatting when `defmt` is used.

## Testing

Append the following to `example/log`:

```rust
panic!(); // No message
panic!("Panicking!"); // String literal
panic!("Panicking with {}!", 42); // Const-formatted message
panic!("Panicking with {}!", core::hint::black_box(1337)); // Dynamic message
```

Comment out statements appropriately to test each individual panic statements.

In addition, the following logging facades need to be tested:

- With `defmt` selected
- With `log` selected
- With all logging disabled using `-d debug-logging-facade`

**Expectation:** the panic location and the panic message (the parameter of `panic!`), if present, should always be printed appropriately, including when using `defmt`.

The testing hardware should not matter.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #1083.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
