### PR TITLE
chore: remove obsolete c2rust target

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1777,12 +1777,6 @@ builders:
           - rustup ${CARGO_TOOLCHAIN} component add rust-src
           - if command -v espup >/dev/null; then espup update --targets=esp32,esp32s2,esp32s3; fi
 
-      install-c2rust:
-        build: false
-        cmd:
-          - echo "Installing c2rust..."
-          - 'echo "WARNING: This uses *a lot* of memory!"'
-          - cargo install c2rust $@
       update-book:
         build: false
         cmd:


### PR DESCRIPTION
# Description

Long ago, when this project had the aim of providing the precise RIOT OS low-level APIs and interacting with it, there were dependencies on c2rust, and a corresponding build target.

The build target persisted and is now removed.

## Issues/PRs references

This has been disused in CI since cd5841408e5810760d2f474eddb4259be279612a (early 2024), and documentation since e702d93c73e20672c22aa264e42a6f7efb4703a7 (2023).

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- n/a I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
