### PR TITLE
feat(st-nucleo-wba55)!: switch SWI to USART2

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1867,7 +1867,7 @@ builders:
     env:
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
-        - CONFIG_SWI=LPUART1
+        - CONFIG_SWI=USART2
 
   - name: st-steval-mkboxpro
     parent: stm32u585ai


### PR DESCRIPTION
# Description

Both LPUART1 and USART1 are used on the development board for COM ports, while USART2 is unused

## Issues/PRs references

Discovered while adding UART support(#978 )  for the nucleo-wba55cg 

## Open Questions

- To me this looks like a breaking change as it might break applications on the stm32wba55cg that were using USART2 
- I don't own the board to test this change

## Changelog entry

<!-- changelog:begin -->
(ST NUCLEO-WBA55) The SWI has been switched from `LPUART1` to `USART2` to free up the interrupt for UART.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
