### PR TITLE
ci(build-pr-labels): introduce more labels to control the set of devices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
               }
               const prLabels = pr.labels.map((label) => label.name);
               console.log(`The labels of PR #${prNumber} are ${prLabels}`);
-              const VALID_LABELS = ['ci-build:full', 'ci-build:skip', 'ci-build:small'];
+              const VALID_LABELS = ['ci-build:full', 'ci-build:rp', 'ci-build:skip', 'ci-build:small'];
               const buildLabels = prLabels.filter((label) => VALID_LABELS.includes(label));
               if (buildLabels.length > 1) { throw 'Only one build label must be attached.'; }
               const buildLabel = buildLabels[0];
@@ -200,6 +200,9 @@ jobs:
           case '${{ needs.check-labels.outputs.label }}' in
             'ci-build:full')
               # Not setting `LAZE_BUILDERS` so that the build is not limited
+              ;;
+            'ci-build:rp')
+              echo "LAZE_BUILDERS=rpi-pico,rpi-pico2,rpi-pico2-w,rpi-pico-w" >> "$GITHUB_ENV"
               ;;
             'ci-build:small')
               echo "LAZE_BUILDERS=ai-c3,espressif-esp32-devkitc,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-devkitc-1,bbc-microbit-v2,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-c031c6,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Following #843 and #1135, this introduces more fine-grained PR labels to control the set of devices the Build workflow builds for.

## How to review this PR

This PR is better reviewed commit by commit.
Additionally, Enabling "Hide whitespace" in the diff view makes it obvious the existing `echo "LAZE_BUILDERS=[…]` line has only been indented.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
