### PR TITLE
fix(rp): DMA channel overlap between storage and cyw43

### DIFF
--- a/src/ariel-os-rp/src/storage.rs
+++ b/src/ariel-os-rp/src/storage.rs
@@ -8,6 +8,6 @@ const FLASH_SIZE: usize = 2 * 1024 * 1024;
 pub fn init(p: &mut crate::OptionalPeripherals) -> Flash {
     embassy_rp::flash::Flash::<_, Async, FLASH_SIZE>::new(
         p.FLASH.take().unwrap(),
-        p.DMA_CH0.take().unwrap(),
+        p.DMA_CH1.take().unwrap(),
     )
 }


### PR DESCRIPTION
# Description

This PR changes which DMA channel is used for storage for the `rpi-pico-w` and `rpi-pico2-w` boards. It was previously using the same channel as the `cyw43` module, causing a runtime crash when both features were used.
This issue was discovered by @anlavandier

## Issues/PRs references

- Related to #1476 

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
