### PR TITLE
docs(sensors): render the documentation of the sensor API

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -84,6 +84,7 @@ jobs:
                   no-boards,
                   random,
                   ariel-os-coap/doc,
+                  sensors,
                   spi,
                   storage,
                   tcp,

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -66,8 +66,7 @@ random = ["dep:ariel-os-random", "ariel-os-embassy/random"]
 csprng = ["dep:ariel-os-random", "ariel-os-random?/csprng"]
 # Enables seeding the random number generator from hardware.
 hwrng = ["ariel-os-embassy/hwrng"]
-# Enables support for sensors.
-# *Currently experimental and undocumented.*
+## Enables unified support for sensors.
 sensors = ["dep:ariel-os-sensors"]
 
 #! ## Network protocols


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This introduces an `unstable` Cargo feature and renders the docs for the sensor API.

## How to review this PR

The sensor API docs can be read using the docs preview.

Examples of usage of the API can be found in #1363 and #1412 (for sensor implementations), and in #1530 and in the `sensors-debug` example (for accessing sensor readings).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
- Closes #334
- Depends on #1191
- Depends on #1522

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
A custom sensor abstraction has been introduced: sensor drivers can be written against it, and sensor driver instances can be registered in a sensor registry inside an application. The registry then allows to query sensor driver instances and fetch their readings asynchronously. The `sensors-debug` example is available for testing. See the documentation of `ariel_os::sensors` for details.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
