### PR TITLE
docs(book): add instructions in getting started page

### DIFF
--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -23,8 +23,15 @@ It explains how to compile and run the `hello-word` example to verify your setup
     pacman -S git ninja pkgconf clang arm-none-eabi-gcc arm-none-eabi-newlib gcc curl make lib32-glibc
     ```
 
-    For RISC-V chips, the compiler can be installed via the `riscv32-gnu-toolchain-elf-bin` AUR package
-    with a AUR helper such as [yay](https://github.com/Jguer/yay):
+    For RISC-V chips, the compiler can be installed via the `riscv32-gnu-toolchain-elf-bin` AUR package.
+
+    First, make sure to install the `fakeroot` and `debugedit` packages (part of the `base-devel` metapackage):
+
+    ```sh
+    pacman -S fakeroot debugedit
+    ```
+
+    `riscv32-gnu-toolchain-elf-bin` can be installed with an AUR helper, such as [yay](https://github.com/Jguer/yay):
 
     ```sh
     yay -S riscv32-gnu-toolchain-elf-bin


### PR DESCRIPTION
# Description

This PR adds instructions in the "Getting Started" book page that aim to avoid the issue encountered in #1495.

## Issues/PRs references

Linked to #1495.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
