### PR TITLE
chore(sensors): remove unneeded unstable feature `used_with_arg`

### DIFF
--- a/src/ariel-os-sensors/src/lib.rs
+++ b/src/ariel-os-sensors/src/lib.rs
@@ -48,8 +48,6 @@
 //! Sensor drivers must implement the [`Sensor`] trait.
 //!
 #![no_std]
-// Required by linkme
-#![feature(used_with_arg)]
 #![deny(clippy::pedantic)]
 #![deny(missing_docs)]
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This is a leftover of when this was need for `linkme`, which is used by the sensor registry to collect sensor driver instances across crates in the build.

Using `ci-build:skip` as there is no users in the tree yet.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
