### PR TITLE
docs: Use admonitions to hightlight blocks

### DIFF
--- a/book/src/adding-board-support.md
+++ b/book/src/adding-board-support.md
@@ -5,9 +5,11 @@ for a board/device to Ariel OS.
 
 Feel free to report anything that is unclear or missing!
 
+> [!NOTE]
 > This guide requires working on your own copy of Ariel OS.
 > You may want to fork the repository to easily upstream your changes later.
 
+> [!IMPORTANT]
 > Unless documented in the User Guide, please expect the module and context names that are defined in the `laze-project.yml` file to change.
 > We're still figuring out a proper naming scheme.
 > You've been warned.
@@ -55,17 +57,15 @@ To do that, install [`sbd-gen`][sbd] with `cargo install sbd-gen`, then run the 
 sbd-gen generate-ariel boards -o src/ariel-os-boards --mode update
 ```
 
+> [!TIP]
 > To build every example and test for a board the following command can be used (as this is only for compilation the credentials do not need to be valid):
 >
 > ```sh
 > CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build --global -b <builder>
 > ```
 
-<div class="warning">
-
-When adding support for a board *in tree*, its name needs to be added to the [list of builders of its corresponding MCU family][ci-builder-lists], so that it gets appropriatetly built for in CI.
-
-</div>
+> [!WARNING]
+> When adding support for a board *in tree*, its name needs to be added to the [list of builders of its corresponding MCU family][ci-builder-lists], so that it gets appropriatetly built for in CI.
 
 ## Extra Steps for Some MCU Families
 

--- a/book/src/application.md
+++ b/book/src/application.md
@@ -11,6 +11,7 @@ These ZSTs indeed are by design neither [`Copy`](https://doc.rust-lang.org/stabl
 Drivers therefore require such ZSTs to be provided to make sure that the caller has (a) access to the peripheral and (b) is the only one having access, since only a single instance of the type can exist at any time.
 Being ZSTs, they do not carry any data to the drivers, only their ownership is meaningful, which is enforced by taking them as parameters for drivers.
 
+> [!TIP]
 > If you are used to thinking about MCU peripherals as referenced by a base address (in the case of memory-mapped peripherals), you can think of these ZSTs as abstraction over these, with a zero-cost, statically-enforced lock ensuring exclusive access.
 
 These Embassy types are defined by [Embassy HAL crates][embassy-hal-crates] in the respective `peripherals` modules.
@@ -53,6 +54,7 @@ Functions can currently be registered as either `spawner`s or `task`s:
 
 Both of these can be provided with an instance of an Ariel OS peripheral struct when needed, using the `peripherals` macro parameters (see the macros' documentation) and taking that Ariel OS peripheral struct as parameter.
 
+> [!TIP]
 > The Embassy peripherals obtained this way are regular Embassy peripherals, which are compatible with both Ariel OS portable drivers and [Embassy HAL crates'][embassy-hal-crates] HAL-specific drivers.
 
 ### Examples

--- a/book/src/async-support.md
+++ b/book/src/async-support.md
@@ -17,12 +17,14 @@ A default flavor compatible with the MCU is automatically selected by default in
 Another flavor can be manually selected, replacing the default one, by [selecting its laze module][laze-modules-book].
 Not all flavors are available on all MCUs however, and the laze configuration will only allow selecting one the compatible ones.
 
+> [!NOTE]
 > The `executor-interrupt` might offer a slight performance advantage.
 
 <!-- TODO: When to use each of them? -->
 
 ## Using Multiple Executors
 
+> [!NOTE]
 > Using multiple executors is possible but currently undocumented.
 
 Running multiple executors allows running them with different priorities.

--- a/book/src/build-system.md
+++ b/book/src/build-system.md
@@ -31,6 +31,7 @@ Tasks available in Ariel OS include:
 - `tree`: Prints the application's `cargo tree`.
 - `vscode-config`: update rust-analyzer configuration for VSCode, see [vscode-configuration](./vscode-configuration.md)
 
+> [!IMPORTANT]
 > As some tasks may trigger a rebuild, it is necessary to pass the same settings to related consecutive commands:
 `laze build -DFOO=1 flash` followed by `laze build -DFOO=other debug` might not
 work as expected, as the second command could be rebuilding the application
@@ -42,6 +43,7 @@ laze allows enabling/disabling individual features using [*modules*](#laze-modul
 or disabled on the command line using `--select <module>` or `--disable <module>`.
 To specify laze modules for an out-of-tree application, see [below](#enabling-laze-modules-for-an-application).
 
+> [!NOTE]
 > Modules are documented in their respective pages.
 
 [laze]: https://kaspar030.github.io/laze/dev/
@@ -67,6 +69,7 @@ Ariel OS's source and configuration are imported using [laze's `imports`][laze-
 The [project templates](./getting-started.md#starting-an-application-project-from-a-template-repository) use a [`git` import][laze-git-import-book] to ask laze to clone Ariel OS's repository.
 The cloned repository is stored inside `build/imports`.
 
+> [!NOTE]
 > It is currently recommended to use Ariel OS's commit ID to track the repository, to avoid surprising changes.
 > This commit ID needs to be updated to update the version of Ariel OS used by the application.
 
@@ -87,6 +90,7 @@ apps:
       - random
 ```
 
+> [!NOTE]
 > Note that, while the [CLI option is named `--select`](#laze-modules), the configuration key is `selects`.
 
 The specified modules will be enabled for the application, some of which may enable associated Cargo features (as individually documented for each laze module).

--- a/book/src/development-processes.md
+++ b/book/src/development-processes.md
@@ -9,6 +9,7 @@ There are three main CI workflows that are relevant for PRs: `CI`, `Build`, and 
 The `CI` workflow runs various checks and linters and runs host-side crate tests.
 It is relatively quick (usually runs in 3 minutes or less, with many checks running in just a few seconds), and is run for *every* PR.
 
+> [!NOTE]
 > Before requesting a review, linting errors should usually be addressed.
 
 ### The `Build` Workflow
@@ -23,6 +24,7 @@ On top of a label for each MCU (sub)family, there are a few other labels with di
 The `ci-build:skip` label additionally allows to skip almost everything in the `Build` workflow.
 As this workflow is more costly and takes much longer (about 10–45 minutes depending on the set of builders and on runner contention), selecting the right label is important to make sure the changes compile correctly while managing the load on the runners.
 
+> [!NOTE]
 > When opening a draft PR, it is recommended to *not* attach a label at first, to limit the load on the runners.
 > *Before* marking the PR as ready for review, a label should be attached (and the workflow manually re-run through the web interface) to check that the changes compile as expected: as this can take some time, not *all* jobs need to be green yet, but at least a few should.
 > When re-running the workflow, it is essential to select “Re-run all jobs” instead of “Re-run failed jobs” so that the `check-labels` job re-runs, otherwise its output—the attached label—might get incorrectly reused.
@@ -43,6 +45,7 @@ As this workflow is more costly and takes much longer (about 10–45 minutes de
 When a CI job is successful it will write to a cache that is keyed on a hash of the file tree.
 This allows it to re-run in mere seconds if changes to the future PR only affect the commit chain—e.g., squashing or editing commit messages—while leaving the tree as-is.
 
+> [!TIP]
 > This means that, when needing to edit the commit chain without changing the tree, it is better to *wait* for the jobs to complete before editing it, to benefit from this caching behavior. Otherwise what was run but not committed to the cache just gets thrown away.
 
 ### The Docs Preview
@@ -50,6 +53,7 @@ This allows it to re-run in mere seconds if changes to the future PR only affect
 This workflow builds the documentation—currently the rustdoc docs and the book—deploys it, and adds a bot comment to the PR.
 This comment contains links that allow accessing the deployed documentation.
 
+> [!IMPORTANT]
 > When making a PR with changes that affect the documentation, the preview should be checked to make sure the docs are rendered as expected.
 
 ## Dependency Vetting
@@ -75,12 +79,9 @@ The following steps must be followed when preparing a new release of `ariel-os`:
 1. Check whether deprecated items should be removed, if any.
 1. Update the version numbers of the crates that need to be bumped.
 
-    <div class="warning">
-        <ul>
-            <li>The crates in <code>/src/lib/</code> are managed separately and their version numbers should <em>not</em> be bumped.</li>
-            <li>The <code>ariel-os-sensors</code> crate's version is decoupled from the rest of the OS, as every sensor driver relies on it, and bumping it may result in fragmenting the entire ecosystem of sensor drivers.</li>
-        </ul>
-    </div>
+    > [!IMPORTANT]
+    > - The crates in `/src/lib/` are managed separately and their version numbers should *not* be bumped.
+    > - The `ariel-os-sensors` crate's version is decoupled from the rest of the OS, as every sensor driver relies on it, and bumping it may result in fragmenting the entire ecosystem of sensor drivers.
 
 1. Update the changelog manually, going through merge commits, especially focusing on PRs with the [`breaking`][issue-label-breaking] and [`changelog:highlight`][issue-label-changelog-highlight] labels, and skipping those with the [`changelog:skip`][issue-label-changelog-skip] label.
    If PR descriptions contain the string `BREAKING CHANGE` (in line with the [Conventional Commits][conventional-commits-spec] specification), these may be highlighted in the changelog.

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -67,6 +67,7 @@ The following assumes you have your target board connected to your host computer
 
 Find the Ariel OS name of your supported board in the [support matrix](./hardware-functionality-support.html).
 
+> [!NOTE]
 > The following assumes the Nordic nRF52840-DK, whose Ariel OS name is `nrf52840dk`.
 > Replace that name with your board's.
 
@@ -94,6 +95,7 @@ laze -C examples/hello-world build -b nrf52840dk flash-erase-all
 
 ![Terminal screencast of compiling and flashing the hello-world example](./hello-world_render.svg)
 
+> [!TIP]
 > If you do not plan on working on Ariel OS *itself*, this repository is not needed anymore and can be deleted.
 
 ## Starting an application project from a template repository
@@ -125,6 +127,7 @@ To check your setup, the default application can be compiled and run as follows:
 laze build -b nrf52840dk run
 ```
 
+> [!IMPORTANT]
 > The board name needs to be replaced with your board's.
 
 See the [Build System page](./build-system.md) to learn more about laze and how to work with out-of-tree applications.

--- a/book/src/hardware-functionality-support.md
+++ b/book/src/hardware-functionality-support.md
@@ -2,6 +2,7 @@
 
 # Hardware & Functionality Support
 
+> [!NOTE]
 > The tables below indicate whether we support using the piece of functionality in a portable manner, through an abstraction layer and platform-aware configuration.
 
 Hardware support is organized into tiers, each with their own testing policy:

--- a/book/src/multithreading.md
+++ b/book/src/multithreading.md
@@ -24,6 +24,7 @@ Ariel OS currently supports symmetric multiprocessing (SMP) on the following MC
 When the `sw/threading` [laze module][laze-modules-book] is selected and when available on the MCU, the `multi-core` laze module automatically gets selected, which enables SMP.
 To disable multicore, disable the `multi-core` [laze module][laze-modules-book].
 
+> [!NOTE]
 > Porting single-core applications to support multicore requires no changes to them.
 
 ### Priority Scheduling

--- a/book/src/networking.md
+++ b/book/src/networking.md
@@ -42,6 +42,7 @@ The configuration can be customized with the following environment variables:
 | `CONFIG_NET_IPV4_STATIC_CIDR_PREFIX_LEN` | `24`         |
 | `CONFIG_NET_IPV4_STATIC_GATEWAY_ADDRESS` | `10.42.0.1`  |
 
+> [!NOTE]
 > Non-static IPv6 address allocation will be supported in the future.
 
 ### Support for Network Protocols

--- a/book/src/randomness.md
+++ b/book/src/randomness.md
@@ -11,13 +11,14 @@ Two different RNG interfaces are provided, which both implement `rand_core` trai
 - A cryptographically secure pseudo-RNG (CSPRNG) interface, which can be obtained with [`random::crypto_rng()`][crypto-rng-fn-rustdoc] when the `csprng` Cargo feature is enabled.
   In addition, the `csprng` Cargo feature also enables support for the [`getrandom` crate][getrandom-cratesio], even when it is present as a transitive dependency only.
 
-
+> [!IMPORTANT]
 > To ensure fast operation of the fast RNG, the obtained RNG must be reused between invocations, instead of obtaining new ones through [`random::fast_rng()`][fast-rng-fn-rustdoc].
 
 ## RNG Seeding
 
 When the `random` module is selected, the `hwrng` [laze module][laze-modules-book] is automatically enabled as well, so that the RNGs get automatically seeded from the hardware RNG (i.e., the TRNG) at startup.
 
+> [!NOTE]
 > In the future, Ariel OS may also support leveraging persistent storage in combination with a pre-provisioned seed to enable to use the CSPRNG on MCUs which do not provide a hardware RNG.
 
 [fast-rng-fn-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/random/fn.fast_rng.html

--- a/book/src/storage.md
+++ b/book/src/storage.md
@@ -51,11 +51,13 @@ The storage module requires at least two flash pages.
 The effective storage space available is `(N - 1) * PAGE_SIZE`,
 where `N` is the number of flash pages allocated.
 
+> [!NOTE]
 > Currently storage is only supported on flash whose pages have a uniform size.
 
 These pages are allocated by Ariel OS after the `rodata` section in the flash
 when the module is enabled.
 
+> [!WARNING]
 > Updating the firmware can move and invalidate the storage pages
   when the firmware size differs from the previous version.
 

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -12,6 +12,7 @@ once set up, tests can be run by issuing `laze build -b <board> test`.
 `embedded-tests` can be used for any target that has `probe-rs` support (which currently means all targets).
 Both async and non-async code can be tested.
 
+> [!NOTE]
 > Currently, Ariel OS requires a fork of `embedded-test`. When using Ariel's
 build system, this will be used automatically.
 
@@ -81,6 +82,7 @@ apps:
       - embedded-test-only
 ```
 
+> [!IMPORTANT]
 > Even a library crate needs an entry in laze's `apps` in order to make the `test` task available.
 > Selecting `embedded-test-only` will make sure that `laze run` is disabled.
 

--- a/book/src/tooling/coap.md
+++ b/book/src/tooling/coap.md
@@ -279,11 +279,12 @@ to accept requests from newly created Ariel OS based CoAP clients
 without the need for the CoAP client to create a network connection to the host.
 (Instead, the host needs to find the Resource Server over the network).
 
-> Note: Some more exploration of this workflow will be necessary
-  as to how the client can trigger the AS to re-install (or renew) its token
-  in case the Resource Server retired the token before its expiration.
-  For Ariel OS internal use,
-  AS-provisioned tokens might just be retained longer.
+> [!NOTE]
+> Some more exploration of this workflow will be necessary
+> as to how the client can trigger the AS to re-install (or renew) its token
+> in case the Resource Server retired the token before its expiration.
+> For Ariel OS internal use,
+> AS-provisioned tokens might just be retained longer.
 
 [New ACE Workflow developed in ACE]: https://www.ietf.org/archive/id/draft-ietf-ace-workflow-and-params-00.html#name-new-ace-workflow
 

--- a/book/src/tooling/ferrocene.md
+++ b/book/src/tooling/ferrocene.md
@@ -1,8 +1,10 @@
 # [Ferrocene]
 
+> [!NOTE]
 > Ferrocene is the open-source qualified Rust compiler toolchain for safety- and mission-critical. Qualified for automotive, industrial and medical development.
 
-Note: Ferrocene requires a (paid) license to use.
+> [!NOTE]
+> Ferrocene requires a (paid) license to use.
 
 Ferrocene uses [`criticalup`][criticalup], its variant of `rustup`, to manage installing its toolchain and components. Once installed, wrapping regular Rust commands like `cargo` and `rustc` with `criticalup run` enables using the qualified tooling.
 


### PR DESCRIPTION
# Description

This converts our mdbook to use the [admonitions](https://github.com/rust-lang/mdBook/blob/master/guide/src/format/markdown.md#admonitions) added in mdbook@0.5.0-alpha.1. Main advantage is that with this formatting, blocks are a bit more visible and especially a warning after a block is not easily lost. 

## Issues/PRs references

None

## Open Questions

Tried my best to gauge whether the info blocks should be notes (General information or additional context.) or tips (A helpful suggestion or best practice.)

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
