### PR TITLE
feat: Add esp-rust-board

### DIFF
--- a/boards/espressif-esp32-c3-devkit-rust-1.yaml
+++ b/boards/espressif-esp32-c3-devkit-rust-1.yaml
@@ -1,0 +1,10 @@
+boards:
+  espressif-esp32-c3-devkit-rust-1:
+    chip: esp32-c3-mini-1
+    buttons:
+      button0:
+        pin: GPIO9
+        active: low
+    leds:
+      led0:
+        pin: GPIO7

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -9,6 +9,7 @@
   - [BBC micro:bit V1](./boards/bbc-microbit-v1.md)
   - [BBC micro:bit V2](./boards/bbc-microbit-v2.md)
   - [DFRobot FireBeetle 2 ESP32-C6](./boards/dfrobot-firebeetle2-esp32-c6.md)
+  - [Espressif ESP32-C3-DevKit-RUST-1](./boards/espressif-esp32-c3-devkit-rust-1.md)
   - [Espressif ESP32-C3-LCDkit](./boards/espressif-esp32-c3-lcdkit.md)
   - [Espressif ESP32-C6-DevKitC-1](./boards/espressif-esp32-c6-devkitc-1.md)
   - [Espressif ESP32-S2-DevKitC-1](./boards/espressif-esp32-s2-devkitc-1.md)

--- a/book/src/boards/espressif-esp32-c3-devkit-rust-1.md
+++ b/book/src/boards/espressif-esp32-c3-devkit-rust-1.md
@@ -1,0 +1,56 @@
+# Espressif ESP32-C3-DevKit-RUST-1
+
+## Board Info
+
+- **Tier:** 3
+- **Ariel OS Name:** `espressif-esp32-c3-devkit-rust-1`
+- **Chip:** [ESP32-C3](../chips/esp32c3.md)
+- **Chip Ariel OS Name:** `esp32c3`
+
+### References
+
+- [Manufacturer link](http://web.archive.org/web/20250729095245/https://github.com/esp-rs/esp-rust-board/tree/v1.2)
+
+## Support Matrix
+
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|UART|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>[^no-generic-usb-peripheral]|
+|Wi-Fi|<span title="supported">✅</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^requires-partitioning-support]|
+
+<p>Legend:</p>
+
+<dl>
+  <div>
+    <dt>✅</dt><dd>supported</dd>
+  </div>
+  <div>
+    <dt>☑️</dt><dd>supported with some caveats</dd>
+  </div>
+  <div>
+    <dt>🚦</dt><dd>needs testing</dd>
+  </div>
+  <div>
+    <dt>❌</dt><dd>available in hardware, but not currently supported by Ariel OS</dd>
+  </div>
+  <div>
+    <dt>–</dt><dd>not available on this piece of hardware</dd>
+  </div>
+</dl>
+<style>
+dt, dd {
+  display: inline;
+}
+</style>
+
+[^no-generic-usb-peripheral]: No generic USB peripheral.
+[^requires-partitioning-support]: Requires partitioning support.

--- a/book/src/boards/index.md
+++ b/book/src/boards/index.md
@@ -37,6 +37,7 @@ Tier 2 hardware only gets tested infrequently, but Ariel OS maintainers do have 
 Tier 3 hardware is build-tested only, as Ariel OS maintainers do not have access to the hardware.
 
 - [BBC micro:bit V1](./bbc-microbit-v1.md)
+- [Espressif ESP32-C3-DevKit-RUST-1](./espressif-esp32-c3-devkit-rust-1.md)
 - [Espressif ESP32-S2-DevKitC-1](./espressif-esp32-s2-devkitc-1.md)
 - [Heltec WiFi LoRa 32 V3](./heltec-wifi-lora-32-v3.md)
 - [Seeed Studio LoRa-E5 mini](./seeedstudio-lora-e5-mini.md)

--- a/book/src/support_matrix_tier3.html
+++ b/book/src/support_matrix_tier3.html
@@ -43,6 +43,23 @@
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
     </tr>
     <tr>
+      <td>ESP32-C3</td>
+      <td><a href="chips/esp32c3.html"><code>esp32c3</code></a></td>
+      <td><a href="http://web.archive.org/web/20250729095245/https://github.com/esp-rs/esp-rust-board/tree/v1.2">Espressif ESP32-C3-DevKit-RUST-1</a></td>
+      <td><a href="boards/espressif-esp32-c3-devkit-rust-1.html"><code>espressif-esp32-c3-devkit-rust-1</code></a></td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
+      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+    </tr>
+    <tr>
       <td>ESP32-S2</td>
       <td><a href="chips/esp32s2.html"><code>esp32s2</code></a></td>
       <td><a href="https://web.archive.org/web/20251022182104/https://www.espressif.com/en/dev-board/esp32-s2-devkitc-1-en">Espressif ESP32-S2-DevKitC-1</a></td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -791,6 +791,13 @@ boards:
     tier: "2"
     support:
 
+  espressif-esp32-c3-devkit-rust-1:
+    name: Espressif ESP32-C3-DevKit-RUST-1
+    url: http://web.archive.org/web/20250729095245/https://github.com/esp-rs/esp-rust-board/tree/v1.2
+    chip: esp32c3
+    tier: "3"
+    support:
+
   espressif-esp32-c3-lcdkit:
     name: Espressif ESP32-C3-LCDkit
     url: https://web.archive.org/web/20250408100740/https://www.espressif.com/en/dev-board/esp32-c3-lcdkit-en

--- a/src/ariel-os-boards/build.rs
+++ b/src/ariel-os-boards/build.rs
@@ -9,6 +9,9 @@ pub fn main() {
     );
     println!("cargo::rustc-check-cfg=cfg(context, values(\"dwm1001\"))");
     println!(
+        "cargo::rustc-check-cfg=cfg(context, values(\"espressif-esp32-c3-devkit-rust-1\"))"
+    );
+    println!(
         "cargo::rustc-check-cfg=cfg(context, values(\"espressif-esp32-c3-lcdkit\"))"
     );
     println!(

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -21,6 +21,11 @@ builders:
   provides:
   - has_buttons
   - has_leds
+- name: espressif-esp32-c3-devkit-rust-1
+  parent: esp32-c3-mini-1
+  provides:
+  - has_buttons
+  - has_leds
 - name: espressif-esp32-c3-lcdkit
   parent: esp32-c3-mini-1
 - name: espressif-esp32-c6-devkitc-1

--- a/src/ariel-os-boards/src/espressif-esp32-c3-devkit-rust-1.rs
+++ b/src/ariel-os-boards/src/espressif-esp32-c3-devkit-rust-1.rs
@@ -1,0 +1,9 @@
+// @generated
+
+pub mod pins {
+    use ariel_os_hal::hal::peripherals;
+    ariel_os_hal::define_peripherals!(LedPeripherals { led0 : GPIO7, });
+    ariel_os_hal::define_peripherals!(ButtonPeripherals { button0 : GPIO9, });
+}
+#[allow(unused_variables)]
+pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}

--- a/src/ariel-os-boards/src/lib.rs
+++ b/src/ariel-os-boards/src/lib.rs
@@ -7,7 +7,9 @@ cfg_if::cfg_if! {
     "bbc-microbit-v2")] { include!("bbc-microbit-v2.rs"); } else if #[cfg(context =
     "dfrobot-firebeetle2-esp32-c6")] { include!("dfrobot-firebeetle2-esp32-c6.rs"); }
     else if #[cfg(context = "dwm1001")] { include!("dwm1001.rs"); } else if #[cfg(context
-    = "espressif-esp32-c3-lcdkit")] { include!("espressif-esp32-c3-lcdkit.rs"); } else if
+    = "espressif-esp32-c3-devkit-rust-1")] {
+    include!("espressif-esp32-c3-devkit-rust-1.rs"); } else if #[cfg(context =
+    "espressif-esp32-c3-lcdkit")] { include!("espressif-esp32-c3-lcdkit.rs"); } else if
     #[cfg(context = "espressif-esp32-c6-devkitc-1")] {
     include!("espressif-esp32-c6-devkitc-1.rs"); } else if #[cfg(context =
     "espressif-esp32-devkitc")] { include!("espressif-esp32-devkitc.rs"); } else if


### PR DESCRIPTION
# Description

This PR adds support for the esp-rust-board, also known as ESP32-C3-DevKit-RUST-1. Contrasted to other devkits, this one has:
- an LED
- an ICM-42670-P IMU
- a SHTC3 temperature sensor

## Changelog entry

<!-- changelog:begin -->
The Espressif ESP32-C3-DevKit-RUST-1 board is now supported.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
