### PR TITLE
chore(deps): remove our now unneeded `embassy-net` patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,8 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-net"
-version = "0.6.0"
-source = "git+https://github.com/ariel-os/embassy?rev=3d9f77ee05cdb18f1cd676233bcda9b6f7be3369#3d9f77ee05cdb18f1cd676233bcda9b6f7be3369"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940c4b9fe5c1375b09a0c6722c0100d6b2ed46a717a34f632f26e8d7327c4383"
 dependencies = [
  "defmt 0.3.100",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ embassy-embedded-hal = { version = "0.3.0", default-features = false }
 embassy-executor = { version = "0.7.0", default-features = false }
 embassy-futures = { version = "0.1.1", default-features = false }
 embassy-hal-internal = { version = "0.2.0", default-features = false }
-embassy-net = { version = "0.6", default-features = false }
+embassy-net = { version = "0.7", default-features = false }
 embassy-net-driver-channel = { version = "0.3.0", default-features = false }
 embassy-nrf = { version = "0.3.1", default-features = false }
 embassy-rp = { version = "0.4", default-features = false }

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -28,8 +28,6 @@ embassy-executor-macros = { git = "https://github.com/ariel-os/embassy", rev = "
 embassy-hal-internal = { git = "https://github.com/ariel-os/embassy", rev = "ed7d22c1881b64f9bdd2e69a5777b002279033a6" }
 # branch = "embassy-nrf-v0.3.1+ariel-os"
 embassy-nrf = { git = "https://github.com/ariel-os/embassy", rev = "1d258e63acc0a322ccea28786a4143115ba303b8" }
-# branch = "embassy-net-v0.6.0+ariel-os"
-embassy-net = { git = "https://github.com/ariel-os/embassy", rev = "3d9f77ee05cdb18f1cd676233bcda9b6f7be3369" }
 # branch = "embassy-rp-v0.4.0+ariel-os+trng-panic-fix"
 embassy-rp = { git = "https://github.com/ariel-os/embassy", rev = "1dd58227a73efa8da2aef96aaccf17b8749b9f7b" }
 # branch = "embassy-stm32-v0.2.0+ariel-os"

--- a/src/ariel-os-coap/src/udp_nal/util.rs
+++ b/src/ariel-os-coap/src/udp_nal/util.rs
@@ -63,7 +63,7 @@ impl embedded_io_async::Error for Error {
             }
             Self::AddressFamilyUnavailable => embedded_io_async::ErrorKind::AddrNotAvailable,
             // These should not happen b/c our sockets are typestated.
-            Self::SendError(udp::SendError::SocketNotBound) |
+            Self::SendError(udp::SendError::SocketNotBound | udp::SendError::PacketTooLarge) |
                 Self::BindError(udp::BindError::InvalidState) |
             // This should not happen b/c in embedded_nal_async this is not expressed through an
             // error.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Following #1188, our `embassy-net` patch can now be removed.

This PR also bumps `embassy-net` from v0.6.0 to v0.7.0 because it is required by `picoserve` (otherwise the `Stack` types are not the same), which is used in one of the examples. As patches [apply to transitive dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#working-with-an-unpublished-minor-version) as well, this was hidden before.

## Testing

Successfully tested the `http-server` example (which uses `picoserve`) on nrf52840dk and espressif-esp32-c6-devkitc-1.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Follow-up to #118.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
