### PR TITLE
fix(native): set linker nostart-stop-gc

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1883,6 +1883,10 @@ builders:
       - probe-rs
     env:
       RUSTC_TARGET: x86_64-unknown-linux-gnu
+      RUSTFLAGS:
+        # This is needed to keep the linkme sections on native also in combination
+        # with gc-sections.
+        - -Clink-arg=-Wl,-znostart-stop-gc
       CARGO_TARGET_PREFIX: CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU
       CARGO_RUNNER: '"sh -c"'
 


### PR DESCRIPTION
# Description

Fix for a native linker error:

```
   Compiling bench_sched_flags v0.0.0 (/home/runner/work/ariel-os/ariel-os/tests/benchmarks/bench_sched_flags)
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/tmp/rustcuF7RaW/symbols.o" "<1 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/runner/work/ariel-os/ariel-os/tests/benchmarks/bench_sched_flags/../../../build/bin/native/cargo/x86_64-unknown-linux-gnu/release/build/ariel-os-rt-fd4bf25bf29a230a/out" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/runner/work/ariel-os/ariel-os/tests/benchmarks/bench_sched_flags/../../../build/bin/native/cargo/x86_64-unknown-linux-gnu/release/deps/bench_sched_flags-7a399a6b3892d983" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: rust-lld: error: undefined symbol: __start_linkme_INIT_FUNCS
          >>> referenced by lib.rs:147 (src/ariel-os-rt/src/lib.rs:147)
          >>>               /home/runner/work/ariel-os/ariel-os/tests/benchmarks/bench_sched_flags/../../../build/bin/native/cargo/x86_64-unknown-linux-gnu/release/deps/bench_sched_flags-7a399a6b3892d983.bench_sched_flags.aad39f264aa4c225-cgu.0.rcgu.o:(ariel_os_rt::INIT_FUNCS::ha7c28ebb03aefdfb)
          >>> the encapsulation symbol needs to be retained under --gc-sections properly; consider -z nostart-stop-gc (see https://lld.llvm.org/ELF/start-stop-gc)
          
          rust-lld: error: undefined symbol: __stop_linkme_INIT_FUNCS
          >>> referenced by lib.rs:147 (src/ariel-os-rt/src/lib.rs:147)
          >>>               /home/runner/work/ariel-os/ariel-os/tests/benchmarks/bench_sched_flags/../../../build/bin/native/cargo/x86_64-unknown-linux-gnu/release/deps/bench_sched_flags-7a399a6b3892d983.bench_sched_flags.aad39f264aa4c225-cgu.0.rcgu.o:(ariel_os_rt::INIT_FUNCS::ha7c28ebb03aefdfb)
```

The background is that on native, linkme uses linker generated meta section names (`__start_FOO`/`__stop__FOO`) for its distributed slices. They need to be retained even with linker garbage collection enabled.

I don't have it entirely clear, but it seems to me that GNU ld and lld have different defaults, maybe depending on how they were compiled. I don't get the above error on my system with neither ld nor lld, and it only shows in selected CI builds.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
