### PR TITLE
fix(rt): move esp32c3 isr stack after .rwdata_dummy

### DIFF
--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -10,8 +10,9 @@ fn main() {
     // Put the linker scripts somewhere the linker can find them
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    if let Some(context) = context_any(&["cortex-m", "riscv", "xtensa"]) {
+    if let Some(context) = context_any(&["esp32c3", "cortex-m", "riscv", "xtensa"]) {
         let insert_somewhere = match context {
+            "esp32c3" => "INSERT AFTER .rwdata_dummy;",
             "cortex-m" => "INSERT BEFORE .data;",
             "riscv" => "INSERT BEFORE .trap;",
             _ => "",
@@ -19,7 +20,7 @@ fn main() {
 
         let region = match context {
             "cortex-m" => "RAM",
-            "riscv" | "xtensa" => "RWDATA",
+            "riscv" | "xtensa" | "esp32c3" => "RWDATA",
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
# Description

This PR moves the isr stack after `.rwdata_dummy`, for esp32c3.

Doing this we lose the implicit stack protection, but this seems to be needed.

## Issues/PRs references

Fixes #1438.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
