### PR TITLE
docs(support-matrix): add uart functionality status for some chips

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -229,6 +229,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage:
         status: not_currently_supported
@@ -299,6 +300,7 @@ chips:
       hwrng: supported
       i2c_controller: needs_testing
       spi_main: needs_testing
+      uart: supported
       logging: supported
       storage:
         status: not_currently_supported


### PR DESCRIPTION
# Description

This PR adds uart functionality status for the ESP32-S3Fx8, ESP32-C3Fx4 and STM32U073KC chips which are currently missing it. They are marked as `needs_testing`.

## Issues/PRs references


## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
