### PR TITLE
docs(gen-book): add board page url to the matrix

### DIFF
--- a/book/src/support_matrix_tier1.html
+++ b/book/src/support_matrix_tier1.html
@@ -29,7 +29,7 @@
       <td>nRF52833</td>
       <td><code>nrf52833</code></td>
       <td><a href="https://web.archive.org/web/20250109121140/https://microbit.org/new-microbit/">BBC micro:bit V2</a></td>
-      <td><code>bbc-microbit-v2</code></td>
+      <td><a href="boards/bbc-microbit-v2.html"><code>bbc-microbit-v2</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -46,7 +46,7 @@
       <td>ESP32-C3</td>
       <td><code>esp32c3</code></td>
       <td><a href="https://web.archive.org/web/20250408100740/https://www.espressif.com/en/dev-board/esp32-c3-lcdkit-en">Espressif ESP32-C3-LCDkit</a></td>
-      <td><code>espressif-esp32-c3-lcdkit</code></td>
+      <td><a href="boards/espressif-esp32-c3-lcdkit.html"><code>espressif-esp32-c3-lcdkit</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -63,7 +63,7 @@
       <td>ESP32-C6</td>
       <td><code>esp32c6</code></td>
       <td><a href="https://web.archive.org/web/20250122153727/https://www.espressif.com/en/dev-board/esp32-c6-devkitc-1-en">Espressif ESP32-C6-DevKitC-1</a></td>
-      <td><code>espressif-esp32-c6-devkitc-1</code></td>
+      <td><a href="boards/espressif-esp32-c6-devkitc-1.html"><code>espressif-esp32-c6-devkitc-1</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -80,7 +80,7 @@
       <td>ESP32-S3</td>
       <td><code>esp32s3</code></td>
       <td><a href="https://web.archive.org/web/20250122153707/https://www.espressif.com/en/dev-board/esp32-s3-devkitc-1-en">Espressif ESP32-S3-DevKitC-1</a></td>
-      <td><code>espressif-esp32-s3-devkitc-1</code></td>
+      <td><a href="boards/espressif-esp32-s3-devkitc-1.html"><code>espressif-esp32-s3-devkitc-1</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="needs testing">🚦</td>
@@ -97,7 +97,7 @@
       <td>nRF52840</td>
       <td><code>nrf52840</code></td>
       <td><a href="https://web.archive.org/web/20250112154748/https://www.nordicsemi.com/Products/Development-hardware/nrf52840-dk">nRF52840-DK</a></td>
-      <td><code>nrf52840dk</code></td>
+      <td><a href="boards/nrf52840dk.html"><code>nrf52840dk</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -114,7 +114,7 @@
       <td>nRF5340</td>
       <td><code>nrf5340</code></td>
       <td><a href="https://web.archive.org/web/20250115224621/https://www.nordicsemi.com/Products/Development-hardware/nrf5340-dk">nRF5340-DK</a></td>
-      <td><code>nrf5340dk</code></td>
+      <td><a href="boards/nrf5340dk.html"><code>nrf5340dk</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -131,7 +131,7 @@
       <td>RP2040</td>
       <td><code>rp2040</code></td>
       <td><a href="https://web.archive.org/web/20250101022830/https://www.raspberrypi.com/products/raspberry-pi-pico/">Raspberry Pi Pico</a></td>
-      <td><code>rpi-pico</code></td>
+      <td><a href="boards/rpi-pico.html"><code>rpi-pico</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -148,7 +148,7 @@
       <td>RP235xa</td>
       <td><code>rp235xa</code></td>
       <td><a href="https://web.archive.org/web/20250130144056/https://www.raspberrypi.com/products/raspberry-pi-pico-2/">Raspberry Pi Pico 2</a></td>
-      <td><code>rpi-pico2</code></td>
+      <td><a href="boards/rpi-pico2.html"><code>rpi-pico2</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -165,7 +165,7 @@
       <td>RP235xa</td>
       <td><code>rp235xa</code></td>
       <td><a href="https://web.archive.org/web/20250130144056/https://www.raspberrypi.com/products/raspberry-pi-pico-2/">Raspberry Pi Pico 2 W</a></td>
-      <td><code>rpi-pico2-w</code></td>
+      <td><a href="boards/rpi-pico2-w.html"><code>rpi-pico2-w</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -182,7 +182,7 @@
       <td>RP2040</td>
       <td><code>rp2040</code></td>
       <td><a href="https://web.archive.org/web/20250101022830/https://www.raspberrypi.com/products/raspberry-pi-pico/">Raspberry Pi Pico W</a></td>
-      <td><code>rpi-pico-w</code></td>
+      <td><a href="boards/rpi-pico-w.html"><code>rpi-pico-w</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -199,7 +199,7 @@
       <td>STM32C031C6</td>
       <td><code>stm32c031c6</code></td>
       <td><a href="https://web.archive.org/web/20241114214921/https://www.st.com/en/evaluation-tools/nucleo-c031c6.html">ST NUCLEO-C031C6</a></td>
-      <td><code>st-nucleo-c031c6</code></td>
+      <td><a href="boards/st-nucleo-c031c6.html"><code>st-nucleo-c031c6</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -216,7 +216,7 @@
       <td>STM32H755ZI</td>
       <td><code>stm32h755zi</code></td>
       <td><a href="https://web.archive.org/web/20240524105149/https://www.st.com/en/evaluation-tools/nucleo-h755zi-q.html">ST NUCLEO-H755ZI-Q</a></td>
-      <td><code>st-nucleo-h755zi-q</code></td>
+      <td><a href="boards/st-nucleo-h755zi-q.html"><code>st-nucleo-h755zi-q</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -233,7 +233,7 @@
       <td>STM32WB55RG</td>
       <td><code>stm32wb55rg</code></td>
       <td><a href="https://web.archive.org/web/20240803070523/https://www.st.com/en/evaluation-tools/nucleo-wb55rg.html">ST NUCLEO-WB55RG</a></td>
-      <td><code>st-nucleo-wb55</code></td>
+      <td><a href="boards/st-nucleo-wb55.html"><code>st-nucleo-wb55</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -250,7 +250,7 @@
       <td>STM32U083MC</td>
       <td><code>stm32u083mc</code></td>
       <td><a href="https://web.archive.org/web/20250119131656/https://www.st.com/en/evaluation-tools/stm32u083c-dk.html">STM32U083C-DK</a></td>
-      <td><code>stm32u083c-dk</code></td>
+      <td><a href="boards/stm32u083c-dk.html"><code>stm32u083c-dk</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>

--- a/book/src/support_matrix_tier2.html
+++ b/book/src/support_matrix_tier2.html
@@ -29,7 +29,7 @@
       <td>ESP32-C6Fx4</td>
       <td><code>esp32c6fx4</code></td>
       <td><a href="https://web.archive.org/web/20250710082029/https://wiki.dfrobot.com/SKU_DFR1075_FireBeetle_2_Board_ESP32_C6">DFRobot FireBeetle 2 ESP32-C6</a></td>
-      <td><code>dfrobot-firebeetle2-esp32-c6</code></td>
+      <td><a href="boards/dfrobot-firebeetle2-esp32-c6.html"><code>dfrobot-firebeetle2-esp32-c6</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -46,7 +46,7 @@
       <td>nRF9151</td>
       <td><code>nrf9151</code></td>
       <td><a href="https://web.archive.org/web/20250329185651/https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-91-X">Nordic Thingy:91 X</a></td>
-      <td><code>nordic-thingy-91-x-nrf9151</code></td>
+      <td><a href="boards/nordic-thingy-91-x-nrf9151.html"><code>nordic-thingy-91-x-nrf9151</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -63,7 +63,7 @@
       <td>nRF52832</td>
       <td><code>nrf52832</code></td>
       <td><a href="https://web.archive.org/web/20250311221943/https://www.nordicsemi.com/Products/Development-hardware/nRF52-DK">nRF52-DK</a></td>
-      <td><code>nrf52dk</code></td>
+      <td><a href="boards/nrf52dk.html"><code>nrf52dk</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
@@ -80,7 +80,7 @@
       <td>nRF9160</td>
       <td><code>nrf9160</code></td>
       <td><a href="https://web.archive.org/web/20250311221943/https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk">nRF9160-DK</a></td>
-      <td><code>nrf9160dk-nrf9160</code></td>
+      <td><a href="boards/nrf9160dk-nrf9160.html"><code>nrf9160dk-nrf9160</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -97,7 +97,7 @@
       <td>STM32L475VG</td>
       <td><code>stm32l475vg</code></td>
       <td><a href="https://web.archive.org/web/20250402084429/https://www.st.com/en/evaluation-tools/b-l475e-iot01a.html">ST B-L475E-IOT01A</a></td>
-      <td><code>st-b-l475e-iot01a</code></td>
+      <td><a href="boards/st-b-l475e-iot01a.html"><code>st-b-l475e-iot01a</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="needs testing">🚦</td>
@@ -114,7 +114,7 @@
       <td>STM32F401RE</td>
       <td><code>stm32f401re</code></td>
       <td><a href="https://web.archive.org/web/20250115005425/https://www.st.com/en/evaluation-tools/nucleo-f401re.html">ST NUCLEO-F401RE</a></td>
-      <td><code>st-nucleo-f401re</code></td>
+      <td><a href="boards/st-nucleo-f401re.html"><code>st-nucleo-f401re</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="needs testing">🚦</td>
@@ -131,7 +131,7 @@
       <td>STM32U585AI</td>
       <td><code>stm32u585ai</code></td>
       <td><a href="https://web.archive.org/web/20250507145935/https://www.st.com/en/evaluation-tools/steval-mkboxpro.html">STEVAL-MKBOXPRO</a></td>
-      <td><code>st-steval-mkboxpro</code></td>
+      <td><a href="boards/st-steval-mkboxpro.html"><code>st-steval-mkboxpro</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>

--- a/book/src/support_matrix_tier3.html
+++ b/book/src/support_matrix_tier3.html
@@ -29,7 +29,7 @@
       <td>nRF51822-xxAA</td>
       <td><code>nrf51822-xxaa</code></td>
       <td><a href="https://web.archive.org/web/20250109121140/https://microbit.org/get-started/features/overview/#original-micro:bit">BBC micro:bit V1</a></td>
-      <td><code>bbc-microbit-v1</code></td>
+      <td><a href="boards/bbc-microbit-v1.html"><code>bbc-microbit-v1</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
@@ -46,7 +46,7 @@
       <td>ESP32-S2</td>
       <td><code>esp32s2</code></td>
       <td><a href="https://web.archive.org/web/20251022182104/https://www.espressif.com/en/dev-board/esp32-s2-devkitc-1-en">Espressif ESP32-S2-DevKitC-1</a></td>
-      <td><code>espressif-esp32-s2-devkitc-1</code></td>
+      <td><a href="boards/espressif-esp32-s2-devkitc-1.html"><code>espressif-esp32-s2-devkitc-1</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="needs testing">🚦</td>
@@ -63,7 +63,7 @@
       <td>ESP32-S3</td>
       <td><code>esp32s3</code></td>
       <td><a href="https://web.archive.org/web/20250807184214/https://heltec.org/project/wifi-lora-32-v3/">Heltec WiFi LoRa 32 V3</a></td>
-      <td><code>heltec-wifi-lora-32-v3</code></td>
+      <td><a href="boards/heltec-wifi-lora-32-v3.html"><code>heltec-wifi-lora-32-v3</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="needs testing">🚦</td>
@@ -80,7 +80,7 @@
       <td>STM32WLE5JC</td>
       <td><code>stm32wle5jc</code></td>
       <td><a href="https://web.archive.org/web/20250802201959/https://wiki.seeedstudio.com/LoRa_E5_mini/">Seeed Studio LoRa-E5 mini</a></td>
-      <td><code>seeedstudio-lora-e5-mini</code></td>
+      <td><a href="boards/seeedstudio-lora-e5-mini.html"><code>seeedstudio-lora-e5-mini</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
@@ -97,7 +97,7 @@
       <td>STM32F042K6</td>
       <td><code>stm32f042k6</code></td>
       <td><a href="https://web.archive.org/web/20241114214921/https://www.st.com/en/evaluation-tools/nucleo-f042k6.html">ST NUCLEO-F042K6</a></td>
-      <td><code>st-nucleo-f042k6</code></td>
+      <td><a href="boards/st-nucleo-f042k6.html"><code>st-nucleo-f042k6</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
@@ -114,7 +114,7 @@
       <td>STM32F411RE</td>
       <td><code>stm32f411re</code></td>
       <td><a href="https://web.archive.org/web/20250311221905/https://www.st.com/en/evaluation-tools/nucleo-f411re.html">ST NUCLEO-F411RE</a></td>
-      <td><code>st-nucleo-f411re</code></td>
+      <td><a href="boards/st-nucleo-f411re.html"><code>st-nucleo-f411re</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -131,7 +131,7 @@
       <td>STM32WBA55CG</td>
       <td><code>stm32wba55cg</code></td>
       <td><a href="https://web.archive.org/web/20240803070523/https://www.st.com/en/evaluation-tools/nucleo-wba55cg.html">ST NUCLEO-WBA55CG</a></td>
-      <td><code>st-nucleo-wba55</code></td>
+      <td><a href="boards/st-nucleo-wba55.html"><code>st-nucleo-wba55</code></a></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>

--- a/book/templates/support-matrix.html.tmpl
+++ b/book/templates/support-matrix.html.tmpl
@@ -22,7 +22,7 @@
       <td>{{ board.chip }}</td>
       <td><code>{{ board.chip_technical_name }}</code></td>
       <td><a href="{{ board.url }}">{{ board.name }}</a></td>
-      <td><code>{{ board.technical_name }}</code></td>
+      <td><a href="{{ board.doc }}"><code>{{ board.technical_name }}</code></a></td>
       {%- for functionality in board.functionalities %}
       <td class="support-cell" title="{{ functionality.description }}">{{ functionality.icon }}</td>
       {%- endfor %}

--- a/doc/gen_book.rs
+++ b/doc/gen_book.rs
@@ -375,6 +375,7 @@ struct BoardSupport {
     chip: String,
     chip_technical_name: String,
     url: String,
+    doc: String,
     technical_name: String,
     name: String,
     tier: String,
@@ -521,6 +522,7 @@ fn gen_functionalities(matrix: &schema::Matrix) -> Result<Vec<BoardSupport>, Err
                     comments,
                 })
             });
+            let board_doc_page = ["boards/", board_technical_name, ".html"].concat();
             let errors = functionalities
                 .clone()
                 .filter_map(|f| f.err())
@@ -530,6 +532,7 @@ fn gen_functionalities(matrix: &schema::Matrix) -> Result<Vec<BoardSupport>, Err
                     chip: chip_info.name.to_owned(),
                     chip_technical_name: board_info.chip.to_owned(),
                     url: board_info.url.to_owned(),
+                    doc: board_doc_page,
                     technical_name: board_technical_name.to_owned(),
                     name: board_name.to_owned(),
                     tier: board_info.tier.to_owned(),


### PR DESCRIPTION
# Description

This adds the URL for the board page to the boards in the support matrix.

## Issues/PRs references

Suggested by @bugadani

## Open Questions

None

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
