### PR TITLE
fix(config): force `const` evaluation in env macros

### DIFF
--- a/src/ariel-os-utils/src/env.rs
+++ b/src/ariel-os-utils/src/env.rs
@@ -99,6 +99,8 @@ pub(crate) use str_from_env;
 ///
 /// - Produces a compile-time error if the environment variable is not found.
 /// - Produces a compile-time error when [`option_env!`](option_env) does.
+/// - Produces a compile-time error when the environment variable cannot be parsed into an IPv4
+///   address.
 #[macro_export]
 macro_rules! ipv4_addr_from_env {
     // $doc is currently unused
@@ -128,7 +130,9 @@ macro_rules! ipv4_addr_from_env {
 ///
 /// # Errors
 ///
-/// Produces a compile-time error when [`option_env!`](option_env) does.
+/// - Produces a compile-time error when [`option_env!`](option_env) does.
+/// - Produces a compile-time error when the environment variable cannot be parsed into an IPv4
+///   address.
 #[macro_export]
 macro_rules! ipv4_addr_from_env_or {
     // $doc is currently unused
@@ -154,6 +158,8 @@ macro_rules! ipv4_addr_from_env_or {
 ///
 /// - Produces a compile-time error if the environment variable is not found.
 /// - Produces a compile-time error when [`option_env!`](option_env) does.
+/// - Produces a compile-time error when the environment variable cannot be parsed into an IPv6
+///   address.
 #[macro_export]
 macro_rules! ipv6_addr_from_env {
     // $doc is currently unused
@@ -183,7 +189,9 @@ macro_rules! ipv6_addr_from_env {
 ///
 /// # Errors
 ///
-/// Produces a compile-time error when [`option_env!`](option_env) does.
+/// - Produces a compile-time error when [`option_env!`](option_env) does.
+/// - Produces a compile-time error when the environment variable cannot be parsed into an IPv6
+///   address.
 #[macro_export]
 macro_rules! ipv6_addr_from_env_or {
     // $doc is currently unused


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This leverages inline `const` expressions to force the `const` evaluation of environment variables used through our config macros, especially the ones that parse IPv4/IPv6 addresses.
[Inline `const` expressions were not yet stabilized](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0/#inline-const-expressions) when these macros [were initially implemented](https://github.com/ariel-os/ariel-os/pull/51).
I don't believe this is a breaking change as this only makes errors that would before happen at runtime now happen at compile time.

## How to review this PR

I would strongly recommend enabling "Hide whitespace" in the diff view.

To test the change, try to add the following to the `hello-world` example:
```rust
let _ip = ariel_os::config::ipv6_addr_from_env!("IPV6_ADDR", "IPv6 address");
```

And use the following command to test this:
```sh
IPV6_ADDR='2001:db8::' laze -C examples/hello-world build -b nrf52840dk
```
Then change the given string to make parsing fail, which will now happen at compile time, even though the macro is used as the RHS of a `let` statement, not a `const` statement.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #1140.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
