### PR TITLE
docs(support): document that the nRF91 chips do not support USB

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -151,6 +151,8 @@ chips:
       logging: supported
       storage: supported
       wifi: not_available
+      user_usb: not_available
+      ethernet_over_usb: not_available
 
   rp2040:
     name: RP2040
@@ -476,8 +478,6 @@ boards:
     chip: nrf9160
     tier: "2"
     support:
-      user_usb: not_available
-      ethernet_over_usb: not_available
 
   rpi-pico:
     name: Raspberry Pi Pico


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This moves the `not_available` support status from the board info to the chip info for the nRF91s. Not only do the boards not feature a user USB port connected to these chips, but the chip themselves do not support USB.
This is easily seen in [Nordic's product comparison table](https://www.nordicsemi.com/-/media/Publications/WQ-Product-guide/Nordic-Product-Comparison-table-WQ-Dec-2024.pdf).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
