### PR TITLE
ci(build): skip the workflow based on a partial tree hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,10 @@ jobs:
             git rev-parse HEAD^{tree} > .git-tree-hash
             echo "git_hash=$(cat .git-tree-hash)" >> $GITHUB_OUTPUT
 
+            echo '${{ hashFiles('**', '!.git', '!book', '!supply-chain') }}' > .partial-tree-hash
+            echo "partial_hash=$(cat .partial-tree-hash)" # For debugging
+            echo "partial_hash=$(cat .partial-tree-hash)" >> $GITHUB_OUTPUT
+
       # Merely checks *whether* the workflow with the same hash has run
       # successfully in the past, restores nothing more than the file containing
       # the hash value.
@@ -137,10 +141,19 @@ jobs:
           path: .git-tree-hash
           key: success-${{ steps.get-tree-hashes.outputs.git_hash }}-${{ matrix.partition }}-${{ github.event_name == 'schedule' && 'full' || needs.check-labels.outputs.label }}
 
+      # Merely checks *whether* the workflow with the same hash has run
+      # successfully in the past, restores nothing more than the file containing
+      # the hash value.
+      - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
+        id: partial-result-cache
+        with:
+          path: .partial-tree-hash
+          key: success-${{ steps.get-tree-hashes.outputs.partial_hash }}-${{ matrix.partition }}-${{ github.event_name == 'schedule' && 'full' || needs.check-labels.outputs.label }}
+
       - name: Whether to skip next steps
         id: should-skip
         run: |
-          result="result=${{ steps.result-cache.outputs.cache-hit == 'true' }}"
+          result="result=${{ steps.partial-result-cache.outputs.cache-hit == 'true'  || steps.git-result-cache.outputs.cache-hit == 'true' }}"
           echo "${result}"
           echo "${result}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This introduces a second check that carefully excludes a couple of directories when checking for whether the Build workflow can be skipped because it already ran successfully before. The goal is to increase cache hits when only modifying paths that are *very clearly* unrelated to what the Build workflow builds.

## How to review this PR

This PR is better reviewed commit by commit.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Tested by modifying `supply-chain/config.toml` by adding a few blank lines and checking that the Build workflow was indeed skipped, while carefully looking at the docs: the first cache fails to restore (as expected, as the git tree hash is different), but the second one does hit as `supply-chain` is excluded from the partial hash calculation.

It also seems that sometimes the second check (and likely the first one as well) results in a cache miss because of the [limited size of GitHub's cache](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#usage-limits-and-eviction-policy). Depending on the number of jobs that has run between the two CI runs the caches may have been evicted.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
