### PR TITLE
docs(support): document the storage support caveat on STM32WLE5JC

### DIFF
--- a/book/src/boards/seeedstudio-lora-e5-mini.md
+++ b/book/src/boards/seeedstudio-lora-e5-mini.md
@@ -25,7 +25,7 @@
 |Wi-Fi|<span title="not available on this piece of hardware">–</span>|
 |Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
-|Persistent Storage|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported with some caveats">☑️</span>[^removing-items-not-supported]|
 
 <p>Legend:</p>
 
@@ -51,3 +51,5 @@ dt, dd {
   display: inline;
 }
 </style>
+
+[^removing-items-not-supported]: Removing items not supported.

--- a/book/src/support_matrix_tier3.html
+++ b/book/src/support_matrix_tier3.html
@@ -91,7 +91,7 @@
       <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="supported with some caveats">☑️</td>
     </tr>
     <tr>
       <td>STM32F042K6</td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -635,7 +635,10 @@ chips:
       spi_main: not_currently_supported
       uart: needs_testing
       logging: supported
-      storage: supported
+      storage:
+        status: supported_with_caveats
+        comments:
+          - removing items not supported
       wifi: not_available
       user_usb: not_available
       ethernet_over_usb: not_available


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds the missing caveat on storage support, as for every other STM32 chip, since the `embassy-stm32` flash driver doesn't implement `MultiwriteNorFlash`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
