### PR TITLE
chore: bump rand crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
  "linkme",
  "once_cell",
  "portable-atomic",
- "rand_core",
+ "rand_core 0.9.3",
  "static_cell",
  "trouble-host",
  "usbd-hid",
@@ -421,7 +421,8 @@ dependencies = [
  "embassy-executor",
  "embassy-time",
  "embedded-hal-async",
- "rand",
+ "getrandom 0.2.16",
+ "rand 0.9.2",
  "sha2",
 ]
 
@@ -463,8 +464,9 @@ version = "0.2.0"
 dependencies = [
  "embassy-sync 0.6.2",
  "getrandom 0.3.3",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.6.4",
+ "rand_core 0.9.3",
  "rand_pcg",
 ]
 
@@ -1303,7 +1305,7 @@ dependencies = [
  "minicbor 0.26.5",
  "minicbor-adapters",
  "p256",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1470,7 +1472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1758,7 +1760,7 @@ dependencies = [
  "generic-array 0.14.7",
  "group",
  "hkdf",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1888,7 +1890,7 @@ dependencies = [
  "fixed",
  "nrf-pac",
  "optfield",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1923,7 +1925,7 @@ dependencies = [
  "nb 1.1.0",
  "optfield",
  "pio",
- "rand_core",
+ "rand_core 0.6.4",
  "rp-binary-info",
  "rp-pac",
  "rp2040-boot2",
@@ -1970,7 +1972,7 @@ dependencies = [
  "optfield",
  "proc-macro2",
  "quote",
- "rand_core",
+ "rand_core 0.6.4",
  "sdio-host",
  "static_assertions",
  "stm32-fmc",
@@ -2205,7 +2207,7 @@ dependencies = [
  "embassy-sync 0.3.0",
  "embedded-nal-async",
  "heapless 0.7.17",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2263,7 +2265,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "p256",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "typenum",
 ]
@@ -2418,7 +2420,7 @@ dependencies = [
  "optfield",
  "paste",
  "portable-atomic",
- "rand_core",
+ "rand_core 0.6.4",
  "riscv",
  "serde",
  "strum",
@@ -2542,7 +2544,7 @@ dependencies = [
  "num-traits",
  "portable-atomic",
  "portable_atomic_enum",
- "rand_core",
+ "rand_core 0.6.4",
  "smoltcp",
  "xtensa-lx-rt",
 ]
@@ -2698,7 +2700,7 @@ version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -2782,7 +2784,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3018,7 +3020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3245,7 +3247,7 @@ version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
- "rand_core",
+ "rand_core 0.9.3",
  "reqwless",
 ]
 
@@ -3563,7 +3565,7 @@ dependencies = [
  "hkdf",
  "lakers-shared",
  "p256",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
 ]
 
@@ -3936,7 +3938,7 @@ dependencies = [
  "embedded-io-async",
  "nrf-mpsl",
  "nrf-sdc-sys",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4187,7 +4189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4552,7 +4554,16 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4562,7 +4573,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4570,17 +4591,23 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "rand_pcg"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4641,8 +4668,8 @@ dependencies = [
  "hex",
  "httparse",
  "nourl",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5063,7 +5090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5587,7 +5614,7 @@ dependencies = [
  "embedded-io 0.6.1",
  "futures",
  "heapless 0.8.0",
- "rand_core",
+ "rand_core 0.6.4",
  "static_cell",
  "trouble-host-macros",
  "zerocopy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,8 +147,8 @@ once_cell = { version = "=1.19.0", default-features = false, features = [
 ] }
 paste = { version = "1.0" }
 pin-project = "1.1.10"
-rand = { version = "0.8.5", default-features = false }
-rand_core = { version = "0.6.4", default-features = false }
+rand = { version = "0.9.2", default-features = false }
+rand_core = { version = "0.9.3", default-features = false }
 rtt-target = { version = "0.6.0" }
 
 rp-pac = { version = "7.0", default-features = false }

--- a/examples/random/src/main.rs
+++ b/examples/random/src/main.rs
@@ -9,7 +9,7 @@ async fn main() {
     let mut rng = ariel_os::random::fast_rng();
 
     for _ in 0..10 {
-        let value = rng.gen_range(1..=6);
+        let value = rng.random_range(1..=6);
         info!("The random value of this round is {}.", value);
     }
 }

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -149,10 +149,11 @@ pub fn init() -> OptionalPeripherals {
     let mut peripherals = OptionalPeripherals::from(esp_hal::init(config));
 
     #[cfg(any(feature = "hwrng", feature = "wifi-esp"))]
-    let rng = esp_hal::rng::Rng::new(peripherals.RNG.take().unwrap());
+    #[allow(unused_mut)]
+    let mut rng = esp_hal::rng::Rng::new(peripherals.RNG.take().unwrap());
 
     #[cfg(feature = "hwrng")]
-    ariel_os_random::construct_rng(rng);
+    ariel_os_random::construct_rng(&mut ariel_os_random::RngAdapter(&mut rng));
 
     #[cfg(feature = "wifi-esp")]
     {

--- a/src/ariel-os-native/Cargo.toml
+++ b/src/ariel-os-native/Cargo.toml
@@ -18,12 +18,13 @@ embassy-time = { workspace = true, default-features = false, features = [
   "std",
 ] }
 embedded-hal-async = { workspace = true }
+getrandom = { version = "0.2", optional = true }
 ariel-os-buildinfo = { workspace = true }
 ariel-os-debug = { workspace = true, features = ["std"] }
 ariel-os-embassy-common = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
 rand = { workspace = true, default-features = false, optional = true, features = [
-  "getrandom",
+  "os_rng",
 ] }
 sha2 = { version = "0.10.8", default-features = false }
 
@@ -32,7 +33,7 @@ sha2 = { version = "0.10.8", default-features = false }
 external-interrupts = ["ariel-os-embassy-common/external-interrupts"]
 
 ## Enables seeding the random number generator from hardware.
-hwrng = ["dep:ariel-os-random", "dep:rand"]
+hwrng = ["dep:ariel-os-random", "dep:rand", "dep:getrandom"]
 
 ## Enables I2C support.
 i2c = ["ariel-os-embassy-common/i2c"]

--- a/src/ariel-os-native/src/hwrng.rs
+++ b/src/ariel-os-native/src/hwrng.rs
@@ -1,4 +1,27 @@
+/// Implement `RngCore` on top of an older `getrandom` crate.
+struct Getrandom02Rng;
+
+impl rand::rand_core::RngCore for Getrandom02Rng {
+    fn next_u32(&mut self) -> u32 {
+        let mut buf = [0; 4];
+        self.fill_bytes(&mut buf);
+        u32::from_le_bytes(buf)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut buf = [0; 8];
+        self.fill_bytes(&mut buf);
+        u64::from_le_bytes(buf)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        if let Err(e) = getrandom::getrandom(dest) {
+            panic!("Error: {}", e);
+        }
+    }
+}
+
 /// Constructs the hardware random number generator (RNG).
 pub fn construct_rng(_peripherals: &mut crate::OptionalPeripherals) {
-    ariel_os_random::construct_rng(rand::rngs::OsRng::default());
+    ariel_os_random::construct_rng(&mut Getrandom02Rng);
 }

--- a/src/ariel-os-nrf/src/hwrng.rs
+++ b/src/ariel-os-nrf/src/hwrng.rs
@@ -10,16 +10,15 @@ pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {
         // The union of all contexts that wind up in a construct_rng should be synchronized
         // with laze-project.yml's hwrng module.
         if #[cfg(any(context = "nrf51", context = "nrf52", context = "nrf5340-net"))] {
-            let rng = embassy_nrf::rng::Rng::new(
+            let p =
                 peripherals
                     .RNG
-                    // We don't even have to take it out, just use it to seed the RNG
-                    .as_mut()
-                    .expect("RNG has not been previously used"),
-                Irqs,
-            );
+                    .take()
+                    .expect("RNG has not been previously used");
 
-            ariel_os_random::construct_rng(rng);
+            let mut rng = embassy_nrf::rng::Rng::new(p, Irqs);
+
+            ariel_os_random::construct_rng(&mut ariel_os_random::RngAdapter(&mut rng));
         } else if #[cfg(context = "ariel-os")] {
             compile_error!("hardware RNG is not supported on this MCU family");
         }

--- a/src/ariel-os-random/Cargo.toml
+++ b/src/ariel-os-random/Cargo.toml
@@ -11,11 +11,12 @@ workspace = true
 
 [dependencies]
 rand_core = { workspace = true }
+rand-core-06 = { package = "rand_core", version = "0.6" }
 
 embassy-sync.workspace = true
 
-rand_pcg = "0.3.1"
-rand_chacha = { version = "0.3.1", default-features = false, optional = true }
+rand_pcg = "0.9.0"
+rand_chacha = { version = "0.9.0", default-features = false, optional = true }
 
 getrandom = { version = "0.3.3", optional = true }
 

--- a/src/ariel-os-random/src/getrandom.rs
+++ b/src/ariel-os-random/src/getrandom.rs
@@ -24,6 +24,7 @@ use getrandom::Error;
 ///
 /// The function panics if error conversion fails.
 #[unsafe(no_mangle)]
+#[allow(clippy::unnecessary_wraps)]
 unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
     // SAFETY: Pointer validity and mutability is provided by the getrandom custom backend
     // conventions.
@@ -31,8 +32,6 @@ unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Res
         core::ptr::write_bytes(dest, 0, len);
         core::slice::from_raw_parts_mut(dest, len)
     };
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-    super::crypto_rng()
-        .try_fill_bytes(buf)
-        .map_err(|e| Error::new_custom(e.raw_os_error().unwrap() as u16))
+    super::crypto_rng().fill_bytes(buf);
+    Ok(())
 }

--- a/src/ariel-os-rp/src/hwrng.rs
+++ b/src/ariel-os-rp/src/hwrng.rs
@@ -1,6 +1,6 @@
 pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {
     #[cfg(context = "rp2040")]
-    let hwrng = {
+    let mut hwrng = {
         let _ = peripherals; // Mark used
 
         // NOTE(datasheet): The RP2040 RNG "does not meet the requirements of randomness for
@@ -9,7 +9,7 @@ pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {
     };
 
     #[cfg(context = "rp235xa")]
-    let hwrng = {
+    let mut hwrng = {
         embassy_rp::bind_interrupts!(struct Irqs {
             TRNG_IRQ => embassy_rp::trng::InterruptHandler<embassy_rp::peripherals::TRNG>;
         });
@@ -25,5 +25,5 @@ pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {
         embassy_rp::trng::Trng::new(trng, Irqs, config)
     };
 
-    ariel_os_random::construct_rng(hwrng);
+    ariel_os_random::construct_rng(&mut ariel_os_random::RngAdapter(&mut hwrng));
 }

--- a/src/ariel-os-stm32/src/hwrng.rs
+++ b/src/ariel-os-stm32/src/hwrng.rs
@@ -27,7 +27,7 @@ bind_interrupts!(struct Irqs {
 });
 
 pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {
-    let rng = Rng::new(
+    let mut rng = Rng::new(
         peripherals
             .RNG
             // We don't even have to take it out, just use it to seed the RNG
@@ -36,5 +36,5 @@ pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {
         Irqs,
     );
 
-    ariel_os_random::construct_rng(rng);
+    ariel_os_random::construct_rng(&mut ariel_os_random::RngAdapter(&mut rng));
 }


### PR DESCRIPTION
# Description

This PR extracts the version bump from https://github.com/ariel-os/ariel-os/pull/1328, and adds an adapter type for rand_core 0.6 implementations, which is needed because the currently supported HALs do not implement rand_core 0.9.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [-] I have made corresponding changes to the documentation.
