### PR TITLE
feat(coapcore): send credential by value if requested

### DIFF
--- a/src/lib/coapcore/src/iana.rs
+++ b/src/lib/coapcore/src/iana.rs
@@ -13,6 +13,13 @@ pub(crate) mod edhoc_ead {
     /// [Section 10.8 of the ACE-EDHOC
     /// profile](https://datatracker.ietf.org/doc/html/draft-ietf-ace-edhoc-oscore-profile-06#section-10.8).
     pub(crate) const ACETOKEN: u16 = 20;
+
+    /// (Requesting an) EAD Credential by value
+    ///
+    /// Value requested but not allocated; described in
+    /// [Section 4.14 of the ACE-EDHOC
+    /// profile](https://www.ietf.org/archive/id/draft-ietf-ace-edhoc-oscore-profile-09.html#name-requesting-authentication-c).
+    pub(crate) const CRED_BY_VALUE: u16 = 15;
 }
 
 /// The [COSE Algorithms](https://www.iana.org/assignments/cose/cose.xhtml#algorithms) registry


### PR DESCRIPTION
# Description

By default, coapcore sends credentials only by reference to keep data low.

When a client does *not* know the credentials yet (eg. because it is doing TOFU or unilateral authentication), [draft-ietf-ace-edhoc-oscore-profile](https://www.ietf.org/archive/id/draft-ietf-ace-edhoc-oscore-profile-09.html#name-requesting-authentication-c) has us covered with an EAD option, support for which is added here: If the option is present, the full credential is sent.

## Issues/PRs references

This only has an effect with a client that sends it, eg. aiocoap after its [!44](https://codeberg.org/aiocoap/aiocoap/pulls/44).

Therefore, the README, examples and credentials are not yet updated to do unilateral authentication more often.

Adding this allows simplifying the trevm CoAP example, as we can then do away with copying the server's credential, as for a firmware upload, unilateral authentication can be fine.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
