### PR TITLE
chore: add vetting criterion for FLOSS

### DIFF
--- a/book/src/development-processes.md
+++ b/book/src/development-processes.md
@@ -66,7 +66,24 @@ Currently, `cargo-vet` is run in CI for each PR; if this proves to block the PR 
 
 Vetting a dependency involves either [performing an audit][cargo-vet-performing-audits], [trusting (all of) its publishers][cargo-vet-trusting-publishers], or adding an exemption (in which case it is not actually “vetted”).
 As we are still figuring out our vetting workflow, we are currently fine with adding new exemptions for both new crates and dependency updates.
-We may also introduce a [custom criteria][cargo-vet-custom-criteria] to reflect the actual meaning of our auditing process.
+
+We have also introduce a [custom criterion][cargo-vet-custom-criteria] (and may define more) to express additional aspects of the auditing process:
+
+* `floss`:
+
+  > (TBD: Find a way to programmatically include the text from supplychain/audits.toml in here before we go on elaborating)
+
+  Reviewing for this can easily happen as part of the regular auditing process,
+  as any lack of source files becomes visible through the point in the code where the source-less data is included.
+  Common entry points for source-less data are
+  invocations of [`include_bytes!()`](https://doc.rust-lang.org/std/macro.include_bytes.html) / [`include_str!()`](https://doc.rust-lang.org/std/macro.include_str.html)
+  and linking to static libraries through [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib).
+
+  An example of non-FLOSS code are statically linked libraries:
+  Even if they are published under an OSI-approved license and contain debug symbols,
+  they can not be modified in the same way their author could.
+  Another example are minified JavaScript libraries;
+  for those, an actual source can often be found and annotated.
 
 ## Release Checklist
 

--- a/book/src/development-processes.md
+++ b/book/src/development-processes.md
@@ -71,7 +71,7 @@ We have also introduce a [custom criterion][cargo-vet-custom-criteria] (and may 
 
 * `floss`:
 
-  > (TBD: Find a way to programmatically include the text from supplychain/audits.toml in here before we go on elaborating)
+  <!-- cmdrun tomlq -r .criteria.floss.description < ../../supply-chain/audits.toml | sed 's/^/  >/g' -->
 
   Reviewing for this can easily happen as part of the regular auditing process,
   as any lack of source files becomes visible through the point in the code where the source-less data is included.

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,29 @@
 
 # cargo-vet audits file
 
+[criteria.floss]
+description = """
+The crate contains Free Software as described by any of the Debians DFSG[1],
+the FSFE[2] or the OSI[3]. Note that checking for the license is *not* a
+sufficient criterion: The definitions also require the presence of source code
+that can actually be modified.
+
+If there are build artifacts contained in the crate that have no source in the
+crate itself, but are available as Free Software somewhere on the Web, the
+crate is eligible to be marked as FLOSS. In that case, the review needs to
+be annotated with references to the original source and any reproduction
+instructions in a note.
+
+[1]: https://www.debian.org/social_contract#guidelines
+[2]: https://fsfe.org/freesoftware/
+[3]: https://opensource.org/osd
+"""
+
+[[audits.log]]
+who = "chrysn <chrysn@fsfe.org>"
+criteria = "floss"
+version = "0.4.28"
+
 [[audits.log]]
 who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
# Description

Adding a criterion roughly like this will help us justify the claim that we produce Free Software (or Open Source software, insert Monty Python PFJ joke here).

Checking crates for this property will be rather quick (probably anything that doesn't have a build.rs might qualify automatically), but knowing this of all our dependencies documents for ourselves and our users that in case there is trouble with any of our dependencies, we have the option to fix things rather than rely on upstream. (This would be a more important criterion if CRA applied to us).

## Issues/PRs references

<del>Blocked by: https://github.com/ariel-os/ariel-os/pull/1296, https://github.com/anlavandier/ariel-os/pull/21, [edit: added] https://github.com/ariel-os/ariel-os/pull/1331</del>

Contributes-To: https://github.com/ariel-os/ariel-os/issues/845

## Change checklist

- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
