### PR TITLE
fix(nrf): enable flash cache

### DIFF
--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -72,6 +72,27 @@ pub static EXECUTOR: Executor = Executor::new();
 #[doc(hidden)]
 #[must_use]
 pub fn init() -> OptionalPeripherals {
+    enable_flash_cache();
+
     let peripherals = embassy_nrf::init(Config::default());
     OptionalPeripherals::from(peripherals)
+}
+
+fn enable_flash_cache() {
+    // (no flash cache on nrf51)
+    cfg_if::cfg_if! {
+        if #[cfg(any(
+                context = "nrf52",
+                context = "nrf5340-net",
+                context = "nrf91"
+            ))] {
+            embassy_nrf::pac::NVMC
+                .icachecnf()
+                .write(|w| w.set_cacheen(true));
+        }
+        else if #[cfg(context = "nrf5340")] {
+            embassy_nrf::pac::CACHE_S
+                .enable().write(|w| w.set_enable(true));
+        }
+    }
 }


### PR DESCRIPTION
# Description

The NRFs have a flash cache that improves performance quite a bit, but is not enabled by default by the nrf pac.

Performance wise, the `bench_sched_flags` result goes from 1574 to 1305 ticks on nrf52840dk, and from ~2300 to ~1100 on nrf5340dk.

*edit* ~~I just realized that as is this only works on nrf52840dk, looking into the pac now.~~ I got nrf52*, nrf5340, nrf5340-net and nrf91.
Tested on nrf52840dk and nrf5340dk and -net.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

Depends on #1162.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

- [x] nrfs other than nrf52840
<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

Signed-off-by: Kaspar Schleiser <kaspar@schleiser.de>
