### PR TITLE
feat(sensors): introduce a variant for disabled channels

### DIFF
--- a/src/ariel-os-sensors/src/sample.rs
+++ b/src/ariel-os-sensors/src/sample.rs
@@ -7,6 +7,8 @@ use crate::sensor::ReadingChannel;
 pub enum SampleError {
     /// The channel is not available at the moment (e.g., part of the sensor is not ready yet).
     TemporarilyUnavailable,
+    /// The channel is disabled by configuration.
+    ChannelDisabled,
 }
 
 #[expect(clippy::doc_markdown)]
@@ -63,6 +65,7 @@ impl Sample {
             SampleMetadata::ChannelTemporarilyUnavailable => {
                 Err(SampleError::TemporarilyUnavailable)
             }
+            SampleMetadata::ChannelDisabled => Err(SampleError::ChannelDisabled),
             SampleMetadata::NoMeasurementError
             | SampleMetadata::UnknownAccuracy
             | SampleMetadata::SymmetricalError { .. } => Ok(self.value),
@@ -122,6 +125,8 @@ pub enum SampleMetadata {
     /// Indicates that the channel is temporarily unavailable.
     /// This may happen when parts of a sensor are not ready yet, but data is already available for other channels.
     ChannelTemporarilyUnavailable,
+    /// The channel is disabled by configuration.
+    ChannelDisabled,
 }
 
 /// Implemented on [`Samples`](crate::sensor::Samples), returned by


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This introduces an new variant similar to `ChannelTemporarilyUnavailable` from #1354 for channels disabled by configuration. This should be useful for IMUs when the configuration disables the accelerometer or the gyroscope for instance (the number of channels returned by a sensor driver must be constant). 

This is not considered a breaking change since the sensor API is undocumented on purpose.

## Documentation

The documentation of the sensor API can be generated locally with:

```sh
cargo +nightly doc -p ariel-os-sensors --open 
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #1521.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
