### PR TITLE
feat(ble): randomize address at boot

### DIFF
--- a/book/src/bluetooth.md
+++ b/book/src/bluetooth.md
@@ -17,7 +17,13 @@ If you want to learn more about BLE concepts, you can read the [TrouBLE document
 The ability to configure which Bluetooth address is used and other capacity parameters like the MTU is planned in future updates.
 
 > [!IMPORTANT]
-> For compatibility reasons the MTU is fixed at 27 bytes and the address is fixed as a static random address of `FF:E4:05:1A:8F:FF`.
+> For compatibility reasons the MTU is fixed at 27 bytes.
+>
+> The device address is randomly generated at boot and may be periodically rotated.
+>
+> Current implementation: the address is a static device address and is not rotated during execution.
+> This allows to use the BLE feature of Ariel OS on multiple devices in the same location.
+> We later plan to switch to private device addresses by default, which *are* rotated during execution.
 
 ## Using the BLE Stack
 

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -130,9 +130,11 @@ eth-stm32 = ["ariel-os-hal/eth-stm32", "net", "eth"]
 ble = [
   "dep:trouble-host",
   "ariel-os-embassy-common/ble",
-  # Some HALs need hwrng to initialize the BLE stack.
-  "hwrng",
   "ariel-os-hal/ble",
+  # Random is needed for BLE initialization and Address generation
+  "ariel-os-random/csprng",
+  "hwrng",
+  "random",
 ]
 ble-cyw43 = ["ble", "ariel-os-hal/ble-cyw43"]
 ble-peripheral = ["ble", "ariel-os-hal/ble-peripheral"]

--- a/src/ariel-os-embassy/src/ble.rs
+++ b/src/ariel-os-embassy/src/ble.rs
@@ -1,3 +1,9 @@
+use trouble_host::{
+    Address,
+    prelude::{AddrKind, BdAddr},
+};
+
+use ariel_os_debug::log::debug;
 use ariel_os_embassy_common::ble::Config;
 
 // Must be async and return &trouble_host::Stack<'static, impl Controller>
@@ -5,5 +11,25 @@ pub use crate::hal::ble::ble_stack;
 
 #[allow(dead_code, reason = "false positive during builds outside of laze")]
 pub(crate) fn config() -> Config {
-    Config::default()
+    // Scanning apps show that the last byte of the array appears fist.
+    let mut raw_address = get_random_addr();
+
+    // Set the two most significant bits to 1 to indicate a static random address https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/low-energy-controller/link-layer-specification.html#UUID-7edea27a-a47f-8436-4bd7-aedc1945c366_figure-idm4497995733171233616486354268
+    raw_address[5] |= 0b1100_0000;
+
+    let address = Address {
+        addr: BdAddr::new(raw_address),
+        kind: AddrKind::RANDOM,
+    };
+
+    debug!("Setting random address: {:?}", address);
+
+    Config { address }
+}
+
+/// Generates a random address.
+fn get_random_addr() -> [u8; 6] {
+    let mut addr = [0u8; 6];
+    rand_core::RngCore::fill_bytes(&mut ariel_os_random::crypto_rng(), &mut addr);
+    addr
 }


### PR DESCRIPTION
# Description

This change randomizes the BLE address at boot, allowing the use of multiple Ariel OS BLE devices in the same location.

## Testing

Tested by running `examples/ble-advertiser` on `nrf52840dk` and `rpi-pico-w`

## Issues/PRs References

- Closes #560
- Depends on #1542 

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
