### PR TITLE
feat(st-nucleo-wb55)!: switch SWI to USART1

### DIFF
--- a/boards/st-nucleo-wb55.yaml
+++ b/boards/st-nucleo-wb55.yaml
@@ -4,7 +4,7 @@ boards:
     flags:
       - has_usb_device_port
     ariel:
-      swi: LPUART1
+      swi: USART1
     leds:
       led0:
         pin: PB5

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -184,7 +184,7 @@ builders:
   - has_usb_device_port
   env:
     CARGO_ENV:
-    - CONFIG_SWI=LPUART1
+    - CONFIG_SWI=USART1
 - name: st-nucleo-wba55
   parent: stm32wba55cg
   provides:


### PR DESCRIPTION
# Description

Change the SWI interrupt to USART1 as suggested in https://github.com/ariel-os/ariel-os/pull/1369

## Issues/PRs references

Required for #1369

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
(ST NUCLEO-WB55) The SWI has been switched from `LPUART1` to `USART1` to free up the interrupt for UART.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
