### PR TITLE
feat(probe-rs): add `attach` laze task

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1027,6 +1027,12 @@ modules:
           - probe-rs download --chip ${PROBE_RS_CHIP} ${out} $@
           - probe-rs reset --chip ${PROBE_RS_CHIP}
 
+      attach:
+        help: Attach probe-rs to rtt logging
+        build: false
+        cmd:
+          - probe-rs attach --chip ${PROBE_RS_CHIP} ${out} $@
+
       debug:
         help: Starts a probe-rs gdb server
         cmd:


### PR DESCRIPTION
# Description

This adds an 'attach' task to the probe-rs module, allowing to re-attach to an already flashed image for more output.

(Skipping CI build as this doesn't change any binary.)

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
