### PR TITLE
docs(gen-book): improve error messages

### DIFF
--- a/doc/gen_book.rs
+++ b/doc/gen_book.rs
@@ -861,8 +861,8 @@ enum Error {
     WritingOutputFile { path: PathBuf, source: io::Error },
     #[error("could not read existing output HTML file `{path}`")]
     ReadingExistingFile { path: PathBuf, source: io::Error },
-    #[error("existing HTML file `{path}` is not up to date")]
+    #[error("existing HTML file `{path}` is not up to date. To update the book, run `laze build update-book`")]
     ExistingHtmlNotUpToDate { path: PathBuf },
-    #[error("existing Markdown file `{path}` is not up to date")]
+    #[error("existing Markdown file `{path}` is not up to date. To update the book, run `laze build update-book`")]
     ExistingMarkdownNotUpToDate { path: PathBuf },
 }


### PR DESCRIPTION
# Description

This PR improves the error message of the `gen_book.rs` script to indicate to the user that they should probably run `laze build update-book`.

## Issues/PRs references

Closes #1504.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
