### PR TITLE
fix(esp): add missing peripheral support for esp32s2

### DIFF
--- a/examples/http-client/laze.yml
+++ b/examples/http-client/laze.yml
@@ -9,3 +9,5 @@ apps:
       - random
     conflicts:
       - ram-small
+      # not enough ram
+      - context::esp32s2

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -2,7 +2,10 @@
 
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(test, no_main)]
-#![cfg_attr(not(target_has_atomic = "ptr"), expect(unsafe_code))]
+#![cfg_attr(
+    all(feature = "log", not(target_has_atomic = "ptr")),
+    expect(unsafe_code)
+)]
 #![deny(missing_docs)]
 
 #[featurecomb::comb]

--- a/src/ariel-os-esp/src/i2c/controller/mod.rs
+++ b/src/ariel-os-esp/src/i2c/controller/mod.rs
@@ -115,7 +115,8 @@ macro_rules! define_i2c_drivers {
                     twim_config.frequency = config.frequency.into();
                     #[cfg(any(context = "esp32c3", context = "esp32c6", context = "esp32s3"))]
                     let disabled_timeout = BusTimeout::Disabled;
-                    #[cfg(context = "esp32")]
+                    // TODO: use `BusTimeout::Disabled` on s2 after esp-hal bump to 1.0.0
+                    #[cfg(any(context = "esp32", context = "esp32s2"))]
                     // Use the maximum value as timeout cannot be disabled.
                     let disabled_timeout = BusTimeout::Maximum;
                     // Disable timeout as we implement it at a higher level.
@@ -189,5 +190,7 @@ define_i2c_drivers!(I2C0, I2C1);
 define_i2c_drivers!(I2C0);
 #[cfg(context = "esp32c6")]
 define_i2c_drivers!(I2C0);
+#[cfg(context = "esp32s2")]
+define_i2c_drivers!(I2C0, I2C1);
 #[cfg(context = "esp32s3")]
 define_i2c_drivers!(I2C0, I2C1);

--- a/src/ariel-os-esp/src/i2c/mod.rs
+++ b/src/ariel-os-esp/src/i2c/mod.rs
@@ -14,6 +14,9 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             let _ = peripherals.I2C0.take().unwrap();
         } else if #[cfg(context = "esp32c6")] {
             let _ = peripherals.I2C0.take().unwrap();
+        } else if #[cfg(context = "esp32s2")] {
+            let _ = peripherals.I2C0.take().unwrap();
+            let _ = peripherals.I2C1.take().unwrap();
         } else if #[cfg(context = "esp32s3")] {
             let _ = peripherals.I2C0.take().unwrap();
             let _ = peripherals.I2C1.take().unwrap();

--- a/src/ariel-os-esp/src/spi/main/mod.rs
+++ b/src/ariel-os-esp/src/spi/main/mod.rs
@@ -23,6 +23,7 @@ use esp_hal::{
     context = "esp32",
     context = "esp32c3",
     context = "esp32c6",
+    context = "esp32s2",
     context = "esp32s3"
 ))]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(80);
@@ -146,5 +147,7 @@ define_spi_drivers!(SPI2, SPI3);
 define_spi_drivers!(SPI2);
 #[cfg(context = "esp32c6")]
 define_spi_drivers!(SPI2);
+#[cfg(context = "esp32s2")]
+define_spi_drivers!(SPI2, SPI3);
 #[cfg(context = "esp32s3")]
 define_spi_drivers!(SPI2, SPI3);

--- a/src/ariel-os-esp/src/spi/mod.rs
+++ b/src/ariel-os-esp/src/spi/mod.rs
@@ -32,6 +32,9 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             let _ = peripherals.SPI2.take().unwrap();
         } else if #[cfg(context = "esp32c6")] {
             let _ = peripherals.SPI2.take().unwrap();
+        } else if #[cfg(context = "esp32s2")] {
+            let _ = peripherals.SPI2.take().unwrap();
+            let _ = peripherals.SPI3.take().unwrap();
         } else if #[cfg(context = "esp32s3")] {
             let _ = peripherals.SPI2.take().unwrap();
             let _ = peripherals.SPI3.take().unwrap();

--- a/src/ariel-os-esp/src/uart.rs
+++ b/src/ariel-os-esp/src/uart.rs
@@ -250,6 +250,8 @@ define_uart_drivers!(UART0, UART1, UART2);
 define_uart_drivers!(UART0, UART1);
 #[cfg(context = "esp32c6")]
 define_uart_drivers!(UART0, UART1);
+#[cfg(context = "esp32s2")]
+define_uart_drivers!(UART0, UART1);
 #[cfg(context = "esp32s3")]
 define_uart_drivers!(UART0, UART1, UART2);
 
@@ -265,6 +267,9 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             let _ = peripherals.UART0.take().unwrap();
             let _ = peripherals.UART1.take().unwrap();
         } else if #[cfg(context = "esp32c6")] {
+            let _ = peripherals.UART0.take().unwrap();
+            let _ = peripherals.UART1.take().unwrap();
+        } else if #[cfg(context = "esp32s2")] {
             let _ = peripherals.UART0.take().unwrap();
             let _ = peripherals.UART1.take().unwrap();
         } else if #[cfg(context = "esp32s3")] {

--- a/src/ariel-os-threads/Cargo.toml
+++ b/src/ariel-os-threads/Cargo.toml
@@ -36,6 +36,10 @@ esp-hal = { workspace = true, features = ["esp32c3"] }
 [target.'cfg(context = "esp32c6")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c6"] }
 
+[target.'cfg(context = "esp32s2")'.dependencies]
+esp-hal = { workspace = true, features = ["esp32s2"] }
+static_cell = { workspace = true, optional = true }
+
 [target.'cfg(context = "esp32s3")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32s3"] }
 static_cell = { workspace = true, optional = true }


### PR DESCRIPTION
# Description

#1465 added basic esp32s2 support, but did not wire up the peripherals support.

Also, disables the http-client for now, there's not enough memory.

Compile-tested with `CONFIG_WIFI_PASSWORD=doesnt CONFIG_WIFI_NETWORK=matter laze build -b espressif-esp32-s2-devkitc-1 -g`.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
