### PR TITLE
feat(sensors): tie channels to samples in return types

### DIFF
--- a/src/ariel-os-sensors/src/sample.rs
+++ b/src/ariel-os-sensors/src/sample.rs
@@ -1,3 +1,5 @@
+use crate::sensor::ReadingChannel;
+
 #[expect(clippy::doc_markdown)]
 /// Represents a value obtained from a sensor device, along with its accuracy.
 ///
@@ -102,7 +104,7 @@ pub enum Accuracy {
 /// [`Sensor::wait_for_reading()`](crate::Sensor::wait_for_reading).
 pub trait Reading: core::fmt::Debug {
     /// Returns the first value returned by [`Reading::samples()`].
-    fn sample(&self) -> Sample;
+    fn sample(&self) -> (ReadingChannel, Sample);
 
     /// Returns an iterator over [`Sample`]s of a sensor reading.
     ///
@@ -112,7 +114,7 @@ pub trait Reading: core::fmt::Debug {
     ///
     /// The default implementation must be overridden on types containing multiple
     /// [`Sample`]s.
-    fn samples(&self) -> impl ExactSizeIterator<Item = Sample> {
+    fn samples(&self) -> impl ExactSizeIterator<Item = (ReadingChannel, Sample)> {
         [self.sample()].into_iter()
     }
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Following #1399, it's now possible to rework the `Reading` trait to return tuples of `(ReadingChannel, Sample)` so that users don't have to awkwardly zip `ReadingChannels` with `Samples` themselves.
It was necessary to introduce a custom iterator type for type erasure (it's not possible to simply use `Iterator::zip()`, because this would require to use `array::IntoIter`, which has the array size as a generic, which makes the march arms have different types).

Using `ci-build:skip` as there is no users of that interface in the tree yet.

This is not considered a breaking change as the sensor API is currently undocumented on purpose.

## Documentation

The documentation of the sensor API can be generated locally with:

```sh
cargo +nightly doc -p ariel-os-sensors --open 
```

The only visible difference should be on the return types of `Reading::sample()` and `Reading::samples()`. It even seems fine to keep the custom iterator private, as the type is only instantiated internally and only returned as an opaque type.

## Testing

Tested by merging against #1412: the only required adjustment is where you would expect, when accessing `Reading::samples()`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
