### PR TITLE
refactor(docs): move Tier enum in external schema module

### DIFF
--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -105,7 +105,7 @@ impl Args {
         }
     }
 
-    fn tier(&self) -> &SupportTier {
+    fn tier(&self) -> &schema::Tier {
         match self.command {
             SubCommand::Generate(SubCommandGenerate { ref tier, .. }) => tier,
             SubCommand::Check(SubCommandCheck { ref tier, .. }) => tier,
@@ -120,40 +120,13 @@ enum SubCommand {
     Check(SubCommandCheck),
 }
 
-enum SupportTier {
-    Tier1,
-    Tier2,
-    Tier3,
-}
-
-impl argh::FromArgValue for SupportTier {
-    fn from_arg_value(value: &str) -> Result<Self, String> {
-        match value {
-            "tier-1" | "1" => Ok(Self::Tier1),
-            "tier-2" | "2" => Ok(Self::Tier2),
-            "tier-3" | "3" => Ok(Self::Tier3),
-            _ => Err("invalid board support tier".to_string()),
-        }
-    }
-}
-
-impl ToString for SupportTier {
-    fn to_string(&self) -> String {
-        match self {
-            SupportTier::Tier1 => "1".to_string(),
-            SupportTier::Tier2 => "2".to_string(),
-            SupportTier::Tier3 => "3".to_string(),
-        }
-    }
-}
-
 #[derive(argh::FromArgs)]
 #[argh(subcommand, name = "generate")]
 /// generate the HTML support matrix
 struct SubCommandGenerate {
     /// board support tier (1, 2, or 3)
     #[argh(option)]
-    tier: SupportTier,
+    tier: schema::Tier,
     #[argh(positional)]
     /// path of the input YAML file
     input_file: PathBuf,
@@ -168,7 +141,7 @@ struct SubCommandGenerate {
 struct SubCommandCheck {
     /// board support tier (1, 2 or 3)
     #[argh(option)]
-    tier: SupportTier,
+    tier: schema::Tier,
     #[argh(positional)]
     /// path of the input YAML file
     input_file: PathBuf,
@@ -373,7 +346,7 @@ fn gen_functionalities(matrix: &schema::Matrix) -> Result<Vec<BoardSupport>, Err
 fn render_html(
     matrix: &schema::Matrix,
     mut boards: Vec<BoardSupport>,
-    board_support_tier: &SupportTier,
+    board_support_tier: &schema::Tier,
 ) -> Result<String, Error> {
     use minijinja::{Environment, context};
 

--- a/doc/schema.rs
+++ b/doc/schema.rs
@@ -66,3 +66,30 @@ impl SupportInfo {
         }
     }
 }
+
+pub enum Tier {
+    Tier1,
+    Tier2,
+    Tier3,
+}
+
+impl argh::FromArgValue for Tier {
+    fn from_arg_value(value: &str) -> Result<Self, String> {
+        match value {
+            "tier-1" | "1" => Ok(Self::Tier1),
+            "tier-2" | "2" => Ok(Self::Tier2),
+            "tier-3" | "3" => Ok(Self::Tier3),
+            _ => Err("invalid board support tier".to_string()),
+        }
+    }
+}
+
+impl ToString for Tier {
+    fn to_string(&self) -> String {
+        match self {
+            Tier::Tier1 => "1".to_string(),
+            Tier::Tier2 => "2".to_string(),
+            Tier::Tier3 => "3".to_string(),
+        }
+    }
+}


### PR DESCRIPTION
# Description

This PR moves the definition of the `Tier` enum to the `schema` module in `schema.rs`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
