### PR TITLE
refactor(coap): use `UdpSocket::endpoint()` instead of `.with()` patch

### DIFF
--- a/src/ariel-os-coap/src/udp_nal/mod.rs
+++ b/src/ariel-os-coap/src/udp_nal/mod.rs
@@ -141,7 +141,7 @@ impl nal::UnconnectedUdp for UnconnectedUdp<'_> {
         // information, so the underlying layers won't even have a *chance* to care if we don't
         // check here.
         debug_assert!(
-            local.port() == 0 || local.port() == self.socket.with(|s, _| s.endpoint().port),
+            local.port() == 0 || local.port() == self.socket.endpoint().port,
             "Port of local address, when given, must match bound port."
         );
 
@@ -171,7 +171,7 @@ impl nal::UnconnectedUdp for UnconnectedUdp<'_> {
                 addr: metadata
                     .local_address
                     .expect("Local address is always populated on receive"),
-                port: self.socket.with(|s, _| s.endpoint().port),
+                port: self.socket.endpoint().port,
             }),
             sockaddr_smol2nal(metadata.endpoint),
         ))


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This uses the upstream `UdpSocket::endpoint()` instead of `UdpSocket::with()` that is only only made accessible by our patch `embassy-net-v0.6.0+ariel-os` in https://github.com/embassy-rs/embassy/commit/7f577b5a7506f9e5e41ec11dff6f44cea589c894.

I am however unsure why `.with()` was used in the first place, so it is possible that this is not actually equivalent, even though [`UdpSocket::endpoint()` *seems* to me to be simply delegating to `smoltcp::socket::udp::Socket::endpoint()`](https://github.com/embassy-rs/embassy/blob/953288f5c831e7048d38479db8f43cd8126807dd/embassy-net/src/udp.rs#L317-L319).

@chrysn If this substitution does not actually make sense, feel free to just close this PR.

---

This would allow us to basically do without our `embassy-net` patch, as the only other thing it does is printing the IP address at `info` level, which we could do some other way.

## Testing

I *only* tested this by removing our `embassy-net` patch, making sure it did not compile, then applying this change and making sure it compiled again (the IP address not being printed as expected when the log level is set as `info`). I am not sure how to test this at runtime.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
