### PR TITLE
feat(random): Add support for getrandom

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,7 +157,7 @@ jobs:
             --
             --deny warnings
 
-      - run: echo 'RUSTFLAGS=--cfg context="esp32c6"' >> $GITHUB_ENV
+      - run: echo 'RUSTFLAGS=--cfg context="esp32c6" --cfg getrandom_backend="custom"' >> $GITHUB_ENV
       - name: clippy for ESP32
         uses: clechasseur/rs-clippy-check@69da786488ddcceb16285b0219841750089369ba # v5
         with:
@@ -176,7 +176,7 @@ jobs:
             --
             --deny warnings
 
-      - run: echo 'RUSTFLAGS=--cfg context="cortex-m" --cfg context="rp" --cfg context="rp2040"' >> $GITHUB_ENV
+      - run: echo 'RUSTFLAGS=--cfg context="cortex-m" --cfg context="rp" --cfg context="rp2040" --cfg getrandom_backend="custom"' >> $GITHUB_ENV
       - name: clippy for RP
         uses: clechasseur/rs-clippy-check@69da786488ddcceb16285b0219841750089369ba # v5
         with:
@@ -195,7 +195,7 @@ jobs:
             --
             --deny warnings
 
-      - run: echo 'RUSTFLAGS=--cfg context="nrf52840" --cfg context="nrf52"' >> $GITHUB_ENV
+      - run: echo 'RUSTFLAGS=--cfg context="nrf52840" --cfg context="nrf52" --cfg getrandom_backend="custom"' >> $GITHUB_ENV
       - name: clippy for nRF
         uses: clechasseur/rs-clippy-check@69da786488ddcceb16285b0219841750089369ba # v5
         with:
@@ -215,7 +215,7 @@ jobs:
             --
             --deny warnings
 
-      - run: echo 'RUSTFLAGS=--cfg context="stm32wb55rg"' >> $GITHUB_ENV
+      - run: echo 'RUSTFLAGS=--cfg context="stm32wb55rg" --cfg getrandom_backend="custom"' >> $GITHUB_ENV
       - name: clippy for STM32
         uses: clechasseur/rs-clippy-check@69da786488ddcceb16285b0219841750089369ba # v5
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ name = "ariel-os-random"
 version = "0.2.0"
 dependencies = [
  "embassy-sync 0.6.2",
+ "getrandom 0.3.3",
  "rand_chacha",
  "rand_core",
  "rand_pcg",

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1307,6 +1307,8 @@ modules:
       global:
         FEATURES:
           - ariel-os/hwrng
+        RUSTFLAGS:
+          - --cfg getrandom_backend=\"custom\"
 
   - name: has_hwrng
     selects:
@@ -1435,17 +1437,6 @@ modules:
       global:
         FEATURES:
           - ariel-os/random
-
-  - name: random-crypto
-    help: A system-wide cryptographically secure RNG is available.
-    selects:
-      - random
-    env:
-      global:
-        FEATURES:
-          - ariel-os/csprng
-        RUSTFLAGS:
-          - --cfg getrandom_backend=\"custom\"
 
   - name: sw/benchmark
     help: provided if a target supports `benchmark()`

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1436,6 +1436,17 @@ modules:
         FEATURES:
           - ariel-os/random
 
+  - name: random-crypto
+    help: A system-wide cryptographically secure RNG is available.
+    selects:
+      - random
+    env:
+      global:
+        FEATURES:
+          - ariel-os/csprng
+        RUSTFLAGS:
+          - --cfg getrandom_backend=\"custom\"
+
   - name: sw/benchmark
     help: provided if a target supports `benchmark()`
     selects:

--- a/src/ariel-os-random/Cargo.toml
+++ b/src/ariel-os-random/Cargo.toml
@@ -17,7 +17,9 @@ embassy-sync.workspace = true
 rand_pcg = "0.3.1"
 rand_chacha = { version = "0.3.1", default-features = false, optional = true }
 
+getrandom = { version = "0.3.3", optional = true }
+
 [features]
 ## If set, the one global RNG is also a cryptographically secure pseudo
 ## random number generator (CSPRNG), and thus, a `CryptoRng` can be produced.
-csprng = ["dep:rand_chacha"]
+csprng = ["dep:rand_chacha", "dep:getrandom"]

--- a/src/ariel-os-random/src/lib.rs
+++ b/src/ariel-os-random/src/lib.rs
@@ -27,6 +27,8 @@
 use core::{cell::RefCell, marker::PhantomData};
 
 use embassy_sync::once_lock::OnceLock;
+#[cfg(feature = "csprng")]
+use getrandom::Error;
 use rand_core::{RngCore, SeedableRng as _};
 
 /// A global RNG.
@@ -245,4 +247,32 @@ pub fn crypto_rng_send() -> CryptoRngSend {
             rand_chacha::ChaCha20Rng::from_rng(i).expect("Global RNG is infallible")
         }),
     }
+}
+
+/// Implements RNG access for the `getrandom` crate
+///
+/// # Safety
+///
+/// See the `getrandom` documentation on custom backends.
+///
+/// # Errors
+///
+/// See the `getrandom` documentation on custom backends.
+///
+/// At the time of writing, all Ariel OS RNGs are infallible.
+///
+/// # Panics
+///
+/// The function panics if error conversion fails.
+#[cfg(feature = "csprng")]
+#[unsafe(no_mangle)]
+unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
+    let buf = unsafe {
+        core::ptr::write_bytes(dest, 0, len);
+        core::slice::from_raw_parts_mut(dest, len)
+    };
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    crypto_rng()
+        .try_fill_bytes(buf)
+        .map_err(|e| Error::new_custom(e.raw_os_error().unwrap() as u16))
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

This adds support for using Ariel OS's random as a backend for [getrandom](https://github.com/rust-random/getrandom) as described [here](https://github.com/rust-random/getrandom?tab=readme-ov-file#custom-backend).

Other crates using `rand` can then automatically use Ariel OS's random backend. The application just needs to be set up to use the custom backend, as described [here](https://github.com/rust-random/getrandom?tab=readme-ov-file#opt-in-backends).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

rust-random/getrandom#716
Depends on #1414.

## Open Questions

<!-- Unresolved questions, if any. -->

I'm not sure about the extra feature `getrandom`. What's your opinion?

I just had the idea of making the type of random generator which is used feature dependent if csprng is enabled or not. What do you think?

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
