### PR TITLE
fix: disentangle native getrandom between "host" and "user" side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
  "embassy-executor",
  "embassy-time",
  "embedded-hal-async",
- "getrandom 0.2.16",
+ "getrandom",
  "rand 0.9.2",
  "sha2",
 ]
@@ -463,7 +463,7 @@ name = "ariel-os-random"
 version = "0.2.0"
 dependencies = [
  "embassy-sync 0.6.2",
- "getrandom 0.3.3",
+ "getrandom",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",
  "rand_core 0.9.3",
@@ -2951,17 +2951,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -2969,7 +2958,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi",
 ]
 
 [[package]]
@@ -4598,7 +4587,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -5343,7 +5332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -5394,7 +5383,7 @@ version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
- "getrandom 0.3.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -5824,7 +5813,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -5863,12 +5852,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -495,6 +495,8 @@ contexts:
       - has_device_identity
       - has_hwrng
       - sw/benchmark
+    provides_unique:
+      - getrandom03-provider
     disables:
       - semihosting
       - defmt
@@ -1359,16 +1361,27 @@ modules:
     help: The board's peripherals are suitable for passing into ariel_os_random::construct_rng.
     selects:
       - has_hwrng
+      # Support for getrandom should be there automatically as soon as we have
+      # a CSPRNG, which is currently equivalent to having a hwrng, but may
+      # later be moved into the equivalent of the ariel-os-random/csprng
+      # feature.
+      - ?getrandom03-provider-ariel
     env:
       global:
         FEATURES:
           - ariel-os/hwrng
-        RUSTFLAGS:
-          - --cfg getrandom_backend=\"custom\"
 
   - name: has_hwrng
     selects:
       - doc-only
+
+  - name: getrandom03-provider-ariel
+    provides_unique:
+      - getrandom03-provider
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg getrandom_backend=\"custom\"
 
   - name: coap
     help: Basic support for the CoAP protocol.

--- a/src/ariel-os-native/Cargo.toml
+++ b/src/ariel-os-native/Cargo.toml
@@ -18,7 +18,7 @@ embassy-time = { workspace = true, default-features = false, features = [
   "std",
 ] }
 embedded-hal-async = { workspace = true }
-getrandom = { version = "0.2", optional = true }
+getrandom = { version = "0.3", optional = true }
 ariel-os-buildinfo = { workspace = true }
 ariel-os-debug = { workspace = true, features = ["std"] }
 ariel-os-embassy-common = { workspace = true }

--- a/src/ariel-os-native/src/hwrng.rs
+++ b/src/ariel-os-native/src/hwrng.rs
@@ -1,27 +1,7 @@
-/// Implement `RngCore` on top of an older `getrandom` crate.
-struct Getrandom02Rng;
-
-impl rand::rand_core::RngCore for Getrandom02Rng {
-    fn next_u32(&mut self) -> u32 {
-        let mut buf = [0; 4];
-        self.fill_bytes(&mut buf);
-        u32::from_le_bytes(buf)
-    }
-
-    fn next_u64(&mut self) -> u64 {
-        let mut buf = [0; 8];
-        self.fill_bytes(&mut buf);
-        u64::from_le_bytes(buf)
-    }
-
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        if let Err(e) = getrandom::getrandom(dest) {
-            panic!("Error: {}", e);
-        }
-    }
-}
-
 /// Constructs the hardware random number generator (RNG).
 pub fn construct_rng(_peripherals: &mut crate::OptionalPeripherals) {
-    ariel_os_random::construct_rng(&mut Getrandom02Rng);
+    use rand::TryRngCore;
+    // Going through unwraps because Ariel OS are not started so early in system startup that it
+    // matters.
+    ariel_os_random::construct_rng(&mut rand::rngs::OsRng.unwrap_mut());
 }


### PR DESCRIPTION
# Description

Our getrandom interaction through native currently just happens to work because they're on different versions. That's not sustainable, eg. if we want native to run somewhere where getrandom 0.2 doesn't work but the feature is only added in the latest version.

During https://github.com/ariel-os/ariel-os/pull/1470 it became apparent that we are using different versions of getrandom to back the native RNG (0.2) and to provide (0.3).

#1470 introduced a workaround; this should go away again.

## Current state

"I needed an issue number because I can't link to my git-stash and also it's volatile."

## Issues/PRs references

Follow-up-for: #1470 (where it became apparent)
Follow-up-for: #1477 (where I had originally intended to fix it but it turned out to be more practical to )

## Change checklist

- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
