### PR TITLE
chore(tests): Add missing publish = false

### DIFF
--- a/tests/i2c-controller/Cargo.toml
+++ b/tests/i2c-controller/Cargo.toml
@@ -2,6 +2,7 @@
 name = "i2c-controller"
 license.workspace = true
 edition.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/tests/spi-loopback/Cargo.toml
+++ b/tests/spi-loopback/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spi-loopback"
 license.workspace = true
 edition.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/tests/spi-main/Cargo.toml
+++ b/tests/spi-main/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spi-main"
 license.workspace = true
 edition.workspace = true
+publish = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Description

Other tests and example have the key, to prevent mistakenly publish these tests on crates.io. For consistency this adds the key to the tests where it is still missing.

## Issues/PRs references


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
