### PR TITLE
refactor(net): rename IPv4-only Cargo features

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1118,7 +1118,7 @@ modules:
     env:
       global:
         FEATURES:
-          - ariel-os/network-config-static
+          - ariel-os/network-config-ipv4-static
 
   - name: sw/storage
     selects:

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -135,7 +135,7 @@ ble-peripheral = ["ble", "ariel-os-hal/ble-peripheral"]
 ble-central = ["ble", "ariel-os-hal/ble-central"]
 
 threading = ["dep:ariel-os-threads", "ariel-os-hal/threading"]
-network-config-static = ["network-config-override"]
+network-config-ipv4-static = ["network-config-override"]
 network-config-override = []
 override-usb-config = []
 ble-config-override = []

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -160,7 +160,7 @@ impl embassy_net::driver::RxToken for DummyDriver {
     }
 }
 
-#[cfg(feature = "network-config-static")]
+#[cfg(feature = "network-config-ipv4-static")]
 // SAFETY: the compiler prevents from defining multiple functions with the same name in the
 // same crate; the function signature is checked by the compiler as it is in the same crate as the
 // FFI declaration.

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -99,8 +99,8 @@ coap-server-config-unprotected = [
 # build system that knows who provides an abort and assert handler.
 liboscore-provide-abort = ["ariel-os-coap/liboscore-provide-abort"]
 liboscore-provide-assert = ["ariel-os-coap/liboscore-provide-assert"]
-# Selects static IP configuration.
-network-config-static = ["ariel-os-embassy/network-config-static"]
+# Selects static IPv4 configuration.
+network-config-ipv4-static = ["ariel-os-embassy/network-config-ipv4-static"]
 
 #! ## Serial communication
 ## Enables I2C support.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Follow-up to #1348 which renamed the laze modules, this now renames the IPv4 *Cargo features*, to prepare for #915.

The only remaining occurrences of `network-config-static` are the deprecated laze module.

## Testing

Successfully tested with:

```sh
laze -C examples/udp-echo/ build -d network-config-ipv4-dhcp -b nrf52840dk
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
