### PR TITLE
docs(ble): remove naming confusion around the BLE Stack

### DIFF
--- a/examples/ble-advertiser/src/main.rs
+++ b/examples/ble-advertiser/src/main.rs
@@ -16,7 +16,8 @@ use ariel_os::{
 #[ariel_os::task(autostart)]
 async fn run_advertisement() {
     info!("starting ble stack");
-    let mut stack = ariel_os::ble::ble_stack().await.build();
+    let stack = ariel_os::ble::ble_stack().await;
+    let mut host = stack.build();
 
     let mut adv_data = [0; 31];
 
@@ -31,14 +32,14 @@ async fn run_advertisement() {
 
     info!("Starting advertising");
 
-    let _ = join(stack.runner.run(), async {
+    let _ = join(host.runner.run(), async {
         let params = AdvertisementParameters {
             interval_min: Duration::from_millis(100),
             interval_max: Duration::from_millis(100),
             ..Default::default()
         };
 
-        let _advertiser = stack
+        let _advertiser = host
             .peripheral
             .advertise(
                 &params,

--- a/examples/ble-scanner/src/main.rs
+++ b/examples/ble-scanner/src/main.rs
@@ -21,12 +21,13 @@ use ariel_os::{
 #[ariel_os::task(autostart)]
 async fn run_scanner() {
     info!("starting ble stack");
+    let stack = ariel_os::ble::ble_stack().await;
 
     let Host {
         central,
         mut runner,
         ..
-    } = ariel_os::ble::ble_stack().await.build();
+    } = stack.build();
 
     let printer = Printer {
         seen: RefCell::new(Deque::new()),


### PR DESCRIPTION
# Description

This PR fixes the variable naming in the BLE examples to match the book. 

## Testing

Successfully ran `examples/ble-scanner` and `examples/ble-advertiser` on `nrf52dk`.

## Issues/PRs References

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
