### PR TITLE
docs(adding-board): remove now unneeded CI instructions

### DIFF
--- a/book/src/adding-board-support.md
+++ b/book/src/adding-board-support.md
@@ -64,9 +64,6 @@ sbd-gen generate-ariel boards -o src/ariel-os-boards --mode update
 > CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build --global -b <builder>
 > ```
 
-> [!WARNING]
-> When adding support for a board *in tree*, its name needs to be added to the [list of builders of its corresponding MCU family][ci-builder-lists], so that it gets appropriatetly built for in CI.
-
 ## Extra Steps for Some MCU Families
 
 ### `stm32`


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
When the PRs listed as dependencies land, the warning introduced in #1493 will not be needed anymore, so this PR removes it.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #1515.
Depends on #1517.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
