### PR TITLE
refactor(macros): replace `enum-iterator` dep by custom code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,6 @@ name = "ariel-os-macros"
 version = "0.2.0"
 dependencies = [
  "ariel-os",
- "enum-iterator",
  "heapless 0.8.0",
  "proc-macro-crate",
  "proc-macro2",
@@ -2279,26 +2278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-enum-iterator = "2.1.0"
 proc-macro-crate = "3.1.0"
 proc-macro2 = "1.0.78"
 quote = "1.0.35"

--- a/src/ariel-os-macros/src/task.rs
+++ b/src/ariel-os-macros/src/task.rs
@@ -171,7 +171,7 @@ mod task {
         }
     }
 
-    #[derive(Debug, PartialEq, Eq, Hash, enum_iterator::Sequence)]
+    #[derive(Debug, PartialEq, Eq, Hash)]
     pub enum Hook {
         UsbBuilder,
     }
@@ -194,7 +194,9 @@ mod task {
         }
 
         fn format_list() -> String {
-            enum_iterator::all::<Self>()
+            let variants = [Hook::UsbBuilder];
+            variants
+                .iter()
                 .map(|h| format!("`{}`", h.param_name()))
                 .collect::<Vec<_>>()
                 .join(", ")


### PR DESCRIPTION
# Description

This PR replaces the `enum-iterator` dependency used in `ariel-os-macros` by custom code. This aims to speed up compilation times by removing a proc macro from the hot path.


## Issues/PRs references

Closes #1174.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
