### PR TITLE
docs(gen-book): add Ariel OS chip name to chip pages

### DIFF
--- a/book/src/chips/esp32c3.md
+++ b/book/src/chips/esp32c3.md
@@ -1,5 +1,9 @@
 # ESP32-C3
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32c3`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/esp32c3fx4.md
+++ b/book/src/chips/esp32c3fx4.md
@@ -1,5 +1,9 @@
 # ESP32-C3Fx4
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32c3fx4`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/esp32c6.md
+++ b/book/src/chips/esp32c6.md
@@ -1,5 +1,9 @@
 # ESP32-C6
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32c6`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/esp32c6fx4.md
+++ b/book/src/chips/esp32c6fx4.md
@@ -1,5 +1,9 @@
 # ESP32-C6Fx4
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32c6fx4`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/esp32s2.md
+++ b/book/src/chips/esp32s2.md
@@ -1,5 +1,9 @@
 # ESP32-S2
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32s2`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/esp32s2fx2.md
+++ b/book/src/chips/esp32s2fx2.md
@@ -1,5 +1,9 @@
 # ESP32-S2Fx2
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32s2fx2`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/esp32s2fx4.md
+++ b/book/src/chips/esp32s2fx4.md
@@ -1,5 +1,9 @@
 # ESP32-S2Fx4
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32s2fx4`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/esp32s2fx4r2.md
+++ b/book/src/chips/esp32s2fx4r2.md
@@ -1,5 +1,9 @@
 # ESP32-S2Fx4R2
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32s2fx4r2`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/esp32s3.md
+++ b/book/src/chips/esp32s3.md
@@ -1,5 +1,9 @@
 # ESP32-S3
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32s3`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/esp32s3fx8.md
+++ b/book/src/chips/esp32s3fx8.md
@@ -1,5 +1,9 @@
 # ESP32-S3Fx8
 
+## Chip Info
+
+- **Ariel OS Name:** `esp32s3fx8`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/nrf51822-xxaa.md
+++ b/book/src/chips/nrf51822-xxaa.md
@@ -1,5 +1,9 @@
 # nRF51822-xxAA
 
+## Chip Info
+
+- **Ariel OS Name:** `nrf51822-xxaa`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/nrf52832.md
+++ b/book/src/chips/nrf52832.md
@@ -1,5 +1,9 @@
 # nRF52832
 
+## Chip Info
+
+- **Ariel OS Name:** `nrf52832`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/nrf52833.md
+++ b/book/src/chips/nrf52833.md
@@ -1,5 +1,9 @@
 # nRF52833
 
+## Chip Info
+
+- **Ariel OS Name:** `nrf52833`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/nrf52840.md
+++ b/book/src/chips/nrf52840.md
@@ -1,5 +1,9 @@
 # nRF52840
 
+## Chip Info
+
+- **Ariel OS Name:** `nrf52840`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/nrf5340.md
+++ b/book/src/chips/nrf5340.md
@@ -1,5 +1,9 @@
 # nRF5340
 
+## Chip Info
+
+- **Ariel OS Name:** `nrf5340`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/nrf9151.md
+++ b/book/src/chips/nrf9151.md
@@ -1,5 +1,9 @@
 # nRF9151
 
+## Chip Info
+
+- **Ariel OS Name:** `nrf9151`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/nrf9160.md
+++ b/book/src/chips/nrf9160.md
@@ -1,5 +1,9 @@
 # nRF9160
 
+## Chip Info
+
+- **Ariel OS Name:** `nrf9160`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/rp2040.md
+++ b/book/src/chips/rp2040.md
@@ -1,5 +1,9 @@
 # RP2040
 
+## Chip Info
+
+- **Ariel OS Name:** `rp2040`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/rp235xa.md
+++ b/book/src/chips/rp235xa.md
@@ -1,5 +1,9 @@
 # RP235xa
 
+## Chip Info
+
+- **Ariel OS Name:** `rp235xa`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32c031c6.md
+++ b/book/src/chips/stm32c031c6.md
@@ -1,5 +1,9 @@
 # STM32C031C6
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32c031c6`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32f042k6.md
+++ b/book/src/chips/stm32f042k6.md
@@ -1,5 +1,9 @@
 # STM32F042K6
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32f042k6`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32f401re.md
+++ b/book/src/chips/stm32f401re.md
@@ -1,5 +1,9 @@
 # STM32F401RE
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32f401re`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32f411re.md
+++ b/book/src/chips/stm32f411re.md
@@ -1,5 +1,9 @@
 # STM32F411RE
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32f411re`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32h755zi.md
+++ b/book/src/chips/stm32h755zi.md
@@ -1,5 +1,9 @@
 # STM32H755ZI
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32h755zi`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32l475vg.md
+++ b/book/src/chips/stm32l475vg.md
@@ -1,5 +1,9 @@
 # STM32L475VG
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32l475vg`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32u073kc.md
+++ b/book/src/chips/stm32u073kc.md
@@ -1,5 +1,9 @@
 # STM32U073KC
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32u073kc`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32u083mc.md
+++ b/book/src/chips/stm32u083mc.md
@@ -1,5 +1,9 @@
 # STM32U083MC
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32u083mc`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32u585ai.md
+++ b/book/src/chips/stm32u585ai.md
@@ -1,5 +1,9 @@
 # STM32U585AI
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32u585ai`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32wb55rg.md
+++ b/book/src/chips/stm32wb55rg.md
@@ -1,5 +1,9 @@
 # STM32WB55RG
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32wb55rg`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32wba55cg.md
+++ b/book/src/chips/stm32wba55cg.md
@@ -1,5 +1,9 @@
 # STM32WBA55CG
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32wba55cg`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/src/chips/stm32wle5jc.md
+++ b/book/src/chips/stm32wle5jc.md
@@ -1,5 +1,9 @@
 # STM32WLE5JC
 
+## Chip Info
+
+- **Ariel OS Name:** `stm32wle5jc`
+
 ## Support Matrix
 
 |Functionality|Support Status|

--- a/book/templates/chip-page.md.tmpl
+++ b/book/templates/chip-page.md.tmpl
@@ -1,5 +1,9 @@
 # {{ chip_info.name }}
 
+## Chip Info
+
+- **Ariel OS Name:** `{{ chip_info.technical_name }}`
+
 ## Support Matrix
 
 |Functionality|Support Status|


### PR DESCRIPTION
# Description

This PR adds the Ariel OS chip name, which is notably used by `laze` commands in the chip page.

## Issues/PRs references

Follow up to #1428.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
