### PR TITLE
fix(ble): remove unused `ble-config-override` feature

### DIFF
--- a/src/ariel-os-embassy-common/src/ble.rs
+++ b/src/ariel-os-embassy-common/src/ble.rs
@@ -27,8 +27,6 @@ pub fn get_ble_host_resources() -> &'static mut BleHostResources {
 }
 
 /// Configuration for the BLE stack.
-///
-/// You can customize it using the `ble-config-override` feature.
 pub struct Config {
     /// The address of the BLE device.
     pub address: trouble_host::Address,

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -142,7 +142,6 @@ threading = ["dep:ariel-os-threads", "ariel-os-hal/threading"]
 network-config-ipv4-static = ["network-config-override"]
 network-config-override = []
 override-usb-config = []
-ble-config-override = []
 
 executor-single-thread = [
   "ariel-os-hal/executor-single-thread",

--- a/src/ariel-os-embassy/src/ble.rs
+++ b/src/ariel-os-embassy/src/ble.rs
@@ -1,9 +1,3 @@
-#![allow(unsafe_code)]
-#![allow(
-    clippy::undocumented_unsafe_blocks,
-    reason = "should be addressed eventually"
-)]
-
 use ariel_os_embassy_common::ble::Config;
 
 // Must be async and return &trouble_host::Stack<'static, impl Controller>
@@ -11,15 +5,5 @@ pub use crate::hal::ble::ble_stack;
 
 #[allow(dead_code, reason = "false positive during builds outside of laze")]
 pub(crate) fn config() -> Config {
-    #[cfg(not(feature = "ble-config-override"))]
-    {
-        Config::default()
-    }
-    #[cfg(feature = "ble-config-override")]
-    {
-        unsafe extern "Rust" {
-            fn __ariel_os_ble_config() -> Config;
-        }
-        unsafe { __ariel_os_ble_config() }
-    }
+    Config::default()
 }

--- a/src/ariel-os-macros/src/config.rs
+++ b/src/ariel-os-macros/src/config.rs
@@ -11,7 +11,6 @@
 ///
 /// | Driver    | Expected type                      | Cargo feature to enable   |
 /// | --------- | ---------------------------------- | ------------------------- |
-// | `ble`     | `ariel_os::reexports::ble::Config` | `ble-config-override`     |
 /// | `network` | `embassy_net::Config`              | `network-config-override` |
 /// | `usb`     | `embassy_usb::Config`              | `override-usb-config`     |
 ///
@@ -59,10 +58,6 @@ pub fn config(args: TokenStream, item: TokenStream) -> TokenStream {
     let ariel_os_crate = utils::ariel_os_crate();
 
     let (config_fn_name, return_type) = match attrs.kind {
-        // Some(ConfigKind::Ble) => (
-        //     format_ident!("__ariel_os_ble_config"),
-        //     quote! {#ariel_os_crate::reexports::ble::Config},
-        // ),
         Some(ConfigKind::Network) => (
             format_ident!("__ariel_os_network_config"),
             quote! {#ariel_os_crate::reexports::embassy_net::Config},
@@ -144,7 +139,6 @@ mod config_macro {
 
     #[derive(Debug, Clone, Copy)]
     pub enum ConfigKind {
-        // Ble,
         Network,
         Usb,
     }
@@ -152,7 +146,6 @@ mod config_macro {
     impl ConfigKind {
         pub fn as_name(self) -> &'static str {
             match self {
-                // Self::Ble => "ble",
                 Self::Network => "network",
                 Self::Usb => "usb",
             }

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -120,8 +120,6 @@ usb-hid = ["ariel-os-embassy/usb-hid"]
 #! specific system functionality.
 #! The features below need to be enabled so that the provided custom
 #! configuration is taken into account.
-# Enables custom BLE configuration.
-ble-config-override = ["ariel-os-embassy/ble-config-override"]
 ## Enables custom network configuration.
 network-config-override = ["ariel-os-embassy/network-config-override"]
 ## Enables custom USB configuration.


### PR DESCRIPTION
# Description

This PR removes the `ble-config-override` feature that was set up but not tested, turns out `bt_hci::param::BdAddr` cannot be constructed with const. 
We also decided during chats that we have other plans concerning the configuration of the BLE address. 

## Testing

Tested with

```
laze -C examples/ble-advertiser/ build -b rpi-pico-w run
```

and 

```
laze -C examples/ble-advertiser/ build -b nrf52840dk run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
