### PR TITLE
fix(rt): set __stack_chk_guard to reasonable value

### DIFF
--- a/src/ariel-os-rt/isr_stack.ld.in
+++ b/src/ariel-os-rt/isr_stack.ld.in
@@ -22,5 +22,7 @@ _stack_start_cpu0 = _stack_highest_tmp;
 _stack_end = _stack_lowest_tmp;
 _stack_start = _stack_highest_tmp;
 
+__stack_chk_guard = _stack_lowest + 4096;
+
 ASSERT(_stack_start != _stack_lowest, "ERROR(ariel-os-rt): isr stack too small");
 ASSERT(_stack_start == _stack_highest_tmp, "ERROR(ariel-os-rt): _stack_start not used!");


### PR DESCRIPTION
# Description
The stack protector is currently not used, but as we're fiddling with the linker defines, we also need to update this. Otherwise the `__stack_chk_guard` points outside the stack, which might be surprising.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
