### PR TITLE
feat(stm32u083c-dk)!: switch SWI to USART4_LPUART3

### DIFF
--- a/boards/stm32u083c-dk.yaml
+++ b/boards/stm32u083c-dk.yaml
@@ -4,7 +4,7 @@ boards:
     flags:
       - has_usb_device_port
     ariel:
-      swi: USART2_LPUART2
+      swi: USART4_LPUART3
     leds:
       led0:
         pin: PA5

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -214,4 +214,4 @@ builders:
   - has_usb_device_port
   env:
     CARGO_ENV:
-    - CONFIG_SWI=USART2_LPUART2
+    - CONFIG_SWI=USART4_LPUART3


### PR DESCRIPTION
# Description

Change the SWI interrupt to `USART4_LPUART3` as suggested in #1369 

## Issues/PRs references

Required for #1369

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
(STM32U083C-DK) The SWI has been switched from `USART2_LPUART2` to `USART4_LPUART3` to free up the interrupt for UART.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
