### PR TITLE
ci(build): avoid the need for listing every `rp` laze builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,11 @@ jobs:
       - name: "limit build unless nightly build"
         if: github.event_name != 'schedule' && steps.should-skip.outputs.result != 'true'
         run: |
+          allow_context() {
+            hal_contexts='context::esp,context::host,context::native,context::nrf,context::rp,context::stm32'
+
+            echo "$hal_contexts" | tr ',' '\n' | grep -v "^context::${1}$" | paste -sd ','
+          }
           case '${{ needs.check-labels.outputs.label }}' in
             'ci-build:esp')
               echo "NEEDS_XTENSA_TOOLCHAIN=1" >> "$GITHUB_ENV"
@@ -160,7 +165,7 @@ jobs:
               echo "LAZE_BUILDERS=bbc-microbit-v1,bbc-microbit-v2,nordic-thingy-91-x-nrf9151,nrf52840dk,nrf52dk,nrf5340dk,nrf5340dk-net,nrf9160dk-nrf9160,nrf9151-dk" >> "$GITHUB_ENV"
               ;;
             'ci-build:rp')
-              echo "LAZE_BUILDERS=rpi-pico,rpi-pico2,rpi-pico2-w,rpi-pico-w" >> "$GITHUB_ENV"
+              echo "LAZE_DISABLE=$(allow_context rp)" >> "$GITHUB_ENV"
               ;;
             'ci-build:small')
               echo "NEEDS_XTENSA_TOOLCHAIN=1" >> "$GITHUB_ENV"
@@ -249,6 +254,8 @@ jobs:
         if: steps.should-skip.outputs.result != 'true'
         run: |
           echo "LAZE_BUILDERS=${LAZE_BUILDERS}"
+          echo "LAZE_DISABLE=${LAZE_DISABLE}"
+          laze build -mg info-boards | uniq
           CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build -DCARGO_ARGS+='--locked' --global --partition hash:${{ matrix.partition }}
 
       # cleanup previous build artifacts. do in background (no need to wait).


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This revisits how we select the set of laze builders for the `ci-build:rp` PR build label, to avoid having to manually list the laze builders.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #1513.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
