### PR TITLE
docs(net): document support for static IPv6

### DIFF
--- a/book/src/networking.md
+++ b/book/src/networking.md
@@ -52,7 +52,7 @@ The configuration can be customized with the following environment variables:
 Support for IPv6 is not currently enabled by default, but can be enabled by selecting the `ipv6` [laze module](./build-system.md#laze-modules).
 IPv4 and IPv6 can both be enabled at the same time.
 
-IPv6 currently only supports static configuration, which can be selected with the `network-config-ipv6-static` [laze module](./build-system.md#laze-modules).
+IPv6 currently only supports static configuration, which is therefore enabled by default; it can also be explicitly selected with the `network-config-ipv6-static` [laze module](./build-system.md#laze-modules).
 
 The configuration must be customized with the following environment variables:
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Document support for static IPv6 newly added by #915.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
- Depends on #915
- Depends on #1571
- Depends on #1651

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
Support for IPv6 has been added, which can be used alongside IPv4 or in place of it. Only static configuration is currently supported. See [the networking documentation](https://ariel-os.github.io/ariel-os/dev/docs/book/networking.html) for details.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
