### PR TITLE
ci(lint): check for missing `rust-version` keys in `ariel-os*` crates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,13 @@ jobs:
       - name: Forbid version keys in manifests of tests and examples
         run: set +e; grep -r '^version\s*=\|^version\.workspace' --line-number examples tests; test $? -eq 1
 
+      # `find -exec` does not make it easy to fail with a non-zero code when the
+      # `exec`ed command fails.
+      - name: Check for missing `rust-version` keys in `ariel-os*` crates
+        run: |
+          find src -iwholename 'src/ariel-os*/Cargo.toml' -exec sh -c \
+            'grep -q --with-filename '^rust-version' "$0" || (echo "$0 is missing a rust-version key"; kill $PPID)' \{\} \;
+
       - id: get_toolchain
         run: echo "toolchain=$(scripts/rust-toolchain.sh)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Follow-up to #1314, makes sure that each and every `ariel-os*` crate has a `rust-version` key from now on.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #1314.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
