### PR TITLE
fix(macros): group_peripherals ident -> path

### DIFF
--- a/src/ariel-os-hal/src/define_peripherals.rs
+++ b/src/ariel-os-hal/src/define_peripherals.rs
@@ -61,7 +61,7 @@ macro_rules! group_peripherals {
         $group:ident {
             $(
                 $(#[$inner:meta])*
-                $peripheral_name:ident : $peripherals:ident
+                $peripheral_name:ident : $peripherals:path
             ),*
             $(,)?
         }


### PR DESCRIPTION
# Description

trying to use `group_peripherals` with a path include (e.g., `pins::LedPeripherals` vs `LedPeripherals` makes it choke:

```
error: no rules expected `::`                                                                                                                                  
  --> examples/gpio/src/main.rs:7:15                                                                                                                           
   |                                                                                                                                                           
 7 |     leds: pins::LedPeripherals,                                                                                                                           
   |               ^^ no rules expected this token in macro call               
   |                                                                                                                                                           
note: while trying to match `}`                                                                                                                                
```

IIUC the macro does expect a type, so this PR changes the macro to using `ty` instead of `ident`.

I did test the changed macro in my use case.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
