### PR TITLE
refactor(sensors): remove the troublemaker `Label::Main`

### DIFF
--- a/src/ariel-os-sensors/src/label.rs
+++ b/src/ariel-os-sensors/src/label.rs
@@ -5,13 +5,6 @@
 ///
 /// Missing variants can be added when required.
 /// Please open an issue to discuss it.
-///
-/// [`Label::Main`] must be used for sensor drivers returning a single
-/// [`Sample`](crate::sensor::Sample), even if a more specific label exists for the
-/// physical quantity.
-/// This allows consumers displaying the label to ignore it for sensor drivers returning a single
-/// [`Sample`](crate::sensor::Sample).
-/// Other labels are reserved for sensor drivers returning multiple physical quantities.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
@@ -36,8 +29,6 @@ pub enum Label {
     Latitude,
     /// Longitude.
     Longitude,
-    /// Used for sensor drivers returning a single [`Sample`](crate::sensor::Sample).
-    Main,
     /// Opaque channel: the associated sample is intended for the sensor driver only, and no guarantees are provided.
     Opaque,
     /// Relative humidity.
@@ -69,7 +60,6 @@ impl core::fmt::Display for Label {
             Self::GroundSpeed => write!(f, "Ground speed"),
             Self::Latitude => write!(f, "Latitude"),
             Self::Longitude => write!(f, "Longitude"),
-            Self::Main => write!(f, ""),
             Self::Opaque => write!(f, "[opaque]"),
             Self::RelativeHumidity => write!(f, "Relative humidity"),
             Self::Heading => write!(f, "Heading"),


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This removes the `Label::Main` variant. It was realized in https://github.com/ariel-os/ariel-os/pull/1530#discussion_r2538294102 that it wasn't actually ergonomic at all. This also just makes `Label` simpler.

## Documentation

The documentation of the sensor API can be generated locally with:

```sh
cargo +nightly doc -p ariel-os-sensors --open 
```

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
