### PR TITLE
docs(gen-book): add link to chip page from board page

### DIFF
--- a/book/src/boards/bbc-microbit-v1.md
+++ b/book/src/boards/bbc-microbit-v1.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 3
 - **Ariel OS Name:** `bbc-microbit-v1`
-- **Chip:** nRF51822-xxAA
+- **Chip:** [nRF51822-xxAA](../chips/nrf51822-xxaa.md)
 - **Chip Ariel OS Name:** `nrf51822-xxaa`
 
 ### References

--- a/book/src/boards/bbc-microbit-v2.md
+++ b/book/src/boards/bbc-microbit-v2.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `bbc-microbit-v2`
-- **Chip:** nRF52833
+- **Chip:** [nRF52833](../chips/nrf52833.md)
 - **Chip Ariel OS Name:** `nrf52833`
 
 ### References

--- a/book/src/boards/dfrobot-firebeetle2-esp32-c6.md
+++ b/book/src/boards/dfrobot-firebeetle2-esp32-c6.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 2
 - **Ariel OS Name:** `dfrobot-firebeetle2-esp32-c6`
-- **Chip:** ESP32-C6Fx4
+- **Chip:** [ESP32-C6Fx4](../chips/esp32c6fx4.md)
 - **Chip Ariel OS Name:** `esp32c6fx4`
 
 ### References

--- a/book/src/boards/espressif-esp32-c3-lcdkit.md
+++ b/book/src/boards/espressif-esp32-c3-lcdkit.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `espressif-esp32-c3-lcdkit`
-- **Chip:** ESP32-C3
+- **Chip:** [ESP32-C3](../chips/esp32c3.md)
 - **Chip Ariel OS Name:** `esp32c3`
 
 ### References

--- a/book/src/boards/espressif-esp32-c6-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-c6-devkitc-1.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `espressif-esp32-c6-devkitc-1`
-- **Chip:** ESP32-C6
+- **Chip:** [ESP32-C6](../chips/esp32c6.md)
 - **Chip Ariel OS Name:** `esp32c6`
 
 ### References

--- a/book/src/boards/espressif-esp32-s2-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-s2-devkitc-1.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 3
 - **Ariel OS Name:** `espressif-esp32-s2-devkitc-1`
-- **Chip:** ESP32-S2
+- **Chip:** [ESP32-S2](../chips/esp32s2.md)
 - **Chip Ariel OS Name:** `esp32s2`
 
 ### References

--- a/book/src/boards/espressif-esp32-s3-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-s3-devkitc-1.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `espressif-esp32-s3-devkitc-1`
-- **Chip:** ESP32-S3
+- **Chip:** [ESP32-S3](../chips/esp32s3.md)
 - **Chip Ariel OS Name:** `esp32s3`
 
 ### References

--- a/book/src/boards/heltec-wifi-lora-32-v3.md
+++ b/book/src/boards/heltec-wifi-lora-32-v3.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 3
 - **Ariel OS Name:** `heltec-wifi-lora-32-v3`
-- **Chip:** ESP32-S3
+- **Chip:** [ESP32-S3](../chips/esp32s3.md)
 - **Chip Ariel OS Name:** `esp32s3`
 
 ### References

--- a/book/src/boards/nordic-thingy-91-x-nrf9151.md
+++ b/book/src/boards/nordic-thingy-91-x-nrf9151.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 2
 - **Ariel OS Name:** `nordic-thingy-91-x-nrf9151`
-- **Chip:** nRF9151
+- **Chip:** [nRF9151](../chips/nrf9151.md)
 - **Chip Ariel OS Name:** `nrf9151`
 
 ### References

--- a/book/src/boards/nrf52840dk.md
+++ b/book/src/boards/nrf52840dk.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `nrf52840dk`
-- **Chip:** nRF52840
+- **Chip:** [nRF52840](../chips/nrf52840.md)
 - **Chip Ariel OS Name:** `nrf52840`
 
 ### References

--- a/book/src/boards/nrf52dk.md
+++ b/book/src/boards/nrf52dk.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 2
 - **Ariel OS Name:** `nrf52dk`
-- **Chip:** nRF52832
+- **Chip:** [nRF52832](../chips/nrf52832.md)
 - **Chip Ariel OS Name:** `nrf52832`
 
 ### References

--- a/book/src/boards/nrf5340dk.md
+++ b/book/src/boards/nrf5340dk.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `nrf5340dk`
-- **Chip:** nRF5340
+- **Chip:** [nRF5340](../chips/nrf5340.md)
 - **Chip Ariel OS Name:** `nrf5340`
 
 ### References

--- a/book/src/boards/nrf9151-dk.md
+++ b/book/src/boards/nrf9151-dk.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 2
 - **Ariel OS Name:** `nrf9151-dk`
-- **Chip:** nRF9151
+- **Chip:** [nRF9151](../chips/nrf9151.md)
 - **Chip Ariel OS Name:** `nrf9151`
 
 ### References

--- a/book/src/boards/nrf9160dk-nrf9160.md
+++ b/book/src/boards/nrf9160dk-nrf9160.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 2
 - **Ariel OS Name:** `nrf9160dk-nrf9160`
-- **Chip:** nRF9160
+- **Chip:** [nRF9160](../chips/nrf9160.md)
 - **Chip Ariel OS Name:** `nrf9160`
 
 ### References

--- a/book/src/boards/rpi-pico-w.md
+++ b/book/src/boards/rpi-pico-w.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `rpi-pico-w`
-- **Chip:** RP2040
+- **Chip:** [RP2040](../chips/rp2040.md)
 - **Chip Ariel OS Name:** `rp2040`
 
 ### References

--- a/book/src/boards/rpi-pico.md
+++ b/book/src/boards/rpi-pico.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `rpi-pico`
-- **Chip:** RP2040
+- **Chip:** [RP2040](../chips/rp2040.md)
 - **Chip Ariel OS Name:** `rp2040`
 
 ### References

--- a/book/src/boards/rpi-pico2-w.md
+++ b/book/src/boards/rpi-pico2-w.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `rpi-pico2-w`
-- **Chip:** RP235xa
+- **Chip:** [RP235xa](../chips/rp235xa.md)
 - **Chip Ariel OS Name:** `rp235xa`
 
 ### References

--- a/book/src/boards/rpi-pico2.md
+++ b/book/src/boards/rpi-pico2.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `rpi-pico2`
-- **Chip:** RP235xa
+- **Chip:** [RP235xa](../chips/rp235xa.md)
 - **Chip Ariel OS Name:** `rp235xa`
 
 ### References

--- a/book/src/boards/seeedstudio-lora-e5-mini.md
+++ b/book/src/boards/seeedstudio-lora-e5-mini.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 3
 - **Ariel OS Name:** `seeedstudio-lora-e5-mini`
-- **Chip:** STM32WLE5JC
+- **Chip:** [STM32WLE5JC](../chips/stm32wle5jc.md)
 - **Chip Ariel OS Name:** `stm32wle5jc`
 
 ### References

--- a/book/src/boards/st-b-l475e-iot01a.md
+++ b/book/src/boards/st-b-l475e-iot01a.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 2
 - **Ariel OS Name:** `st-b-l475e-iot01a`
-- **Chip:** STM32L475VG
+- **Chip:** [STM32L475VG](../chips/stm32l475vg.md)
 - **Chip Ariel OS Name:** `stm32l475vg`
 
 ### References

--- a/book/src/boards/st-nucleo-c031c6.md
+++ b/book/src/boards/st-nucleo-c031c6.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `st-nucleo-c031c6`
-- **Chip:** STM32C031C6
+- **Chip:** [STM32C031C6](../chips/stm32c031c6.md)
 - **Chip Ariel OS Name:** `stm32c031c6`
 
 ### References

--- a/book/src/boards/st-nucleo-f042k6.md
+++ b/book/src/boards/st-nucleo-f042k6.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 3
 - **Ariel OS Name:** `st-nucleo-f042k6`
-- **Chip:** STM32F042K6
+- **Chip:** [STM32F042K6](../chips/stm32f042k6.md)
 - **Chip Ariel OS Name:** `stm32f042k6`
 
 ### References

--- a/book/src/boards/st-nucleo-f401re.md
+++ b/book/src/boards/st-nucleo-f401re.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 2
 - **Ariel OS Name:** `st-nucleo-f401re`
-- **Chip:** STM32F401RE
+- **Chip:** [STM32F401RE](../chips/stm32f401re.md)
 - **Chip Ariel OS Name:** `stm32f401re`
 
 ### References

--- a/book/src/boards/st-nucleo-f411re.md
+++ b/book/src/boards/st-nucleo-f411re.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 3
 - **Ariel OS Name:** `st-nucleo-f411re`
-- **Chip:** STM32F411RE
+- **Chip:** [STM32F411RE](../chips/stm32f411re.md)
 - **Chip Ariel OS Name:** `stm32f411re`
 
 ### References

--- a/book/src/boards/st-nucleo-h755zi-q.md
+++ b/book/src/boards/st-nucleo-h755zi-q.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `st-nucleo-h755zi-q`
-- **Chip:** STM32H755ZI
+- **Chip:** [STM32H755ZI](../chips/stm32h755zi.md)
 - **Chip Ariel OS Name:** `stm32h755zi`
 
 ### References

--- a/book/src/boards/st-nucleo-wb55.md
+++ b/book/src/boards/st-nucleo-wb55.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `st-nucleo-wb55`
-- **Chip:** STM32WB55RG
+- **Chip:** [STM32WB55RG](../chips/stm32wb55rg.md)
 - **Chip Ariel OS Name:** `stm32wb55rg`
 
 ### References

--- a/book/src/boards/st-nucleo-wba55.md
+++ b/book/src/boards/st-nucleo-wba55.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 3
 - **Ariel OS Name:** `st-nucleo-wba55`
-- **Chip:** STM32WBA55CG
+- **Chip:** [STM32WBA55CG](../chips/stm32wba55cg.md)
 - **Chip Ariel OS Name:** `stm32wba55cg`
 
 ### References

--- a/book/src/boards/st-steval-mkboxpro.md
+++ b/book/src/boards/st-steval-mkboxpro.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 2
 - **Ariel OS Name:** `st-steval-mkboxpro`
-- **Chip:** STM32U585AI
+- **Chip:** [STM32U585AI](../chips/stm32u585ai.md)
 - **Chip Ariel OS Name:** `stm32u585ai`
 
 ### References

--- a/book/src/boards/stm32u083c-dk.md
+++ b/book/src/boards/stm32u083c-dk.md
@@ -4,7 +4,7 @@
 
 - **Tier:** 1
 - **Ariel OS Name:** `stm32u083c-dk`
-- **Chip:** STM32U083MC
+- **Chip:** [STM32U083MC](../chips/stm32u083mc.md)
 - **Chip Ariel OS Name:** `stm32u083mc`
 
 ### References

--- a/book/templates/board-page.md.tmpl
+++ b/book/templates/board-page.md.tmpl
@@ -4,7 +4,7 @@
 
 - **Tier:** {{ board_info.tier }}
 - **Ariel OS Name:** `{{ board_info.technical_name }}`
-- **Chip:** {{ board_info.chip }}
+- **Chip:** [{{ board_info.chip }}](../chips/{{ board_info.chip_technical_name }}.md)
 - **Chip Ariel OS Name:** `{{ board_info.chip_technical_name }}`
 
 ### References


### PR DESCRIPTION
# Description

This PR adds a link to the chip page from the corresponding board page.

## Issues/PRs references

Follow up to #1428.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
