### PR TITLE
refactor: make generic timer queue size configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "embassy-stm32",
  "embassy-sync 0.6.2",
  "embassy-time",
+ "embassy-time-queue-utils",
  "embassy-usb",
  "embedded-hal 1.0.0",
  "embedded-hal-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ embassy-rp = { version = "0.4", default-features = false }
 embassy-stm32 = { version = "0.2", default-features = false }
 embassy-sync = { version = "0.6.1", default-features = false }
 embassy-time = { version = "0.4.0", default-features = false }
+embassy-time-queue-utils = { version = "0.1.0", default-features = false }
 embassy-usb = { version = "0.4.0", default-features = false }
 
 embedded-hal = { version = "1.0.0", default-features = false }

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -941,6 +941,8 @@ modules:
       global:
         isr_stacksize_required_default: "512"
         executor_stacksize_required_default: "512"
+        FEATURES:
+          - ariel-os/generic-queue-8
 
   - name: ram-small
     help: This module marks MCUs with little RAM (currently, the ones which cannot run HTTP or CoAP)

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -27,6 +27,7 @@ embassy-net = { workspace = true, optional = true, features = [
 ] }
 embassy-sync = { workspace = true }
 embassy-time = { workspace = true, optional = true }
+embassy-time-queue-utils = { workspace = true, optional = true }
 embassy-usb = { workspace = true, optional = true }
 
 embedded-hal = { workspace = true }
@@ -72,7 +73,7 @@ external-interrupts = [
   "ariel-os-embassy-common/external-interrupts",
   "ariel-os-hal/external-interrupts",
 ]
-time = ["dep:embassy-time"]
+time = ["dep:embassy-time", "dep:embassy-time-queue-utils"]
 
 ## Enables I2C support.
 i2c = [
@@ -143,8 +144,22 @@ ble-central = ["ble", "ariel-os-hal/ble-central"]
 threading = [
   "dep:ariel-os-threads",
   "ariel-os-hal/threading",
-  "embassy-time?/generic-queue-128",
+  # this sets the default timer queue size, which is currently 64. See `generic-queue-*` features.
+  "embassy-time-queue-utils?/_generic-queue",
 ]
+
+# See ariel-os/Cargo.toml for more details
+## Generic Queue with 8 timers
+timer-generic-queue-8 = ["embassy-time?/generic-queue-8"]
+## Generic Queue with 16 timers
+timer-generic-queue-16 = ["embassy-time?/generic-queue-16"]
+## Generic Queue with 32 timers
+timer-generic-queue-32 = ["embassy-time?/generic-queue-32"]
+## Generic Queue with 64 timers
+timer-generic-queue-64 = ["embassy-time?/generic-queue-64"]
+## Generic Queue with 128 timers
+timer-generic-queue-128 = ["embassy-time?/generic-queue-128"]
+
 network-config-ipv4-static = ["network-config-override"]
 network-config-override = []
 override-usb-config = []

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -160,6 +160,21 @@ ble-peripheral = ["ble", "ariel-os-embassy/ble-peripheral"]
 # Enables BLE to act as a central. Can be used in conjunction with `ble-peripheral`.
 ble-central = ["ble", "ariel-os-embassy/ble-central"]
 
+#! ## Timer queue size configuration
+#! Should only be enabled when threading is enabled, too.
+#! Default is 64 entries for regular boards and 8 entries for those with little ram.
+#! When more than this number of concurrent timers are used, the system will loop (and not sleep/idle anymore).
+## Enables support for up to 8 concurrent timers. (default on `ram-tiny` boards)
+timer-generic-queue-8 = ["ariel-os-embassy/timer-generic-queue-8"]
+## Enables support for up to 16 concurrent timers.
+timer-generic-queue-16 = ["ariel-os-embassy/timer-generic-queue-16"]
+## Enables support for up to 32 concurrent timers.
+timer-generic-queue-32 = ["ariel-os-embassy/timer-generic-queue-32"]
+## Enables support for up to 64 concurrent timers. (default)
+timer-generic-queue-64 = ["ariel-os-embassy/timer-generic-queue-64"]
+## Enables support for up to 128 concurrent timers.
+timer-generic-queue-128 = ["ariel-os-embassy/timer-generic-queue-128"]
+
 #! ## Development and debugging
 # Enables the debug console, required to use
 # [`println!`](ariel_os_debug::println).


### PR DESCRIPTION
# Description

#1552 enabled the embassy generic timer queue with size 128 for all targets, which is too much for the smaller boards.

This PR:

- passes the generic-timer-queue-N features from ariel-os through ariel-os-embassy to the embassy crates
- uses just `_generic-timer-queue` to get the default
- thus, lowers the default to 64 entries
- sets `generic-timer-queue-8` for `ram-tiny` boards

This lacks a way to override the default for `ram-tiny` targets, but that can be tackled later.

<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
Using `embassy-time` types (e.g., `Timer`) within threads is now supported. A generic timer queue is used, whose size can be configured using the `generic-timer-queue-*` Cargo features.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
