### PR TITLE
fix(nrf): peripheral overlap between SPI and UART

### DIFF
--- a/src/ariel-os-nrf/src/spi/main/mod.rs
+++ b/src/ariel-os-nrf/src/spi/main/mod.rs
@@ -237,11 +237,13 @@ define_spi_drivers!(
 #[cfg(context = "nrf5340")]
 define_spi_drivers!(
     SERIAL2 => SERIAL2,
+    // Used by UART
     // SERIAL3 => SERIAL3,
 );
 // FIXME: arbitrary selected peripherals
 #[cfg(context = "nrf91")]
 define_spi_drivers!(
     SERIAL2 => SERIAL2,
-    SERIAL3 => SERIAL3,
+    // Used by UART
+    // SERIAL3 => SERIAL3,
 );

--- a/src/ariel-os-nrf/src/spi/mod.rs
+++ b/src/ariel-os-nrf/src/spi/mod.rs
@@ -32,10 +32,12 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             let _ = peripherals.SPI3.take().unwrap();
         } else if #[cfg(context = "nrf5340")] {
             let _ = peripherals.SERIAL2.take().unwrap();
-            let _ = peripherals.SERIAL3.take().unwrap();
+            // Used by UART
+            // let _ = peripherals.SERIAL3.take().unwrap();
         } else if #[cfg(context = "nrf91")] {
             let _ = peripherals.SERIAL2.take().unwrap();
-            let _ = peripherals.SERIAL3.take().unwrap();
+            // Used by UART
+            // let _ = peripherals.SERIAL3.take().unwrap();
         } else {
             compile_error!("this nRF chip is not supported");
         }


### PR DESCRIPTION
# Description

This PR removes the use of `SERIAL3` by the `spi` feature on the `nrf5340` and `nrf91` series of MCU as this peripheral is also used by the `uart` feature. 
This would cause a build time error (because of the interrupt) for the `nrf91` series and a runtime crash for the `nrf5340` when both `spi` and `uart` features are enabled.

## Issues/PRs references

Discovered with #1482

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
(nRF5340, nRF9151, nRF9160) The `SERIAL3` peripheral is now dedicated to the UART drivers instead of the SPI drivers.
<!-- changelog:end -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
