### PR TITLE
fix(sensors): be more specific about relative humidity

### DIFF
--- a/src/ariel-os-sensors/src/category.rs
+++ b/src/ariel-os-sensors/src/category.rs
@@ -31,10 +31,10 @@ pub enum Category {
     Color,
     /// Gyroscope.
     Gyroscope,
-    /// Humidity sensor.
-    Humidity,
-    /// Humidity & temperature sensor.
-    HumidityTemperature,
+    /// Relative humidity sensor.
+    RelativeHumidity,
+    /// Relative humidity & temperature sensor.
+    RelativeHumidityTemperature,
     /// Light sensor.
     Light,
     /// Magnetometer.

--- a/src/ariel-os-sensors/src/label.rs
+++ b/src/ariel-os-sensors/src/label.rs
@@ -18,8 +18,8 @@
 pub enum Label {
     /// Used for sensor drivers returning a single [`Sample`](crate::sensor::Sample).
     Main,
-    /// Humidity.
-    Humidity,
+    /// Relative humidity.
+    RelativeHumidity,
     /// Temperature.
     Temperature,
     /// X axis.
@@ -34,7 +34,7 @@ impl core::fmt::Display for Label {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Main => write!(f, ""),
-            Self::Humidity => write!(f, "Humidity"),
+            Self::RelativeHumidity => write!(f, "Relative humidity"),
             Self::Temperature => write!(f, "Temperature"),
             Self::X => write!(f, "X"),
             Self::Y => write!(f, "Y"),


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This clarifies that the existing "humidity" variants are about relative humidity (we can add absolute humidity later if needed).
This is not a breaking change as this is not yet rendered in the docs.

---

`ci-build:skip` is enough because there is no users of these types for now anyway.

## How to review this PR

Docs can be rendered with:

```sh
cargo doc -p ariel-os-sensors
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
