### PR TITLE
fix(rt): consider `executor-single-thread` for isr_stacksize

### DIFF
--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -58,7 +58,7 @@ mod isr_stack {
             "ISR stack size (in bytes)"
         );
 
-        #[cfg(feature = "executor-interrupt")]
+        #[cfg(any(feature = "executor-interrupt", feature = "executor-single-thread"))]
         {
             const CONFIG_EXECUTOR_STACKSIZE: usize = ariel_os_utils::usize_from_env_or!(
                 "CONFIG_EXECUTOR_STACKSIZE",
@@ -69,7 +69,7 @@ mod isr_stack {
             CONFIG_ISR_STACKSIZE + CONFIG_EXECUTOR_STACKSIZE
         }
 
-        #[cfg(not(feature = "executor-interrupt"))]
+        #[cfg(not(any(feature = "executor-interrupt", feature = "executor-single-thread")))]
         CONFIG_ISR_STACKSIZE
     };
 

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -198,7 +198,7 @@ executor-interrupt = [
   "ariel-os-rt/executor-interrupt",
 ]
 # Enables the single thread-mode executor.
-executor-single-thread = ["ariel-os-embassy/executor-single-thread"]
+executor-single-thread = ["ariel-os-rt/executor-single-thread", "ariel-os-embassy/executor-single-thread"]
 # Enables the ariel-os-threading thread executor.
 executor-thread = ["ariel-os-embassy/executor-thread", "threading"]
 # Don't start any executor automatically.


### PR DESCRIPTION
# Description

On esp, with `executor-single-thread` mode, there's only one stack used. This needs to be taken into account for stack size calculations.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
