### PR TITLE
fix(nrf-ble): set executor interrupt priority

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1262,7 +1262,6 @@ modules:
       - doc_only
 
   - name: has_nrf_ble
-    help: Marks an incompatibility of nrf devices with the interrupt executor (MPSL crashing)
     context:
       - nrf52
       - nrf53
@@ -1270,8 +1269,6 @@ modules:
       - hwrng
     provides:
       - has_ble
-    conflicts:
-      - executor-interrupt
 
   - name: ble-peripheral
     help: Enables BLE peripheral functionality

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -152,6 +152,12 @@ pub(crate) fn init() {
     debug!("ariel-os-embassy::init(): using interrupt mode executor");
     let p = hal::init();
 
+    #[cfg(any(context = "nrf", context = "stm32"))]
+    {
+        use crate::hal::interrupt::{InterruptExt, Priority};
+        hal::SWI.set_priority(Priority::P1);
+    }
+
     #[cfg(any(context = "nrf", context = "rp", context = "stm32"))]
     {
         hal::EXECUTOR.start(hal::SWI);

--- a/src/ariel-os-nrf/src/irqs.rs
+++ b/src/ariel-os-nrf/src/irqs.rs
@@ -25,7 +25,7 @@ bind_interrupts!(pub(crate) struct Irqs {
     #[cfg(all(feature = "ble", context = "nrf52"))]
     EGU1_SWI1 => nrf_sdc::mpsl::LowPrioInterruptHandler;
     #[cfg(all(feature = "ble", context = "nrf53"))]
-    EGU0 => nrf_sdc::mpsl::LowPrioInterruptHandler;
+    SWI0 => nrf_sdc::mpsl::LowPrioInterruptHandler;
 
     #[cfg(feature = "ble")]
     RADIO => nrf_sdc::mpsl::HighPrioInterruptHandler;


### PR DESCRIPTION
# Description

This allows to use ble with the interrupt executor on nRF boards.

Tested on nrf5340dk-net, nrf52dk.

## Issues/PRs references

Fixes #1165 

## Open Questions

Seems like usb on stm32 also needs the priority to be changed, should we make P1 the default ?


## Changelog entry

<!-- changelog:begin -->
The `executor-interrupt` flavor is now using the lowest interrupt priority on STM32 and nRF MCUs. This allows using BLE in combination with that executor flavor on nRF.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
