### PR TITLE
fix(warnings): fix last occurences of hidden lifetime warnings

### DIFF
--- a/examples/usb-keyboard/src/main.rs
+++ b/examples/usb-keyboard/src/main.rs
@@ -28,7 +28,7 @@ const HID_READER_BUFFER_SIZE: usize = 1;
 const HID_WRITER_BUFFER_SIZE: usize = 8;
 
 #[ariel_os::config(usb)]
-const USB_CONFIG: embassy_usb::Config = {
+const USB_CONFIG: embassy_usb::Config<'_> = {
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
     config.manufacturer = Some(ariel_os::buildinfo::OS_NAME);
     config.product = Some("HID keyboard example");
@@ -44,7 +44,7 @@ const USB_CONFIG: embassy_usb::Config = {
     config
 };
 
-static HID_STATE: StaticCell<hid::State> = StaticCell::new();
+static HID_STATE: StaticCell<hid::State<'_>> = StaticCell::new();
 
 #[ariel_os::task(autostart, peripherals, usb_builder_hook)]
 async fn usb_keyboard(button_peripherals: pins::Buttons) {

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -15,7 +15,7 @@ use embassy_usb::{
 const MAX_FULL_SPEED_PACKET_SIZE: u8 = 64;
 
 #[ariel_os::config(usb)]
-const USB_CONFIG: embassy_usb::Config = {
+const USB_CONFIG: embassy_usb::Config<'_> = {
     let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
     config.manufacturer = Some(ariel_os::buildinfo::OS_NAME);
     config.product = Some("USB serial example");
@@ -35,7 +35,7 @@ const USB_CONFIG: embassy_usb::Config = {
 async fn main() {
     info!("Hello World!");
 
-    static STATE: StaticCell<State> = StaticCell::new();
+    static STATE: StaticCell<State<'_>> = StaticCell::new();
 
     // Create and inject the USB class on the system USB builder.
     let mut class = USB_BUILDER_HOOK

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -45,7 +45,7 @@ mod demo_setup {
         hex!("72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac");
 
     /// Scope usable by any client inside any demo device.
-    const UNAUTHENTICATED_SCOPE: cboritem::CborItem = cbor!([
+    const UNAUTHENTICATED_SCOPE: cboritem::CborItem<'_> = cbor!([
             ["/.well-known/core", 1],
             ["/poem", 1],
             ["/hello", 1],
@@ -54,7 +54,7 @@ mod demo_setup {
     ]);
 
     /// Scope usable by the the administrator of the demo device.
-    const ADMIN_SCOPE: cboritem::CborItem = cbor!([
+    const ADMIN_SCOPE: cboritem::CborItem<'_> = cbor!([
             ["/stdout", 17 / GET and FETCH /],
             ["/.well-known/core", 1],
             ["/poem", 1]

--- a/src/ariel-os-esp/src/wifi/esp_wifi.rs
+++ b/src/ariel-os-esp/src/wifi/esp_wifi.rs
@@ -18,7 +18,7 @@ pub type NetworkDevice = WifiDevice<'static, WifiStaDevice>;
 // `EspWifiInitialization` from `crate::init()`.
 // Using a `once_cell::OnceCell` here for critical-section support, just to be
 // sure.
-pub static WIFI_INIT: OnceCell<EspWifiController> = OnceCell::new();
+pub static WIFI_INIT: OnceCell<EspWifiController<'_>> = OnceCell::new();
 
 pub fn init(peripherals: &mut crate::OptionalPeripherals, spawner: Spawner) -> NetworkDevice {
     let wifi = peripherals.WIFI.take().unwrap();


### PR DESCRIPTION
# Description

This PR fixes the last occurences of the "hidden lifetime parameter in types are deprecated" rustc warning. The fix is to add an explicit anonymous lifetime annotation (e.g: `Type<'_>`).

## Issues/PRs references

Closes #1175.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
