### PR TITLE
docs(examples): add (currently BLE) clock example

### DIFF
--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "clock-app"
+license.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os", features = ["time"] }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+defmt.workspace = true
+
+embassy-futures = { version = "0.1.1" }
+embassy-sync = "0.6.2"
+embedded-hal-async.workspace = true
+static_cell = "2"
+trouble-host = { workspace = true, features = ["defmt"] }

--- a/examples/clock/README.md
+++ b/examples/clock/README.md
@@ -1,0 +1,42 @@
+# Clock application
+
+## About
+
+This application provides the best clock experience the hardware and Ariel OS can offer.
+
+Aspirationally, this will take time for wherever is possible (preferably trusted),
+and show it using any means customary for a clock
+(e.g. on a display, or run bell tower behavior if a speaker is available).
+
+At the time of writing, options are limited:
+- The only available source for "human time"
+  (i.e., time accurate to within a few seconds, taking time zones into account)
+  is BLE Current Time Service.
+- The only available output mode is printing to the console.
+
+Worse, neither continuously running RTC backends (not even across reboots, let alone low-power situations)
+nor time zones are persisted,
+so on every restart, the clock starts up in an indefinite state.
+See [our wishlist entry for a time abstraction](https://github.com/ariel-os/ariel-os/discussions/642#discussioncomment-14153832)
+and [the one for displays](https://github.com/ariel-os/ariel-os/discussions/642#discussioncomment-11618055)
+for more ideas on what this could be supporting.
+
+## Running
+
+In its current state, this needs any board with BLE support;
+start it as:
+
+```sh-session
+$ laze build -b particle-xenon run
+```
+
+Then, connect to the peripheral from any host that runs the Current Time Service
+(and preferably the Next DSC Change Service as well).
+Options both for Android and for Linux are [listed in najnesnja's blog entry on Current Time Service](https://najnesnaj.github.io/pinetime-zephyr/current-time.html).
+
+## Implementation status
+
+Currently, this example is not performing any abstracting separations.
+As Ariel OS grows in provided features
+(or possibly as part of making display and clock provided features),
+its code size is expected to shrink considerably.

--- a/examples/clock/laze.yml
+++ b/examples/clock/laze.yml
@@ -1,0 +1,9 @@
+apps:
+  - name: clock-app
+    env:
+      global:
+        executor_stacksize_required:
+          # For BLE. FIXME: Can we bump that through a mechanism as we do in CoAP?
+          - "16384"
+    selects:
+      - ble-peripheral

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -1,0 +1,284 @@
+#![no_main]
+#![no_std]
+
+use embassy_futures::join::join;
+use embassy_futures::select::select3;
+use trouble_host::prelude::*;
+
+use ariel_os::debug::log::*;
+
+use ::defmt::{self, Format};
+
+/// A representation of current time.
+///
+/// This should, as this develops, move towards a more universal format than the current BLE
+/// inspired format, but right now, this will do. (A likely change is that it'll go to some integer
+/// time stamp; formatting can then still save the costly divisions by memoization).
+#[derive(Debug)]
+struct CurrentTime {
+    current_time: [u8; 10],
+    time_offset: [u8; 2],
+}
+
+impl Format for CurrentTime {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(
+            f,
+            "Time {:04}-{:02}-{:02} {:02}:{:02}:{:02}+{}/256 at time zone {}",
+            u16::from_le_bytes(self.current_time.as_chunks().0[0]),
+            self.current_time[2],
+            self.current_time[3],
+            self.current_time[4],
+            self.current_time[5],
+            self.current_time[6],
+            // ignoring day of week
+            self.current_time[8],
+            self.time_offset,
+        )
+    }
+}
+
+#[derive(Debug, Format)]
+enum BleGetTimeError<BleErr> {
+    /// The service or any needed characteristic were not present.
+    NotPresent,
+    /// A high-level error occurred (such as a characteristic not having the right length)
+    HighLevelError,
+    /// A BLE error occurred
+    Ble(BleHostError<BleErr>),
+}
+
+impl<T> From<BleHostError<T>> for BleGetTimeError<T> {
+    fn from(value: BleHostError<T>) -> Self {
+        BleGetTimeError::Ble(value)
+    }
+}
+
+/// Collection of GATT services offered by the device
+// FIXME: Can we gather OS-wide which services we want to provide?
+#[gatt_server]
+struct Server {
+    _dev_info: DevInfo,
+}
+
+/// Device Information Service
+// FIXME: This is one of the services that the OS should offer to throw in.
+#[gatt_service(uuid = service::DEVICE_INFORMATION)]
+struct DevInfo {
+    // Manufacturer Name String
+    #[characteristic(uuid = "2a29", read, value = *b"Ariel OS")]
+    manufacturer: [u8; 8],
+}
+
+#[ariel_os::task(autostart)]
+async fn main() {
+    let stack = ariel_os::ble::ble_stack().await;
+
+    let Host {
+        peripheral, runner, ..
+    } = stack.build();
+
+    // Actually, we don't expect either to terminate (if anything, they panic, but that should(!)
+    // only be due to implementation errors, not due to to anything a peer can do).
+    join(ble_task(runner), ble_loop(peripheral, stack)).await;
+}
+
+// FIXME: The OS should run this, ideally as an own task (which only Ariel can do, as it can name
+// the type of the runner)
+async fn ble_task<C: Controller>(mut runner: Runner<'_, C>) -> ! {
+    loop {
+        if let Err(e) = runner.run().await {
+            panic!("[ble_task] error: {:?}", defmt::Debug2Format(&e));
+        }
+        debug!("[ble_task] Terminated successfully; restarting.");
+    }
+}
+
+async fn ble_loop<'c, C: Controller>(
+    mut peripheral: Peripheral<'c, C>,
+    stack: &'c Stack<'c, C>,
+) -> ! {
+    let server = Server::new_with_config(GapConfig::Peripheral(PeripheralConfig {
+        name: "Ariel Clock",
+        appearance: &appearance::CLOCK,
+    }))
+    .unwrap();
+
+    loop {
+        info!("[adv] New round of advertising...");
+        match advertise("Ariel Clock", &mut peripheral).await {
+            Ok(conn) => {
+                let servconn = conn
+                    .clone()
+                    .with_attribute_server(&server)
+                    .expect("It's not C dependent so probably no user-data-dependent error?");
+                let servertask = gatt_events_task(&servconn);
+                let client = GattClient::<'_, _, 1>::new(&stack, &conn).await.unwrap();
+                let client_task = client.task();
+                // FIXME: Refactor to make clock run all the time (but right now we only print on
+                // update anyway)
+                let closed = select3(servertask, client_task, async {
+                    match look_for_time(&client).await {
+                        Ok(time) => info!("Got time: {:?}", time),
+                        Err(BleGetTimeError::NotPresent) => info!("Peer did not offer CTS"),
+                        Err(BleGetTimeError::HighLevelError) => {
+                            warn!("Peer implemented CTS erroneously")
+                        }
+                        Err(BleGetTimeError::Ble(_)) => {
+                            warn!("BLE error produced while attempting to read time")
+                        }
+                    }
+                    // Yeah the clock task is done, but if we returned here, we'd have to take care
+                    // of shutting down.
+                    core::future::pending::<()>().await;
+                    Ok::<_, BleHostError<C::Error>>(())
+                })
+                .await;
+                warn!(
+                    "[adv] first to close was: {:?}",
+                    defmt::Debug2Format(&closed)
+                );
+            }
+            Err(e) => panic!("[adv] error: {:?}", defmt::Debug2Format(&e)),
+        }
+    }
+}
+
+/// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
+async fn advertise<'a, 'b, C: Controller>(
+    name: &'a str,
+    peripheral: &mut Peripheral<'a, C>,
+) -> Result<Connection<'a>, BleHostError<C::Error>> {
+    let mut advertiser_data = [0; 31];
+    AdStructure::encode_slice(
+        &[
+            AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+            // FIXME: Does this even make sense to advertise? Can we advertise "please connect so I
+            // can run Current Time Service"?
+            AdStructure::ServiceUuids16(&[service::DEVICE_INFORMATION.to_le_bytes()]),
+            AdStructure::CompleteLocalName(name.as_bytes()),
+        ],
+        &mut advertiser_data[..],
+    )
+    .expect("Constant size array too small");
+    let advertiser = peripheral
+        .advertise(
+            &Default::default(),
+            Advertisement::ConnectableScannableUndirected {
+                adv_data: &advertiser_data[..],
+                scan_data: &[],
+            },
+        )
+        .await?;
+    info!("[adv] advertising");
+    let conn = advertiser.accept().await?;
+    info!("[adv] connection established");
+    Ok(conn)
+}
+
+/// Process incoming events.
+///
+/// This does not apply any business logic, it merely ensures that the events are accepted and thus
+/// responses are sent.
+async fn gatt_events_task(conn: &GattConnection<'_, '_>) -> Result<(), Error> {
+    loop {
+        match conn.next().await {
+            GattConnectionEvent::Disconnected { reason } => {
+                info!("[gatt] disconnected: {:?}", reason);
+                break;
+            }
+            GattConnectionEvent::Gatt { event } => match event {
+                Ok(event) => {
+                    // All our own GATT server properties are static-only, we don't have actual
+                    // handling to do.
+                    //
+                    // (More realistic clocks might actually have BLE configurable properties, such
+                    // as volume control for any bell tower sounds, or maybe brightness/contrast if
+                    // we pretend that the Electronic Shelf Label service applies).
+
+                    match event.accept() {
+                        Ok(reply) => {
+                            reply.send().await;
+                        }
+                        Err(e) => warn!("[gatt] error sending response: {:?}", e),
+                    }
+                }
+                Err(e) => warn!("[gatt] error processing event: {:?}", e),
+            },
+            _ => {}
+        }
+    }
+    info!("[gatt] task finished");
+    Ok(())
+}
+
+/// A client implementation of the Current Time Service
+///
+/// It is yet to be evaluated whether using the Device Time Service might be preferable, of if they
+/// should be combined. The Current Time Service appears to be more widespread at the moment,
+/// whereas the Device Time Service is more featureful. The latter can even change the time
+/// representation that is to be rendered, it has a more straightforward time+zone representation
+/// of 32bit seconds and time zone and DST in the same message, but also has its own weirdnesses
+/// (including different epochs indicated by flag bits). There is a mechanism for a
+/// DST_Offset_Update around its DTCP, but it is unclear whether that allows scheduling updates for
+/// the future (and if not, the Next DST Change feature would still be needed).
+async fn look_for_time<'a, C: Controller>(
+    client: &GattClient<'a, C, 1>,
+) -> Result<CurrentTime, BleGetTimeError<C::Error>> {
+    debug!("[cts] Connection available, looking for Current Time Service");
+
+    // not const for lack of into constness or other const conversion
+    let current_time_service: Uuid = Uuid::new_short(service::CURRENT_TIME.into());
+    let services = client.services_by_uuid(&current_time_service).await?;
+
+    if let Some(service) = services.iter().next() {
+        debug!("[cts] Found a time service");
+        let c: Characteristic<u8> = client
+            .characteristic_by_uuid(
+                &service,
+                &Uuid::new_short(characteristic::CURRENT_TIME.into()),
+            )
+            .await
+            .expect("But The Spec Said It's Mandatory");
+        let c_local: Characteristic<u8> = client
+            .characteristic_by_uuid(
+                &service,
+                &Uuid::new_short(characteristic::LOCAL_TIME_INFORMATION.into()),
+            )
+            .await
+            .expect("Nah I won't go fully time zone blind");
+
+        debug!("[cts] Found characteristic for time");
+        let mut buffer = [0; 10];
+        let offset1 = client
+            .read_characteristic(&c_local, &mut buffer)
+            .await
+            .unwrap();
+        let offset1: [u8; 2] = buffer[..offset1]
+            .try_into()
+            .map_err(|_| BleGetTimeError::HighLevelError)?;
+        let time = client.read_characteristic(&c, &mut buffer).await.unwrap();
+        let time: [u8; 10] = buffer[..time]
+            .try_into()
+            .map_err(|_| BleGetTimeError::HighLevelError)?;
+        let offset2 = client
+            .read_characteristic(&c_local, &mut buffer)
+            .await
+            .unwrap();
+        let offset2: [u8; 2] = buffer[..offset2]
+            .try_into()
+            .map_err(|_| BleGetTimeError::HighLevelError)?;
+        if offset1 != offset2 {
+            panic!("Won't use this b/c didn't get an atomic answer"); // or try again
+        }
+
+        // maybe also query the Next DST Change service, or people will wake up unhappy
+
+        Ok(CurrentTime {
+            current_time: time,
+            time_offset: offset1,
+        })
+    } else {
+        Err(BleGetTimeError::NotPresent)
+    }
+}

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -9,6 +9,7 @@ subdirs:
   - ble-advertiser
   - ble-scanner
   - blinky
+  - clock
   - coap-client
   - coap-server
   - device-metadata


### PR DESCRIPTION
# Description

This example, in its first and current phase, implements a BLE clock that prints time to stdout.

Before it should be merged, it should reach a state where it prints time per second (or per minute) and when it is updated by some source.

Over time, more displays and time backends can come in.

As with the CoAP example in its early stages, the idea here is that the code is verbose right now, but as we enhance our abstractions and OS facilities, this becomes as few lines as it should be.

## Issues/PRs references

See discussion at https://github.com/ariel-os/ariel-os/discussions/642#discussioncomment-14153832

## Open questions

- [ ] Do we have an area where maturing examples can sit? (Some CoAP stuff is in tests for that reason).
- [ ] Should we differentiate between examples (that show how something is done didactically) and (demo) applications, that aim to be ready-to-use?

## Change checklist

- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
