### PR TITLE
refactor(sensors): rename `Accuracy` to `SampleMetadata`

### DIFF
--- a/src/ariel-os-sensors/src/sample.rs
+++ b/src/ariel-os-sensors/src/sample.rs
@@ -10,7 +10,7 @@ pub enum SampleError {
 }
 
 #[expect(clippy::doc_markdown)]
-/// Represents a value obtained from a sensor device, along with its accuracy.
+/// Represents a value obtained from a sensor device, along with its metadata.
 ///
 /// # Scaling
 ///
@@ -22,7 +22,7 @@ pub enum SampleError {
 ///
 /// For instance, in the case of a temperature sensor, if [`Self::value()`] returns `2225` and the
 /// scaling value is `-2`, this means that the temperature measured and returned by the sensor
-/// device is `22.25` (the [measurement error](Accuracy) must additionally be taken into
+/// device is `22.25` (the [measurement error](SampleMetadata) must additionally be taken into
 /// account).
 /// This is required to avoid handling floats.
 ///
@@ -33,7 +33,7 @@ pub enum SampleError {
 ///
 /// # Accuracy
 ///
-/// The accuracy can be obtained with [`Self::accuracy()`].
+/// The accuracy can be obtained through [`Self::metadata()`].
 // NOTE(derive): we do not implement `Eq` or `PartialOrd` on purpose: `Eq` would prevent us from
 // possibly adding floats in the future and `PartialOrd` does not make sense because interpreting
 // the sample requires the `ReadingChannel` associated with this `Sample`.
@@ -41,7 +41,7 @@ pub enum SampleError {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Sample {
     value: i32,
-    accuracy: Accuracy,
+    metadata: SampleMetadata,
 }
 
 impl Sample {
@@ -49,8 +49,8 @@ impl Sample {
     ///
     /// This constructor is intended for sensor driver implementors only.
     #[must_use]
-    pub const fn new(value: i32, accuracy: Accuracy) -> Self {
-        Self { value, accuracy }
+    pub const fn new(value: i32, metadata: SampleMetadata) -> Self {
+        Self { value, metadata }
     }
 
     /// Returns the sample value.
@@ -59,33 +59,37 @@ impl Sample {
     ///
     /// [`SampleError`] is returned in case of error.
     pub fn value(&self) -> Result<i32, SampleError> {
-        match self.accuracy {
-            Accuracy::ChannelTemporarilyUnavailable => Err(SampleError::TemporarilyUnavailable),
-            Accuracy::NoError | Accuracy::Unknown | Accuracy::SymmetricalError { .. } => {
-                Ok(self.value)
+        match self.metadata {
+            SampleMetadata::ChannelTemporarilyUnavailable => {
+                Err(SampleError::TemporarilyUnavailable)
             }
+            SampleMetadata::NoMeasurementError
+            | SampleMetadata::UnknownAccuracy
+            | SampleMetadata::SymmetricalError { .. } => Ok(self.value),
         }
     }
 
-    /// Returns the measurement accuracy.
+    /// Returns the measurement metadata, including accuracy if available.
     #[must_use]
-    pub fn accuracy(&self) -> Accuracy {
-        self.accuracy
+    pub fn metadata(&self) -> SampleMetadata {
+        self.metadata
     }
 }
 
-/// Specifies the accuracy of a measurement.
+/// Metadata associated with a [`Sample`].
+///
+/// Includes the measurement accuracy if available.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Accuracy {
+pub enum SampleMetadata {
     /// Unknown accuracy.
-    Unknown,
-    /// No measurement error (e.g., boolean values from a push button).
-    NoError,
-    /// Measurement error symmetrical around the [`bias`](Accuracy::SymmetricalError::bias).
+    UnknownAccuracy,
+    /// No observational/measurement error (e.g., boolean values from a push button).
+    NoMeasurementError,
+    /// Measurement error symmetrical around the [`bias`](SampleMetadata::SymmetricalError::bias).
     ///
     /// The unit of measurement is provided by the [`ReadingChannel`](crate::sensor::ReadingChannel)
-    /// associated to the [`Sample`].
+    /// associated with the [`Sample`].
     /// The `scaling` value is used for both `deviation` and `bias`.
     /// The accuracy error is thus given by the following formulas:
     ///
@@ -95,11 +99,11 @@ pub enum Accuracy {
     ///
     /// The DS18B20 temperature sensor accuracy error is <mo>+</mo><mn>0.05</mn>/<mo>-</mo><mn>0.45</mn>
     /// at 20 °C (see Figure 1 of its datasheet).
-    /// [`Accuracy`] would thus be the following:
+    /// [`SampleMetadata`] would thus be the following:
     ///
     /// ```
-    /// # use ariel_os_sensors::sensor::Accuracy;
-    /// Accuracy::SymmetricalError {
+    /// # use ariel_os_sensors::sensor::SampleMetadata;
+    /// SampleMetadata::SymmetricalError {
     ///     deviation: 25,
     ///     bias: -20,
     ///     scaling: -2,
@@ -111,8 +115,8 @@ pub enum Accuracy {
         deviation: u8,
         /// Bias (mean accuracy error).
         bias: i8,
-        /// Scaling of [`deviation`](Accuracy::SymmetricalError::deviation) and
-        /// [`bias`](Accuracy::SymmetricalError::bias).
+        /// Scaling of [`deviation`](SampleMetadata::SymmetricalError::deviation) and
+        /// [`bias`](SampleMetadata::SymmetricalError::bias).
         scaling: i8,
     },
     /// Indicates that the channel is temporarily unavailable.
@@ -145,7 +149,7 @@ mod tests {
 
     #[test]
     fn assert_type_sizes() {
-        assert!(size_of::<Accuracy>() <= size_of::<u32>());
+        assert!(size_of::<SampleMetadata>() <= size_of::<u32>());
         // Make sure the type is small enough.
         assert!(size_of::<Sample>() <= 2 * size_of::<u32>());
     }

--- a/src/ariel-os-sensors/src/sensor.rs
+++ b/src/ariel-os-sensors/src/sensor.rs
@@ -11,7 +11,7 @@ use crate::{Category, Label, MeasurementUnit};
 
 pub use crate::{
     Reading,
-    sample::{Accuracy, Sample, SampleError},
+    sample::{Sample, SampleError, SampleMetadata},
 };
 
 ariel_os_macros::define_count_adjusted_sensor_enums!();


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This makes the name of the type more generic, so we can store other sorts of metadata without it looking odd, like in #1354 (and we'll likely introduce another metadata variant for channels disabled by configuration, e.g., for IMUs, see #1522).

This is not considered a breaking change as the sensor API is undocumented on purpose.

## Testing

Merged against #1412, the required adjustments were as expected.

## Documentation

The documentation of the sensor API can be generated locally with:

```sh
cargo +nightly doc -p ariel-os-sensors --open 
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
