### PR TITLE
ci(build): increase number of commits fetched in `check-labels`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,12 @@ jobs:
             // Would be incorrect if multiple PRs are open for exactly the same commit.
             for (const pr of items) {
               const prNumber = pr.number;
-              const { data: commits } = await github.rest.pulls.listCommits({ owner: 'ariel-os', repo: 'ariel-os', pull_number: prNumber });
+              const { data: commits } = await github.rest.pulls.listCommits({
+                owner: 'ariel-os',
+                repo: 'ariel-os',
+                pull_number: prNumber,
+                per_page: 100
+              });
               // TODO: handle pagination
               const tipCommitId = commits[commits.length - 1].sha;
               if (tipCommitId != commitId) {


### PR DESCRIPTION
# Description

As mentioned in https://github.com/ariel-os/ariel-os/pull/1206#discussion_r2285524045, this increases the number of commits retrieved for determining the build label on a PR. See https://octokit.github.io/rest.js/v22/#pulls-list-commits for the API documentation

## Issues/PRs references

None

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
