### PR TITLE
docs(support): document that some ESP chips do not support generic USB

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -214,6 +214,11 @@ chips:
         status: supported_with_caveats
         comments:
           - not currently compatible with threading
+      user_usb:
+        status: not_available
+        comments:
+          - no generic USB peripheral
+      ethernet_over_usb: not_available
 
   # Currently identical to esp32c3.
   esp32c3fx4:
@@ -233,6 +238,11 @@ chips:
         status: supported_with_caveats
         comments:
           - not currently compatible with threading
+      user_usb:
+        status: not_available
+        comments:
+          - no generic USB peripheral
+      ethernet_over_usb: not_available
 
   esp32c6:
     name: ESP32-C6
@@ -252,6 +262,11 @@ chips:
         status: supported_with_caveats
         comments:
           - not currently compatible with threading
+      user_usb:
+        status: not_available
+        comments:
+          - no generic USB peripheral
+      ethernet_over_usb: not_available
 
   esp32s3:
     name: ESP32-S3
@@ -620,11 +635,6 @@ boards:
     chip: esp32c3
     tier: "1"
     support:
-      user_usb:
-        status: not_available
-        comments:
-          - no generic USB peripheral
-      ethernet_over_usb: not_available
 
   espressif-esp32-c6-devkitc-1:
     name: Espressif ESP32-C6-DevKitC-1
@@ -632,11 +642,6 @@ boards:
     chip: esp32c6
     tier: "1"
     support:
-      user_usb:
-        status: not_available
-        comments:
-          - no generic USB peripheral
-      ethernet_over_usb: not_available
 
   espressif-esp32-s3-devkitc-1:
     name: Espressif ESP32-S3-DevKitC-1


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Similarly to #1435, this moves the user USB support status from the board info into the chip info, for ESPs that do not have a generic USB peripheral (ESP32-C3 and ESP32-C6).
This is in a way a follow-up to #1179.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #1433.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
