### PR TITLE
feat(boards): add Support for Nordic Thingy:52

### DIFF
--- a/boards/nordic-thingy-52.yaml
+++ b/boards/nordic-thingy-52.yaml
@@ -1,0 +1,10 @@
+boards:
+  nordic-thingy-52:
+    chip: nrf52832
+    # While there are two sets of RGB LEDs (the highly visible "well" LED and
+    # the "sense" LEDs on the backside close to the color sensor), those are
+    # connected through the currently unsupported IO expander.
+    buttons:
+      button0:
+        pin: P0_11
+        active: low

--- a/src/ariel-os-boards/build.rs
+++ b/src/ariel-os-boards/build.rs
@@ -20,6 +20,7 @@ pub fn main() {
     );
     println!("cargo::rustc-check-cfg=cfg(context, values(\"heltec-wifi-lora-32-v3\"))");
     println!("cargo::rustc-check-cfg=cfg(context, values(\"native\"))");
+    println!("cargo::rustc-check-cfg=cfg(context, values(\"nordic-thingy-52\"))");
     println!(
         "cargo::rustc-check-cfg=cfg(context, values(\"nordic-thingy-91-x-nrf9151\"))"
     );

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -38,6 +38,10 @@ builders:
   - has_leds
 - name: native
   parent: native-chip
+- name: nordic-thingy-52
+  parent: nrf52832
+  provides:
+  - has_buttons
 - name: nordic-thingy-91-x-nrf9151
   parent: nrf9151
   provides:

--- a/src/ariel-os-boards/src/lib.rs
+++ b/src/ariel-os-boards/src/lib.rs
@@ -15,6 +15,7 @@ cfg_if::cfg_if! {
     include!("espressif-esp32-s3-devkitc-1.rs"); } else if #[cfg(context =
     "heltec-wifi-lora-32-v3")] { include!("heltec-wifi-lora-32-v3.rs"); } else if
     #[cfg(context = "native")] { include!("native.rs"); } else if #[cfg(context =
+    "nordic-thingy-52")] { include!("nordic-thingy-52.rs"); } else if #[cfg(context =
     "nordic-thingy-91-x-nrf9151")] { include!("nordic-thingy-91-x-nrf9151.rs"); } else if
     #[cfg(context = "nrf52840-mdk")] { include!("nrf52840-mdk.rs"); } else if
     #[cfg(context = "nrf52840dk")] { include!("nrf52840dk.rs"); } else if #[cfg(context =

--- a/src/ariel-os-boards/src/nordic-thingy-52.rs
+++ b/src/ariel-os-boards/src/nordic-thingy-52.rs
@@ -1,0 +1,8 @@
+// @generated
+
+pub mod pins {
+    use ariel_os_hal::hal::peripherals;
+    ariel_os_hal::define_peripherals!(ButtonPeripherals { button0 : P0_11, });
+}
+#[allow(unused_variables)]
+pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}


### PR DESCRIPTION
# Description

It's a nice affordable board with included battery and end-user friendly finishing.

Also a good way for me to try out the new board generation; awesome to have this in.

## Open issues

* [ ] LEDs and other peripherals are wired through a port multiplier. Until this is supported, the new board would be *very* bare-bones.

## Change checklist

- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
