### PR TITLE
fix(boards): correct which hardware module is used by the `ai-c3` board

### DIFF
--- a/boards/ai-c3.yaml
+++ b/boards/ai-c3.yaml
@@ -1,3 +1,3 @@
 boards:
   ai-c3:
-    chip: esp-c3-01m
+    chip: esp32-c3-mini-1

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -413,9 +413,6 @@ contexts:
       PROBE_RS_PROTOCOL: jtag
       CARGO_TARGET_PREFIX: CARGO_TARGET_RISCV32IMC_UNKNOWN_NONE_ELF
 
-  - name: esp-c3-01m
-    parent: esp32c3
-
   - name: esp32c6
     parent: esp
     selects:

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -2,7 +2,7 @@
 
 builders:
 - name: ai-c3
-  parent: esp-c3-01m
+  parent: esp32-c3-mini-1
 - name: bbc-microbit-v1
   parent: nrf51822-xxaa
   provides:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The AI-C3 board, which seems to be [this board](https://github.com/kreier/AI-C3), actually relies on an `esp32-c3-mini-1` hardware module.

Not considering this a breaking change as the `ai-c3` board is undocumented.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
