### PR TITLE
docs(book): add fmt to the laze tasks

### DIFF
--- a/book/src/build-system.md
+++ b/book/src/build-system.md
@@ -30,6 +30,7 @@ Tasks available in Ariel OS include:
 - `reset`: Reboots the target.
 - `tree`: Prints the application's `cargo tree`.
 - `vscode-config`: update rust-analyzer configuration for VSCode, see [vscode-configuration](./vscode-configuration.md)
+- `fmt`: Formats the project's Rust source code following the [Coding Conventions](./coding-conventions.md) (formats all Rust files except generated ones).
 
 > [!IMPORTANT]
 > As some tasks may trigger a rebuild, it is necessary to pass the same settings to related consecutive commands:


### PR DESCRIPTION
# Description

Adds `laze build fmt` to the list of laze tasks in the book.

## Issues/PRs references

#1481 

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
