### PR TITLE
feat(sensors): add a sensor driver for the built-in nRF91 GNSS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -314,6 +314,19 @@ jobs:
             --
             --deny warnings
 
+      - name: Clippy on nrf91 sensor drivers
+        uses: clechasseur/rs-clippy-check@286fd9545eb133adad54b4af34bcb642e266ddd1 # v5
+        with:
+          args: |
+            --locked
+            -p ariel-os-sensor-nrf91-gnss
+            --features "
+              ariel-os-debug-log/log,
+              nrf-modem/nrf9160
+              "
+            --
+            --deny warnings
+
   lint-rustdoc:
     runs-on: ubuntu-latest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ariel-os-sensor-nrf91-gnss"
+version = "0.1.0"
+dependencies = [
+ "ariel-os-debug-log",
+ "ariel-os-sensors",
+ "ariel-os-sensors-gnss-time-ext",
+ "ariel-os-sensors-utils",
+ "defmt 1.0.1",
+ "embassy-futures",
+ "embassy-sync 0.7.2",
+ "futures-util",
+ "libm",
+ "nrf-modem",
+ "portable-atomic",
+ "time",
+]
+
+[[package]]
 name = "ariel-os-sensor-stts22h"
 version = "0.1.0"
 dependencies = [
@@ -3386,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-intrusive"
@@ -3423,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3434,28 +3452,27 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
 ]
 
 [[package]]
@@ -4223,6 +4240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "liboscore"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4571,9 +4594,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -4896,12 +4919,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pio"
@@ -5618,6 +5635,7 @@ dependencies = [
  "ariel-os-boards",
  "ariel-os-sensor-lis2du12",
  "ariel-os-sensor-lps22df",
+ "ariel-os-sensor-nrf91-gnss",
  "ariel-os-sensor-stts22h",
  "ariel-os-sensors",
  "ariel-os-sensors-gnss-time-ext",
@@ -6273,9 +6291,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "num-conv",
@@ -6285,9 +6303,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinyrlibc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
   "src/lib/ringbuffer",
   "src/sensors/ariel-os-sensor-lis2du12",
   "src/sensors/ariel-os-sensor-lps22df",
+  "src/sensors/ariel-os-sensor-nrf91-gnss",
   "src/sensors/ariel-os-sensor-stts22h",
   "tests/benchmarks/bench_sched_flags",
   "tests/benchmarks/bench_sched_yield",
@@ -152,6 +153,7 @@ ariel-os-utils = { path = "src/ariel-os-utils", default-features = false }
 # Built-in sensor drivers.
 ariel-os-sensor-lis2du12 = { path = "src/sensors/ariel-os-sensor-lis2du12" }
 ariel-os-sensor-lps22df = { path = "src/sensors/ariel-os-sensor-lps22df" }
+ariel-os-sensor-nrf91-gnss = { path = "src/sensors/ariel-os-sensor-nrf91-gnss" }
 ariel-os-sensor-stts22h = { path = "src/sensors/ariel-os-sensor-stts22h" }
 
 const-str = "1.0.0"
@@ -182,7 +184,9 @@ trouble-host = { version = "0.5.0" }
 #nrf-sdc = { version = "0.4.0" }
 nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc", rev = "e64ad081a6948b3439d1e811da36d39a5785dbda" }
 
+futures-util = { version = "0.3.32", default-features = false }
 nrf-modem = { version = "0.10.2" }
+time = { version = "0.3.47", default-features = false }
 tinyrlibc = "0.5.0"
 
 [workspace.lints.rust]

--- a/examples/sensors-debug/Cargo.toml
+++ b/examples/sensors-debug/Cargo.toml
@@ -13,6 +13,7 @@ ariel-os = { path = "../../src/ariel-os", features = [
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 ariel-os-sensor-lis2du12 = { workspace = true }
 ariel-os-sensor-lps22df = { workspace = true }
+ariel-os-sensor-nrf91-gnss = { workspace = true, optional = true }
 ariel-os-sensor-stts22h = { workspace = true }
 ariel-os-sensors = { path = "../../src/ariel-os-sensors" }
 ariel-os-sensors-gnss-time-ext = { workspace = true, optional = true }
@@ -22,7 +23,11 @@ once_cell = { workspace = true }
 [features]
 # Enable this feature when a GNSS driver is in use to print the time.
 gnss = ["dep:ariel-os-sensors-gnss-time-ext"]
-defmt = ["ariel-os-sensors-gnss-time-ext?/defmt"]
+defmt = [
+  "ariel-os-sensor-nrf91-gnss?/defmt",
+  "ariel-os-sensors-gnss-time-ext?/defmt",
+]
+nrf-modem = ["dep:ariel-os-sensor-nrf91-gnss", "gnss"]
 
 [lints]
 workspace = true

--- a/examples/sensors-debug/laze.yml
+++ b/examples/sensors-debug/laze.yml
@@ -20,6 +20,7 @@ apps:
       - stm32u083c-dk
     selects:
       - ?defmt-app
+      - ?nrf91-modem-sensor
 
 modules:
   - name: defmt-app
@@ -29,3 +30,11 @@ modules:
       global:
         FEATURES:
           - defmt
+
+  - name: nrf91-modem-sensor
+    selects:
+      - nrf91-modem
+    env:
+      global:
+        FEATURES:
+          - nrf-modem

--- a/examples/sensors-debug/src/sensors.rs
+++ b/examples/sensors-debug/src/sensors.rs
@@ -10,6 +10,9 @@ pub async fn init() {
 
     #[cfg(any(context = "st-steval-mkboxpro", context = "stm32u083c-dk"))]
     stts22h::init().await;
+
+    #[cfg(context = "nrf91")]
+    nrf91::init().await;
 }
 
 #[cfg(any(context = "st-steval-mkboxpro"))]
@@ -124,3 +127,24 @@ mod stts22h {
 #[allow(unused, reason = "should be directly accessible without going through the registry")]
 #[cfg(any(context = "st-steval-mkboxpro", context = "stm32u083c-dk"))]
 pub use stts22h::STTS22H_I2C;
+
+#[cfg(context = "nrf91")]
+mod nrf91 {
+    use ariel_os_sensor_nrf91_gnss::{Nrf91Gnss, config::Config};
+
+    pub static NRF91_GNSS: Nrf91Gnss = const { Nrf91Gnss::new(Some("onboard")) };
+
+    #[ariel_os::reexports::linkme::distributed_slice(ariel_os::sensors::SENSOR_REFS)]
+    #[linkme(crate = ariel_os::reexports::linkme)]
+    static NRF91_GNSS_REF: &'static dyn ariel_os::sensors::Sensor = &NRF91_GNSS;
+    pub(super) async fn init() {
+        let mut config = Config::default();
+        config.log_nmea = true;
+        NRF91_GNSS.init(config).await;
+    }
+
+    #[ariel_os::task(autostart)]
+    pub async fn nrf91_gnss_runner() {
+        NRF91_GNSS.run().await;
+    }
+}

--- a/src/sensors/ariel-os-sensor-nrf91-gnss/Cargo.toml
+++ b/src/sensors/ariel-os-sensor-nrf91-gnss/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ariel-os-sensor-nrf91-gnss"
+# This crate is versioned separately from Ariel OS.
+version = "0.1.0"
+edition.workspace = true
+# This crate's MSRV is decoupled from Ariel OS's.
+rust-version = "1.90"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+ariel-os-debug-log = { workspace = true }
+ariel-os-sensors = { workspace = true, features = ["max-sample-min-count-8"] }
+ariel-os-sensors-gnss-time-ext = { workspace = true }
+ariel-os-sensors-utils = { workspace = true }
+defmt = { workspace = true, optional = true }
+embassy-futures = { workspace = true }
+embassy-sync = { workspace = true }
+futures-util = { workspace = true, default-features = false }
+libm = "0.2.15"
+nrf-modem = { workspace = true, features = ["modem-log"] }
+portable-atomic = { workspace = true }
+time = { workspace = true }
+
+[features]
+defmt = ["dep:defmt", "ariel-os-sensors/defmt", "nrf-modem/defmt"]
+
+[lints]
+workspace = true

--- a/src/sensors/ariel-os-sensor-nrf91-gnss/src/config.rs
+++ b/src/sensors/ariel-os-sensor-nrf91-gnss/src/config.rs
@@ -1,0 +1,54 @@
+/// Operation modes for the GNSS module.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum GnssOperationMode {
+    /// Always keep the GNSS module active.
+    Continuous,
+    /// Update the GNSS fix periodically.
+    /// The period is defined in seconds and should be in the range 10..=65535.
+    Periodic(u16),
+    /// Try to get a GNSS fix only when requested. Timeout is defined in seconds, 300 recommended.
+    SingleShot(u16),
+}
+
+/// Configuration for the GNSS sensor.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct Config {
+    /// The GNSS operating mode to use.
+    pub operation_mode: GnssOperationMode,
+    /// Whether NMEA messages should be logged as debug logs (adds extra processing).
+    pub log_nmea: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            operation_mode: GnssOperationMode::Continuous,
+            log_nmea: false,
+        }
+    }
+}
+
+pub(crate) fn convert_gnss_config(config: &Config) -> nrf_modem::GnssConfig {
+    nrf_modem::GnssConfig {
+        // Satellites with elevation below that angle are not used.
+        // Default value in nrfxlib is 5 degrees.
+        elevation_threshold_angle: 5,
+        use_case: nrf_modem::GnssUsecase {
+            low_accuracy: false,
+            scheduled_downloads_disable: false,
+        },
+        nmea_mask: nrf_modem::NmeaMask {
+            gga: config.log_nmea,
+            gll: config.log_nmea,
+            gsa: config.log_nmea,
+            gsv: config.log_nmea,
+            rmc: config.log_nmea,
+        },
+        // Tcxo offers more precise 1PPS but uses more energy, we don't use 1PPS so Rtc makes more sense.
+        timing_source: nrf_modem::GnssTimingSource::Rtc,
+        power_mode: nrf_modem::GnssPowerSaveMode::Disabled,
+    }
+}

--- a/src/sensors/ariel-os-sensor-nrf91-gnss/src/lib.rs
+++ b/src/sensors/ariel-os-sensor-nrf91-gnss/src/lib.rs
@@ -1,0 +1,549 @@
+//! Driver for the GNSS modem of the [nRF91 SiP series] compatible with [`ariel_os_sensors::Sensor`].
+//!
+//! This driver has 3 operation modes selectable in [`config::Config`]:
+//! - `Contiunuous`: the GNSS will always stay active and send an update approximately every 3 seconds.
+//! - `Periodic`: acquires a fix every x seconds and sends an update.
+//! - `SingleShot`: acquires a fix only when requested by [`Sensor::trigger_measurement()`] with a set timeout in seconds.
+//!
+//! In `Continuous` and `Periodic` mode the driver will try to obtain a fix as soon as it's initialized.
+//! Using [`Sensor::trigger_measurement()`] then [`Sensor::wait_for_reading()`] will wait for the next update.
+//!
+//! If a fix cannot be obtained in the allowed amount of time, [`Sensor::wait_for_reading()`] will still return a reading, but some of the [`Sample`]s' values will be [`SampleError::TemporarilyUnavailable`].
+//!
+//! To access the time returned by the GNSS fix, you need to use the [`ariel_os_sensors_gnss_time_ext::GnssTimeExt`] trait.
+//!
+//! [nRF91 SiP series]: https://docs.nordicsemi.com/category/nrf-91-series
+//! [`SampleError::TemporarilyUnavailable`]: ariel_os_sensors::sensor::SampleError::TemporarilyUnavailable
+
+#![no_std]
+
+pub mod config;
+
+use core::f64::consts::PI;
+
+use embassy_futures::select::{Either, select};
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel, once_lock::OnceLock,
+};
+use futures_util::StreamExt as _;
+use nrf_modem::{Gnss, GnssData, GnssStream};
+use time::{Date, Month, Time, UtcDateTime};
+
+use ariel_os_debug_log::{Debug2Format, debug, error, warn};
+use ariel_os_sensors::{
+    Category, Label, MeasurementUnit, Sensor,
+    sensor::{
+        Mode, ReadingChannel, ReadingChannels, ReadingError, ReadingResult, ReadingWaiter, Sample,
+        SampleMetadata, Samples, State,
+    },
+    signal::Signal,
+};
+use ariel_os_sensors_utils::AtomicState;
+
+use crate::config::{Config, GnssOperationMode, convert_gnss_config};
+
+// From WGS 84, Mean Radius of the Three Semi-axes in meters.
+// Source: table 3.5 in https://nsgreg.nga.mil/doc/view?i=4085
+const EARTH_RADIUS: f64 = 6_371_008.771_4;
+// The fraction of degrees representing a meter for the latitude (and the longitude at the equator).
+// Computed at build time to improve performance.
+const DEGREES_PER_METER_BASE: f64 = 360.0 / (EARTH_RADIUS * 2.0 * PI);
+
+#[derive(Debug)]
+enum Command {
+    Start,
+    Trigger,
+    Stop,
+}
+
+// Clamp to allowed u8 values and convert it to u8
+#[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+fn clamp_to_u8(value: f32) -> u8 {
+    value.clamp(u8::MIN.into(), u8::MAX.into()) as u8
+}
+
+pub struct Nrf91Gnss {
+    config: OnceLock<config::Config>,
+    label: Option<&'static str>,
+    state: AtomicState,
+    command_channel: Channel<CriticalSectionRawMutex, Command, 1>,
+    result_signal: Signal<ReadingResult<Samples>>,
+}
+
+impl Nrf91Gnss {
+    /// Creates a new uninitialized GNSS driver with the corresponding label.
+    #[must_use]
+    pub const fn new(label: Option<&'static str>) -> Self {
+        Self {
+            config: OnceLock::new(),
+            label,
+            state: AtomicState::new(State::Uninitialized),
+            command_channel: Channel::new(),
+            result_signal: Signal::new(),
+        }
+    }
+
+    /// Initializes the driver with a configuration. Needs to be run before triggering measurements.
+    #[expect(
+        clippy::unused_async,
+        reason = "uniformity with other drivers so it can be codegened"
+    )]
+    pub async fn init(&self, config: config::Config) {
+        self.state.set(State::Enabled);
+
+        let _ = self.config.init(config);
+
+        debug!("nRF91 GNSS driver initialized");
+    }
+
+    /// At this point the sensor assume the modem is already initialized with the GNSS feature enabled.
+    /// In single shot mode, taking a measurement will return until a fix is obtained or the timeout is reached.
+    /// In continuous or periodic mode, taking a measurement will return the current status of the GNSS module, even if a fix has not been obtained yet.
+    ///
+    /// # Panics
+    ///
+    /// When the modem library refuses the config or fails to initialize the GNSS system.
+    pub async fn run(&'static self) {
+        let configuration = self.config.get().await;
+        loop {
+            // Wait until the state is Enabled.
+            if self.state.get() != State::Enabled
+                && !matches!(self.command_channel.receive().await, Command::Start)
+            {
+                continue;
+            }
+
+            let gnss_stream = match configuration.operation_mode {
+                GnssOperationMode::Continuous => Gnss::new()
+                    .await
+                    .unwrap()
+                    .start_continuous_fix(convert_gnss_config(configuration))
+                    .expect("Continuous fix initialization"),
+                GnssOperationMode::Periodic(period) => Gnss::new()
+                    .await
+                    .unwrap()
+                    .start_periodic_fix(convert_gnss_config(configuration), period)
+                    .expect("Periodic fix initialization"),
+
+                GnssOperationMode::SingleShot(timeout) => {
+                    match self.command_channel.receive().await {
+                        Command::Trigger => Gnss::new()
+                            .await
+                            .unwrap()
+                            .start_single_fix(convert_gnss_config(configuration), timeout)
+                            .expect("Single shot fix initialization"),
+
+                        Command::Stop => {
+                            warn!("Trying to stop the GNSS module when it is already stopped");
+                            continue;
+                        }
+                        Command::Start => {
+                            debug!("Ignoring Start command in SingleShot mode");
+                            continue;
+                        }
+                    }
+                }
+            };
+
+            self.handle_gnss_stream(gnss_stream, configuration).await;
+        }
+    }
+
+    async fn handle_gnss_stream(
+        &'static self,
+        mut gnss_stream: GnssStream,
+        configuration: &Config,
+    ) {
+        let mut latest_data = None;
+        let mut should_send_update = false;
+
+        loop {
+            if !matches!(self.state.get(), State::Enabled | State::Measuring) {
+                error!("Invalid state found");
+                break;
+            }
+
+            match select(self.command_channel.receive(), gnss_stream.next()).await {
+                Either::First(Command::Start) => {
+                    warn!("GNSS sensor already started");
+                }
+                Either::First(Command::Stop) => {
+                    break;
+                }
+                Either::Second(None) => {
+                    // In single shot mode, the stream ending means it has found a fix.
+                    if matches!(
+                        configuration.operation_mode,
+                        GnssOperationMode::SingleShot(_)
+                    ) {
+                        self.result_signal.clear();
+                        if let Some(data) = latest_data {
+                            let samples = self.convert_to_samples(&data);
+                            self.result_signal.signal(Ok(samples));
+                        } else {
+                            self.result_signal.signal(Err(ReadingError::SensorAccess));
+                        }
+                    }
+                    break;
+                }
+                Either::First(Command::Trigger) => {
+                    // Ignore, already running
+                    if should_send_update
+                        || matches!(
+                            configuration.operation_mode,
+                            GnssOperationMode::SingleShot(_)
+                        )
+                    {
+                        warn!("Received Trigger command while already processing one");
+                    } else {
+                        should_send_update = true;
+                    }
+                }
+                Either::Second(Some(Ok(message))) => match message {
+                    GnssData::PositionVelocityTime(pos) => {
+                        if should_send_update {
+                            let samples = self.convert_to_samples(&pos);
+                            self.result_signal.signal(Ok(samples));
+                            should_send_update = false;
+                        }
+
+                        // Only matters if we're in SingleShot mode.
+                        latest_data = Some(pos);
+                    }
+                    GnssData::Nmea(nmea_message) => {
+                        debug!("NMEA: {}", nmea_message.as_str());
+                    }
+                    GnssData::Agps(_) => {
+                        // Ignore AGPS data
+                    }
+                },
+                Either::Second(Some(Err(e))) => {
+                    warn!("GNSS error: {}", e);
+                }
+            }
+        }
+        let _ = gnss_stream.deactivate().await;
+    }
+
+    /// Convert time from `nrf_modem` to parts that can be put in samples.
+    ///
+    /// # Panics
+    ///
+    /// When the date is too far in the future / past.
+    fn convert_to_time_parts(
+        data: &nrf_modem::nrfxlib_sys::nrf_modem_gnss_pvt_data_frame,
+    ) -> Option<(i32, i32)> {
+        let parsed_date = Date::from_calendar_date(
+            data.datetime.year.into(),
+            Month::try_from(data.datetime.month).ok()?,
+            data.datetime.day,
+        )
+        .ok()?;
+
+        let time = Time::from_hms_milli(
+            data.datetime.hour,
+            data.datetime.minute,
+            data.datetime.seconds,
+            data.datetime.ms,
+        )
+        .ok()?;
+
+        // Default year when no GNSS fix.
+        if data.datetime.year == 1980 {
+            return None;
+        }
+
+        let timestamp = UtcDateTime::new(parsed_date, time).unix_timestamp_nanos();
+
+        Some(ariel_os_sensors_gnss_time_ext::convert_datetime_to_parts(timestamp).unwrap())
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    fn convert_to_samples(
+        &'static self,
+        data: &nrf_modem::nrfxlib_sys::nrf_modem_gnss_pvt_data_frame,
+    ) -> Samples {
+        let time_parts = Self::convert_to_time_parts(data);
+
+        let (time_seconds_part, time_nanos_part) = if let Some(time_parts) = time_parts {
+            (
+                Sample::new(time_parts.0, SampleMetadata::UnknownAccuracy),
+                Sample::new(time_parts.1, SampleMetadata::UnknownAccuracy),
+            )
+        } else {
+            (
+                Sample::new(0, SampleMetadata::ChannelTemporarilyUnavailable),
+                Sample::new(0, SampleMetadata::ChannelTemporarilyUnavailable),
+            )
+        };
+
+        let latitude_accuracy = (f64::from(data.accuracy) * DEGREES_PER_METER_BASE) as f32;
+
+        // For longitude, the distance represented by a degree changes depending on the latitude
+        //
+        // The perimeter of the circle formed by the latitude is `cos(latitude_radians) * EARTH_RADIUS * 2 * PI`
+        // Full formula here is `longitude_accuracy = accuracy * 360 / (cos(latitude_radians) * EARTH_RADIUS * 2 * PI)`. We have 360 / (EARTH_RADIUS * 2 * PI) already pre-computed.
+        let longitude_accuracy = (f64::from(data.accuracy) * DEGREES_PER_METER_BASE
+            / libm::cos(data.latitude.to_radians())) as f32;
+
+        let latitude_value = (data.latitude * 10_000_000f64) as i32;
+        let longitude_value = (data.longitude * 10_000_000f64) as i32;
+        let altitude_value = (data.altitude * 100f32) as i32;
+
+        let fix_valid = (u32::from(data.flags)
+            & nrf_modem::nrfxlib_sys::NRF_MODEM_GNSS_PVT_FLAG_FIX_VALID)
+            != 0;
+
+        let (latitude, longitude, altitude) = if fix_valid {
+            let latitude = Sample::new(
+                latitude_value,
+                SampleMetadata::SymmetricalError {
+                    // One meter is approximately 0.000009 degrees. Accuracy value usually between 1 and 50 meters.
+                    deviation: clamp_to_u8(latitude_accuracy * 100_000f32),
+                    bias: 0,
+                    scaling: -5,
+                },
+            );
+            let longitude = Sample::new(
+                longitude_value,
+                SampleMetadata::SymmetricalError {
+                    deviation: clamp_to_u8(longitude_accuracy * 100_000f32),
+                    bias: 0,
+                    scaling: -5,
+                },
+            );
+            let altitude = Sample::new(
+                altitude_value,
+                SampleMetadata::SymmetricalError {
+                    deviation: clamp_to_u8(data.altitude_accuracy * 10f32),
+                    bias: 0,
+                    scaling: -1,
+                },
+            );
+            (latitude, longitude, altitude)
+        } else {
+            (
+                Sample::new(
+                    latitude_value,
+                    SampleMetadata::ChannelTemporarilyUnavailable,
+                ),
+                Sample::new(
+                    longitude_value,
+                    SampleMetadata::ChannelTemporarilyUnavailable,
+                ),
+                Sample::new(
+                    altitude_value,
+                    SampleMetadata::ChannelTemporarilyUnavailable,
+                ),
+            )
+        };
+
+        let horizontal_speed_value = (data.speed * 1_000_000f32) as i32;
+        let vertical_speed_value = (data.vertical_speed * 1_000_000f32) as i32;
+        let heading_value = (data.heading * 1_000_000f32) as i32;
+
+        let velocity_valid = (u32::from(data.flags)
+            & nrf_modem::nrfxlib_sys::NRF_MODEM_GNSS_PVT_FLAG_VELOCITY_VALID)
+            != 0;
+
+        let (horizontal_speed, vertical_speed, heading) = if velocity_valid {
+            let horizontal_speed = Sample::new(
+                horizontal_speed_value,
+                SampleMetadata::SymmetricalError {
+                    deviation: clamp_to_u8(data.speed_accuracy * 10f32),
+                    bias: 0,
+                    scaling: -1,
+                },
+            );
+
+            let vertical_speed = Sample::new(
+                vertical_speed_value,
+                SampleMetadata::SymmetricalError {
+                    deviation: clamp_to_u8(data.vertical_speed_accuracy * 10f32),
+                    bias: 0,
+                    scaling: -1,
+                },
+            );
+
+            let heading = Sample::new(
+                heading_value,
+                SampleMetadata::SymmetricalError {
+                    deviation: clamp_to_u8(data.heading_accuracy),
+                    bias: 0,
+                    scaling: 0,
+                },
+            );
+            (horizontal_speed, vertical_speed, heading)
+        } else {
+            (
+                Sample::new(
+                    horizontal_speed_value,
+                    SampleMetadata::ChannelTemporarilyUnavailable,
+                ),
+                Sample::new(
+                    vertical_speed_value,
+                    SampleMetadata::ChannelTemporarilyUnavailable,
+                ),
+                Sample::new(heading_value, SampleMetadata::ChannelTemporarilyUnavailable),
+            )
+        };
+
+        Samples::from_8(
+            self,
+            [
+                time_seconds_part,
+                time_nanos_part,
+                latitude,
+                longitude,
+                altitude,
+                horizontal_speed,
+                vertical_speed,
+                heading,
+            ],
+        )
+    }
+}
+
+impl Sensor for Nrf91Gnss {
+    fn trigger_measurement(&self) -> Result<(), ariel_os_sensors::sensor::TriggerMeasurementError> {
+        // Clear the last value if there was one.
+        self.result_signal.clear();
+        match self.state.get() {
+            State::Measuring => {
+                warn!("GNSS: already measuring");
+            }
+            State::Enabled => {
+                // Mark as measuring so we don't trigger twice.
+                self.state.set(State::Measuring);
+
+                if let Err(e) = self.command_channel.try_send(Command::Trigger) {
+                    error!("Couldn't send trigger command: {:?} ", Debug2Format(&e));
+                }
+            }
+
+            State::Disabled | State::Sleeping | State::Uninitialized => {
+                return Err(ariel_os_sensors::sensor::TriggerMeasurementError::NonEnabled);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn wait_for_reading(&'static self) -> ariel_os_sensors::sensor::ReadingWaiter {
+        match self.state.get() {
+            State::Measuring => {
+                self.state.set(State::Enabled);
+                ReadingWaiter::new(self.result_signal.wait())
+            }
+            State::Enabled => ReadingWaiter::new_err(ReadingError::NotMeasuring),
+            State::Disabled | State::Uninitialized | State::Sleeping => {
+                ReadingWaiter::new_err(ReadingError::NonEnabled)
+            }
+        }
+    }
+
+    fn reading_channels(&self) -> ariel_os_sensors::sensor::ReadingChannels {
+        ReadingChannels::from([
+            // Putting these first so `GnssExt` doesn't spend more time searching for them.
+            ReadingChannel::new(
+                // Seconds since Ariel epoch (2025-01-01)
+                Label::OpaqueGnssTime,
+                0,
+                MeasurementUnit::Second,
+            ),
+            ReadingChannel::new(
+                // Milliseconds
+                Label::Opaque,
+                -3,
+                MeasurementUnit::Second,
+            ),
+            ReadingChannel::new(
+                // Accuracy is in meters.
+                Label::Latitude,
+                -7,
+                MeasurementUnit::DecimalDegree,
+            ),
+            ReadingChannel::new(
+                // Max value of an i32 is 2,147,483,647
+                // The value ranges from -180 to 180, we can go to 10^-7, making the max possible value 214.
+                // The smallest distance between two points at the equator is 40,075,016/360 * 10^-7 ~= 0.012 meters
+                // Accuracy is in meters.
+                Label::Longitude,
+                -7,
+                MeasurementUnit::DecimalDegree,
+            ),
+            ReadingChannel::new(
+                // Smallest distance between two altitude reading: 0.01 meters.
+                // Value ranging from -21,474,836 meters to 21,474,836 meters.
+                Label::Altitude,
+                -2,
+                MeasurementUnit::Meter,
+            ),
+            ReadingChannel::new(
+                // Max value is 2,147 m/s
+                // Smallest distance between two speed readings: 0.000001 m/s
+                Label::GroundSpeed,
+                -6,
+                MeasurementUnit::MeterPerSecond,
+            ),
+            ReadingChannel::new(
+                // Max value is 2,147 m/s
+                // Smallest distance between two speed readings: 0.000001 m/s
+                Label::VerticalSpeed,
+                -6,
+                MeasurementUnit::MeterPerSecond,
+            ),
+            ReadingChannel::new(
+                // Max value is 360 degrees
+                // Smallest distance between two heading readings: 0.000001 degrees
+                Label::Heading,
+                -6,
+                MeasurementUnit::Degree,
+            ),
+        ])
+    }
+
+    fn set_mode(
+        &self,
+        mode: Mode,
+    ) -> Result<ariel_os_sensors::sensor::State, ariel_os_sensors::sensor::SetModeError> {
+        let old = self.state.set_mode(mode)?;
+
+        let result = match mode {
+            Mode::Enabled => self.command_channel.try_send(Command::Start),
+            Mode::Disabled | Mode::Sleeping => self.command_channel.try_send(Command::Stop),
+        };
+
+        // We also check the state in the run loop.
+        // An error here means that the channel is full, meaning the state update will be noticed once the run loop checks the new state.
+        if let Err(err) = result {
+            debug!("Couldn't send the command: {:?}", Debug2Format(&err));
+        }
+
+        Ok(old)
+    }
+
+    fn state(&self) -> State {
+        self.state.get()
+    }
+
+    fn categories(&self) -> &'static [ariel_os_sensors::Category] {
+        &[Category::Gnss]
+    }
+
+    fn label(&self) -> Option<&'static str> {
+        self.label
+    }
+
+    fn display_name(&self) -> Option<&'static str> {
+        Some("nRF91 GNSS")
+    }
+
+    fn part_number(&self) -> Option<&'static str> {
+        Some("nRF91xx")
+    }
+
+    fn version(&self) -> u8 {
+        0
+    }
+}

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -83,6 +83,31 @@ criteria = "safe-to-deploy"
 delta = "0.1.3 -> 0.2.0"
 notes = "The source code was not changed at all"
 
+[[audits.futures-core]]
+who = "Nils Ponsard <nils.ponsard@inria.fr>"
+criteria = "safe-to-deploy"
+delta = "0.3.31 -> 0.3.32"
+
+[[audits.futures-macro]]
+who = "Nils Ponsard <nils.ponsard@inria.fr>"
+criteria = "safe-to-deploy"
+delta = "0.3.31 -> 0.3.32"
+
+[[audits.futures-sink]]
+who = "Nils Ponsard <nils.ponsard@inria.fr>"
+criteria = "safe-to-deploy"
+delta = "0.3.31 -> 0.3.32"
+
+[[audits.futures-task]]
+who = "Nils Ponsard <nils.ponsard@inria.fr>"
+criteria = "safe-to-deploy"
+delta = "0.3.31 -> 0.3.32"
+
+[[audits.futures-util]]
+who = "Nils Ponsard <nils.ponsard@inria.fr>"
+criteria = "safe-to-deploy"
+delta = "0.3.31 -> 0.3.32"
+
 [[audits.litrs]]
 who = "Antoine Lavandier <antoine.lavandier@inria.fr>"
 criteria = "safe-to-deploy"
@@ -109,6 +134,11 @@ who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"
 delta = "2.9.2 -> 3.0.3+3.0.2"
 notes = "Review extends to the source of nrfxlib-sys only. The library ships also proprietary C components, which were not (and, due to being closed source, can not) be reviewed."
+
+[[audits.num-conv]]
+who = "Nils Ponsard <nils.ponsard@inria.fr>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
 
 [[audits.pretty-hex]]
 who = "ROMemories <152802150+ROMemories@users.noreply.github.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1417,6 +1417,10 @@ criteria = "safe-to-deploy"
 version = "0.3.45"
 criteria = "safe-to-deploy"
 
+[[exemptions.time]]
+version = "0.3.47"
+criteria = "safe-to-deploy"
+
 [[exemptions.time-core]]
 version = "0.1.7"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -194,6 +194,12 @@ when = "2025-04-15"
 user-id = 55123
 user-login = "rust-lang-owner"
 
+[[publisher.libm]]
+version = "0.2.16"
+when = "2026-01-24"
+user-id = 55123
+user-login = "rust-lang-owner"
+
 [[publisher.linkme]]
 version = "0.3.33"
 when = "2025-05-17"
@@ -2858,6 +2864,13 @@ side-effectful std functions, etc.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.num-conv]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Revision only removes code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.num-derive]]
 who = "Josh Stone <jistone@redhat.com>"
 criteria = "safe-to-deploy"
@@ -3086,6 +3099,37 @@ who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
 delta = "0.13.1 -> 0.13.2"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Kershaw Chang <kershaw@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.1 -> 0.1.2"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.2 -> 0.1.4"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.time-core]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.4 -> 0.1.8"
+notes = "No unsafe code"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.tinystr]]
 who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"


### PR DESCRIPTION
# Description

This PR adds the GNSS support for the nrf91 SiP, exposing it via the sensor abstraction.

## Testing 


Doc can be open using:

```sh
cargo doc -p ariel-os-sensor-nrf91-gnss --features "nrf-modem/nrf9160, ariel-os-debug-log/log" --open 
```

Can be tested on hardware using: 

```sh
laze -C examples/sensors-debug/ build -b nrf9160dk-nrf9160 run
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
- Depends on #1332
- Depends on #1354
- Depends on #1398
- Depends on #1351 
- Depends on #1683 
- Depends on #1981

## Open Questions

<!-- Unresolved questions, if any. -->

u8 for the deviation is quite limiting, for example the heading accuracy number returned by the modem is 180 when no movement is detected, this means the accuracy can only be indicated down to the degree.
Same thing for the latitude and longitude, the modem returns accuracy numbers over 25 meters on the first seconds.
Currently I clamp the deviation values to stay within the u8 limits, for example I wanted to have `-1 scaling` on the position accuracy, meaning if the reported accuracy number is greater than 25.5 meters it gets clamped down to 25.5


The main modem initialization has to happen in `ariel-os-nrf` so it can also be used to setup LTE-M networking, right now that means the app has to explicitly select the `nrf91-modem` laze feature, it would be better to have the GNSS driver express the dependency. 

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The GNSS on the nRF91 SiP family can now be used as a sensor through Ariel OS's sensor API.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
