### PR TITLE
chore: reconfigure renovate to skip build CI for actions updates and pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,6 +57,16 @@
     {
       "matchPackageNames" : [ "/^.*-rp$/i" ],
       "labels": ["ci-build:rp"]
+    },
+    // GHA updates skip build CI
+    {
+      "matchManagers": ["github-actions"],
+      "labels": ["ci-build:skip"]
+    },
+    // Nothing updates i.e. version/digest pinning and digest update also skip build CI
+    {
+      "matchUpdateTypes": ["pinDigest", "pin", "digest"],
+      "labels": ["ci-build:skip"]
     }
   ],
   // Add a 'renovate' label to every PR for the matrix bot


### PR DESCRIPTION


# Description

<!-- Please write a summary of your changes and why you made them.-->
Reconfigure Renovate to use `ci-build:skip` for `actions` updates and also for PRs that pin versions, pin digests or update digests without changing versions. 

## Issues/PRs references

Should solve the issue raised by @ROMemories in #1252 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
