### PR TITLE
refactor(task-macro): avoid the need for `extra-traits` on `syn`

### DIFF
--- a/src/ariel-os-macros/src/task.rs
+++ b/src/ariel-os-macros/src/task.rs
@@ -129,7 +129,7 @@ mod task {
     pub const PERIPHERALS_PARAM: &str = "peripherals";
     pub const POOL_SIZE_PARAM: &str = "pool_size";
 
-    #[derive(Debug, Default)]
+    #[derive(Default)]
     pub struct Attributes {
         pub autostart: bool,
         pub peripherals: bool,


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
[`syn::Expr` only implements the `Debug` trait if `extra-traits` is enabled.](https://docs.rs/syn/latest/syn/enum.Expr.html#impl-Debug-for-Expr) This was hidden by feature unification.
As `Debug` is not actually needed on that internal type, this simply removes the derive, also avoiding the slight extra compilation cost as this is a proc-macro.

The motivation for this is to be able to render the docs for the `ariel-os-sensors` crate (which depends on `ariel-os-macros`) separately:

```sh
cargo +nightly doc -p ariel-os-sensors
```

---

`ci-build:skip` is enough because the `ariel-os-macros` crate has unit tests that are run by the `cargo-test` CI job.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
