### PR TITLE
docs(esp32-c): mark User USB as not available in hardware

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -473,8 +473,11 @@ boards:
     chip: esp32c3
     tier: "1"
     support:
-      user_usb: not_currently_supported
-      ethernet_over_usb: not_currently_supported
+      user_usb:
+        status: not_available
+        comments:
+          - no generic USB peripheral
+      ethernet_over_usb: not_available
 
   espressif-esp32-c6-devkitc-1:
     name: Espressif ESP32-C6-DevKitC-1
@@ -482,8 +485,11 @@ boards:
     chip: esp32c6
     tier: "1"
     support:
-      user_usb: not_currently_supported
-      ethernet_over_usb: not_currently_supported
+      user_usb:
+        status: not_available
+        comments:
+          - no generic USB peripheral
+      ethernet_over_usb: not_available
 
   espressif-esp32-s3-devkitc-1:
     name: Espressif ESP32-S3-DevKitC-1


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
There is a USB peripheral in hardware on the ESP32-C3 and ESP32-C6 but it only supports CDC-ACM (USB Serial), it's not a generic USB peripheral.
The ESP32-S3, however, does have a generic, OTG-enabled USB peripheral.
The ESP32, whose support is not currently documented anyway, does not have any kind of USB peripheral.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
