### PR TITLE
feat(sensors): make the accuracy's deviation an unsigned integer

### DIFF
--- a/src/ariel-os-sensors/src/sample.rs
+++ b/src/ariel-os-sensors/src/sample.rs
@@ -89,7 +89,7 @@ pub enum Accuracy {
     /// ```
     SymmetricalError {
         /// Deviation around the bias value.
-        deviation: i8,
+        deviation: u8,
         /// Bias (mean accuracy error).
         bias: i8,
         /// Scaling of [`deviation`](Accuracy::SymmetricalError::deviation) and


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Unlike the bias which is a position, the deviation is a distance so it can only be positive or zero.

This is not a breaking change as this API is not yet documented.

Using `ci-build:skip` as there is no users in the tree yet.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->
@nponsard Can you check this actually makes sense?

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
