### PR TITLE
fix(esp): re-enable wifi x threads on esp riscv

### DIFF
--- a/book/src/boards/espressif-esp32-c3-lcdkit.md
+++ b/book/src/boards/espressif-esp32-c3-lcdkit.md
@@ -22,7 +22,7 @@
 |UART|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
 |User USB|<span title="not available on this piece of hardware">–</span>[^no-generic-usb-peripheral]|
-|Wi-Fi|<span title="supported with some caveats">☑️</span>[^not-currently-compatible-with-threading]|
+|Wi-Fi|<span title="supported">✅</span>|
 |Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
 |Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^requires-partitioning-support]|
@@ -53,5 +53,4 @@ dt, dd {
 </style>
 
 [^no-generic-usb-peripheral]: No generic USB peripheral.
-[^not-currently-compatible-with-threading]: Not currently compatible with threading.
 [^requires-partitioning-support]: Requires partitioning support.

--- a/book/src/boards/espressif-esp32-c6-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-c6-devkitc-1.md
@@ -22,7 +22,7 @@
 |UART|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
 |User USB|<span title="not available on this piece of hardware">–</span>[^no-generic-usb-peripheral]|
-|Wi-Fi|<span title="supported with some caveats">☑️</span>[^not-currently-compatible-with-threading]|
+|Wi-Fi|<span title="supported">✅</span>|
 |Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
 |Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^requires-partitioning-support]|
@@ -53,5 +53,4 @@ dt, dd {
 </style>
 
 [^no-generic-usb-peripheral]: No generic USB peripheral.
-[^not-currently-compatible-with-threading]: Not currently compatible with threading.
 [^requires-partitioning-support]: Requires partitioning support.

--- a/book/src/support_matrix_tier1.html
+++ b/book/src/support_matrix_tier1.html
@@ -54,7 +54,7 @@
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="not available on this piece of hardware">–</td>
-      <td class="support-cell" title="supported with some caveats">☑️</td>
+      <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
@@ -71,7 +71,7 @@
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="not available on this piece of hardware">–</td>
-      <td class="support-cell" title="supported with some caveats">☑️</td>
+      <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -211,9 +211,7 @@ chips:
         comments:
           - requires partitioning support
       wifi:
-        status: supported_with_caveats
-        comments:
-          - not currently compatible with threading
+        status: supported
       user_usb:
         status: not_available
         comments:
@@ -236,9 +234,7 @@ chips:
         comments:
           - requires partitioning support
       wifi:
-        status: supported_with_caveats
-        comments:
-          - not currently compatible with threading
+        status: supported
       user_usb:
         status: not_available
         comments:
@@ -260,9 +256,7 @@ chips:
         comments:
           - requires partitioning support
       wifi:
-        status: supported_with_caveats
-        comments:
-          - not currently compatible with threading
+        status: supported
       user_usb:
         status: not_available
         comments:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1476,8 +1476,6 @@ modules:
   - name: wifi-esp
     selects:
       - alloc
-      - riscv:
-          - wifi-esp-xor-threads
     context:
       - esp
     provides_unique:
@@ -1492,12 +1490,6 @@ modules:
           - $(72*1024)
         FEATURES:
           - ariel-os/wifi-esp
-
-  - name: wifi-esp-xor-threads
-    help: Helper module to conditionally make esp-wifi conflict with threads on esp32 riscv
-    selects:
-      - sw/threading:
-          - wifi-with-threads-currently-broken-on-esp-riscv
 
   - name: executor-thread
     help: use embassy executor within ariel-os-threads thread


### PR DESCRIPTION
# Description

#1451 fixed wifi for a couple of ESPs. Lets update laze and docs.

## Issues/PRs references

Depends on #1451.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
(ESP32-C3, ESP32-C6) Wi-Fi and multithreading can now be used at the same time.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
