### PR TITLE
fix(nrf): PPI overlap between UART and BLE

### DIFF
--- a/src/ariel-os-nrf/src/uart.rs
+++ b/src/ariel-os-nrf/src/uart.rs
@@ -305,17 +305,17 @@ macro_rules! define_uart_drivers {
 // Define a driver per peripheral
 #[cfg(context = "nrf52832")]
 define_uart_drivers!(
-   UARTE0 => UARTE0 + TIMER4 + PPI_CH18 + PPI_CH19 + PPI_GROUP5,
+   UARTE0 => UARTE0 + TIMER4 + PPI_CH14 + PPI_CH15 + PPI_GROUP5,
 );
 #[cfg(context = "nrf52833")]
 define_uart_drivers!(
-   UARTE0 => UARTE0 + TIMER3 + PPI_CH16 + PPI_CH17 + PPI_GROUP4,
-   UARTE1 => UARTE1 + TIMER4 + PPI_CH18 + PPI_CH19 + PPI_GROUP5,
+   UARTE0 => UARTE0 + TIMER3 + PPI_CH13 + PPI_CH14 + PPI_GROUP4,
+   UARTE1 => UARTE1 + TIMER4 + PPI_CH15 + PPI_CH16 + PPI_GROUP5,
 );
 #[cfg(context = "nrf52840")]
 define_uart_drivers!(
-   UARTE0 => UARTE0 + TIMER3 + PPI_CH16 + PPI_CH17 + PPI_GROUP4,
-   UARTE1 => UARTE1 + TIMER4 + PPI_CH18 + PPI_CH19 + PPI_GROUP5,
+   UARTE0 => UARTE0 + TIMER3 + PPI_CH13 + PPI_CH14 + PPI_GROUP4,
+   UARTE1 => UARTE1 + TIMER4 + PPI_CH15 + PPI_CH16 + PPI_GROUP5,
 );
 #[cfg(context = "nrf5340")]
 define_uart_drivers!(
@@ -333,32 +333,32 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
         if #[cfg(context = "nrf52832")] {
             let _ = peripherals.UARTE0.take().unwrap();
             let _ = peripherals.TIMER4.take().unwrap();
-            let _ = peripherals.PPI_CH18.take().unwrap();
-            let _ = peripherals.PPI_CH19.take().unwrap();
+            let _ = peripherals.PPI_CH14.take().unwrap();
+            let _ = peripherals.PPI_CH15.take().unwrap();
             let _ = peripherals.PPI_GROUP5.take().unwrap();
         } else if #[cfg(context = "nrf52833")] {
             let _ = peripherals.UARTE0.take().unwrap();
             let _ = peripherals.TIMER3.take().unwrap();
-            let _ = peripherals.PPI_CH16.take().unwrap();
-            let _ = peripherals.PPI_CH17.take().unwrap();
+            let _ = peripherals.PPI_CH13.take().unwrap();
+            let _ = peripherals.PPI_CH14.take().unwrap();
             let _ = peripherals.PPI_GROUP4.take().unwrap();
 
             let _ = peripherals.UARTE1.take().unwrap();
             let _ = peripherals.TIMER4.take().unwrap();
-            let _ = peripherals.PPI_CH18.take().unwrap();
-            let _ = peripherals.PPI_CH19.take().unwrap();
+            let _ = peripherals.PPI_CH15.take().unwrap();
+            let _ = peripherals.PPI_CH16.take().unwrap();
             let _ = peripherals.PPI_GROUP5.take().unwrap();
         } else if #[cfg(context = "nrf52840")] {
             let _ = peripherals.UARTE0.take().unwrap();
             let _ = peripherals.TIMER3.take().unwrap();
-            let _ = peripherals.PPI_CH16.take().unwrap();
-            let _ = peripherals.PPI_CH17.take().unwrap();
+            let _ = peripherals.PPI_CH13.take().unwrap();
+            let _ = peripherals.PPI_CH14.take().unwrap();
             let _ = peripherals.PPI_GROUP4.take().unwrap();
 
             let _ = peripherals.UARTE1.take().unwrap();
             let _ = peripherals.TIMER4.take().unwrap();
-            let _ = peripherals.PPI_CH18.take().unwrap();
-            let _ = peripherals.PPI_CH19.take().unwrap();
+            let _ = peripherals.PPI_CH15.take().unwrap();
+            let _ = peripherals.PPI_CH16.take().unwrap();
             let _ = peripherals.PPI_GROUP5.take().unwrap();
         } else if #[cfg(context = "nrf5340")] {
             let _ = peripherals.SERIAL3.take().unwrap();


### PR DESCRIPTION
# Description

On the nrf52 boards there was some PPI peripherals used in both the UART and BLE implementation.
This PR changes the used PPIs in the UART implementation to not interfere with the BLE implementation.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

Needs to be tested on the affected hardware, tested working on the nrf52840.

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
