### PR TITLE
feat(sensors-api): add opaque sample values

### DIFF
--- a/src/ariel-os-sensors/src/label.rs
+++ b/src/ariel-os-sensors/src/label.rs
@@ -38,6 +38,8 @@ pub enum Label {
     Longitude,
     /// Used for sensor drivers returning a single [`Sample`](crate::sensor::Sample).
     Main,
+    /// Opaque channel: the associated sample is intended for the sensor driver only, and no guarantees are provided.
+    Opaque,
     /// Relative humidity.
     RelativeHumidity,
     /// Heading.
@@ -68,6 +70,7 @@ impl core::fmt::Display for Label {
             Self::Latitude => write!(f, "Latitude"),
             Self::Longitude => write!(f, "Longitude"),
             Self::Main => write!(f, ""),
+            Self::Opaque => write!(f, "[opaque]"),
             Self::RelativeHumidity => write!(f, "Relative humidity"),
             Self::Heading => write!(f, "Heading"),
             Self::Temperature => write!(f, "Temperature"),


### PR DESCRIPTION
# Description

This PR adds opaque sample values, those values are meant to be read using a custom trait provided by the sensor driver or a library.

## Issues/PRs references

- Depends on #1399


## Open Questions

I just realized while preparing this PR that going this way would hurt the discoverability aspect of the sensors api. These changes would be to make opaque the storage of a timestamp coming from the nrf91 GNSS API.

Is this a good idea ? 

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
