### PR TITLE
docs(readme): add documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ See the [Getting Started page][getting-started-mdbook] in the User Guide to get 
 
 ![Terminal screencast of compiling and flashing the hello-world example](./book/src/hello-world_render.svg)
 
+## Documentation
+
+Multiple resources are available to learn Ariel OS:
+
+- 📔 Extensive documentation for Ariel OS can be found in the
+  [book](https://ariel-os.github.io/ariel-os/dev/docs/book/).
+- 🛠️ Reference documentation for Ariel OS can be found in the
+  [API documentation](https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/).
+- ⚙️  The git repository is available on
+  [GitHub](https://github.com/ariel-os/ariel-os).
+- ✨ [Examples](https://github.com/ariel-os/ariel-os/tree/main/examples)
+  demonstrate various features of Ariel OS.
+- 🧪 A set of [test cases](https://github.com/ariel-os/ariel-os/tree/main/tests)
+  further verifies the capabilities of Ariel OS.
+- 🚧 The [roadmap](https://github.com/ariel-os/ariel-os/issues/242)
+  shows the planned features for Ariel OS.
+
 ## Minimum Supported Rust Version (MSRV) and Policy
 
 Ariel OS compiles with stable Rust version 1.85 and up.


### PR DESCRIPTION
# Description

While not everything here is strictly documentation, I've added the same set of urls as present in the api docs and PR'd for the book in #1352. The url to the github repo is in here too for completeness as the readme is not always read from the repo itself.

## Issues/PRs references

None

## Open Questions

- better section title welcome

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
