### PR TITLE
ci(pr-title): avoid shell injection from the PR title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -18,4 +18,6 @@ jobs:
         with:
           tool: committed
 
-      - run: committed --config committed.toml --commit-file <(echo "${{ github.event.pull_request.title }}")
+      - run: committed --config committed.toml --commit-file <(echo "${PR_TITLE}")
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This fixes a template injection issue, from the PR title.
This was found with [zizmor](https://github.com/zizmorcore/zizmor) and the fix is [the one recommended](https://docs.zizmor.sh/audits/#template-injection), that uses a environment variable to avoid the inline template expansion. 

Impact is very limited as we required workflow approval for PRs from external contributors. 

---

Using `ci-build:skip` as we do not need the Build workflow in this run.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
