### PR TITLE
docs(uart): correct the baud rate unit spelling

### DIFF
--- a/src/ariel-os-embassy-common/src/uart.rs
+++ b/src/ariel-os-embassy-common/src/uart.rs
@@ -18,19 +18,19 @@ pub enum ConfigError {
 pub enum Baudrate<A> {
     /// HAL-specific baud rate.
     Hal(A),
-    /// 2400 bauds.
+    /// 2400 baud.
     _2400,
-    /// 4800 bauds.
+    /// 4800 baud.
     _4800,
-    /// 9600 bauds.
+    /// 9600 baud.
     _9600,
-    /// 19200 bauds.
+    /// 19200 baud.
     _19200,
-    /// 38400 bauds.
+    /// 38400 baud.
     _38400,
-    /// 57600 bauds.
+    /// 57600 baud.
     _57600,
-    /// 115200 bauds.
+    /// 115200 baud.
     _115200,
 }
 

--- a/src/ariel-os-nrf/src/uart.rs
+++ b/src/ariel-os-nrf/src/uart.rs
@@ -41,39 +41,39 @@ impl Default for Config {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Baudrate {
-    /// 1200 bauds.
+    /// 1200 baud.
     _1200,
-    /// 2400 bauds.
+    /// 2400 baud.
     _2400,
-    /// 4800 bauds.
+    /// 4800 baud.
     _4800,
-    /// 9600 bauds.
+    /// 9600 baud.
     _9600,
-    /// 14400 bauds.
+    /// 14400 baud.
     _14400,
-    /// 19200 bauds.
+    /// 19200 baud.
     _19200,
-    /// 28800 bauds.
+    /// 28800 baud.
     _28800,
-    /// 31250 bauds.
+    /// 31250 baud.
     _31250,
-    /// 38400 bauds.
+    /// 38400 baud.
     _38400,
-    /// 56000 bauds.
+    /// 56000 baud.
     _56000,
-    /// 57600 bauds.
+    /// 57600 baud.
     _57600,
-    /// 76800 bauds.
+    /// 76800 baud.
     _76800,
-    /// 115200 bauds.
+    /// 115200 baud.
     _115200,
-    /// 230400 bauds.
+    /// 230400 baud.
     _230400,
-    /// 250000 bauds.
+    /// 250000 baud.
     _250000,
-    /// 460800 bauds.
+    /// 460800 baud.
     _460800,
-    /// 921600 bauds.
+    /// 921600 baud.
     _921600,
     /// 1 Megabaud.
     _1000000,


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
The plural of "baud" is "baud" when used as a unit. 

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
