### PR TITLE
ci: reset `RUSTFLAGS` before running Clippy on `coapcore`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,6 +232,8 @@ jobs:
             --
             --deny warnings
 
+      # Reset `RUSTFLAGS`.
+      - run: echo 'RUSTFLAGS=' >> $GITHUB_ENV
       - name: clippy
         uses: clechasseur/rs-clippy-check@69da786488ddcceb16285b0219841750089369ba # v5
         with:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This resets the `RUSTFLAGS` environment variable before running the `coapcore` Clippy check, otherwise the `RUSTFLAGS` value set before still gets passed to `coapcore`, which makes it fail when passing a `--cfg` flag intended for embedded `getrandom` only, as `getrandom` is a transitive dependency of `cbindgen`, which `liboscore` uses (see https://github.com/ariel-os/ariel-os/pull/1339#issuecomment-3364623200).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Extracted from #1339.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
