### PR TITLE
fix(sensors): avoid missing docs error on macro-generated enum variants

### DIFF
--- a/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
+++ b/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
@@ -70,8 +70,10 @@ pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
         /// This type is automatically generated, the number of variants is automatically adjusted.
         #[derive(Debug, Copy, Clone)]
         pub enum Samples {
-            #[doc(hidden)]
-            #(#samples_variants),*
+            #(
+                #[doc(hidden)]
+                #samples_variants
+            ),*
         }
 
         impl Reading for Samples {
@@ -95,8 +97,10 @@ pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
         /// This type is automatically generated, the number of variants is automatically adjusted.
         #[derive(Debug, Copy, Clone)]
         pub enum ReadingChannels {
-            #[doc(hidden)]
-            #(#reading_channels_variants),*,
+            #(
+                #[doc(hidden)]
+                #reading_channels_variants
+            ),*,
         }
 
         impl ReadingChannels {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The `#[doc(hidden)]` attribute must be added on each enum variant, not just the first one, otherwise we get `missing_docs` errors when using `ariel-os-sensors` Cargo features `max-sample-min-count-$c` with `$c` > 1.

I'm also working on improving the documentation of these enums separately.

## How to review this PR

This can be tested using the following:

```sh
cargo +nightly doc -p ariel-os-sensors --features max-sample-min-count-2
```

This should fail on `main` and should not anymore with this PR.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
