### PR TITLE
refactor(dhcpv4): enable the `dhcpv4` feature through laze

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1097,6 +1097,10 @@ modules:
       - network-config-dhcp
     provides_unique:
       - network-config-ipv4
+    env:
+      global:
+        FEATURES:
+          - ariel-os/dhcpv4
 
   - name: network-config-static
     help: "deprecated: use `network-config-ipv4-static` instead"

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -22,8 +22,8 @@ embassy-executor = { workspace = true }
 embassy-futures = { workspace = true }
 embassy-hal-internal = { workspace = true }
 embassy-net = { workspace = true, optional = true, features = [
-  "dhcpv4",
   "medium-ethernet",
+  "proto-ipv4",
 ] }
 embassy-sync = { workspace = true }
 embassy-time = { workspace = true, optional = true }
@@ -98,6 +98,8 @@ random = ["dep:ariel-os-random", "dep:rand_core"]
 ## Use a hardware RNG to seed into the ariel-os-random system-wide RNG
 hwrng = ["ariel-os-hal/hwrng"]
 
+## Enables support for DHCPv4.
+dhcpv4 = ["embassy-net?/dhcpv4"]
 ## Enables support for TCP.
 tcp = ["embassy-net?/tcp"]
 ## Enables support for UDP.
@@ -157,4 +159,4 @@ defmt = [
 ]
 log = ["ariel-os-hal/log"]
 
-_test = ["executor-none", "i2c", "spi", "time", "external-interrupts"]
+_test = ["dhcpv4", "executor-none", "i2c", "spi", "time", "external-interrupts"]

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -21,6 +21,7 @@ heapless = { workspace = true }
 ariel-os = { workspace = true, features = [
   "threading",
   "no-boards",
+  "dhcpv4",
   "usb-ethernet",
   "network-config-override",
 ] }

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -70,6 +70,8 @@ hwrng = ["ariel-os-embassy/hwrng"]
 sensors = ["dep:ariel-os-sensors"]
 
 #! ## Network protocols
+# Enables support for DHCPv4.
+dhcpv4 = ["ariel-os-embassy/dhcpv4"]
 ## Enables support for TCP.
 tcp = ["ariel-os-embassy/tcp"]
 ## Enables support for UDP.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Until now, DHCPv4 was hard-coded as always enabled on `embassy-net` even when when unused. This PR enables DHCPv4 only when the `network-config-ipv4-dhcp` laze module is selected, which is necessary for supporting IPv6 and makes the binary smaller when DHCP is not used.

## How to review this PR

Hiding whitespace helps a bit.

## Testing

Successfully tested with DHCP on espressif-esp32-c6-devkitc-1 and without it on nrf52840dk.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Extracted from #915.

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
DHCPv4 is now only enabled when the `network-config-ipv4-dhcp` laze module (formerly `network-config-dhcp`) is enabled, instead of always being enabled. This may reduce the size of applications not using DHCP.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
