### PR TITLE
ci(rustdoc): render rustdoc docs for common HAL traits

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -94,6 +94,17 @@ jobs:
                   usb-hid,
                   coapcore/_nightly_docs
                   "
+          cargo doc \
+            --target=riscv32imac-unknown-none-elf \
+            --no-deps \
+            -p embedded-hal@1.0.0 \
+            -p embedded-hal-async \
+            -p embedded-io-async
+          cargo doc \
+            --no-deps \
+            -p embedded-hal@1.0.0 \
+            -p embedded-hal-async \
+            -p embedded-io-async
           RUSTDOCFLAGS='-D warnings --cfg context="esp32c6" --cfg nightly' cargo doc \
               --target=riscv32imac-unknown-none-elf \
               --no-deps \


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
As we render rustdoc docs for HAL crates with `--no-deps`, the docs for ecosystem traits (e.g., traits from `embedded-hal-async`) are not rendered, which makes it difficult to figure out which traits the HAL drivers implement (the `I2c` *trait* is not a link in the screenshot below):

<img width="590" height="207" alt="Screenshot_20251117_142510" src="https://github.com/user-attachments/assets/6457cb40-902b-4848-a110-cafb9defc0f6" />

This renders the rustdoc docs for a small set of such crates providing such traits, to try to alleviate this issue.

## How to review this PR

Check the docs preview: the I2C, SPI, and UART drivers from `ariel_os::hal` should have clickable `embedded-hal`, `embedded-hal-async`, and `embedded-io-async` traits, for the four HALs (ESP behaves differently).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
