### PR TITLE
fix(sensors): fix the sensor data structs when `max-sample-min-count`>1

### DIFF
--- a/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
+++ b/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
@@ -67,7 +67,7 @@ pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
     let reading_channels_iter = (1..=count)
         .map(|i| {
             let variant = variant_name(i);
-            quote! { InnerReadingChannels::#variant(ref samples) => samples.iter().copied() }
+            quote! { InnerReadingChannels::#variant(ref channels) => channels.iter().copied() }
         });
 
     let expanded = quote! {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This fixes #1379, which found a type issue introduced in #1360 that appears when `max-sample-min-count`>1.

## How to review this PR

This PR is better reviewed commit by commit.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #1379.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
