### PR TITLE
feat(threads): introduce `Semaphore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,6 +5515,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "threading-semaphore"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -31,6 +31,7 @@ subdirs:
   - threading-channel
   - threading-event
   - threading-multicore
+  - threading-semaphore
   - threading-timers
   - udp-echo
   - usb-keyboard

--- a/examples/threading-semaphore/Cargo.toml
+++ b/examples/threading-semaphore/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "threading-semaphore"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os" }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+
+[lints]
+workspace = true

--- a/examples/threading-semaphore/README.md
+++ b/examples/threading-semaphore/README.md
@@ -1,0 +1,43 @@
+# Threading Semaphores
+
+## About
+
+This application demonstrates the usage of a
+[`Semaphore`](https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/thread/sync/struct.Semaphore.html)
+as synchronization method for threads.
+
+The example starts three threads (0 through 2).
+A static `Semaphore` is created as synchronization mechanism for the threads.
+All threads wait for the semaphore to become available,
+printing output before and after taking it.
+Only thread 2 is different in that
+it gives the semaphore three times before waiting on that same semaphore.
+All threads must thus wait for thread 2 to release the semaphore
+before they can continue.
+
+## How to run
+
+In this directory, run
+
+    laze build -b nrf52840dk run
+
+The application will start three threads with different priorities.
+All but one threads block on a global `Semaphore` until the one thread sets it.
+
+## Example output
+
+When run, this example shows the following output:
+
+    [INFO ] [ThreadId(0)@RunqueueId(3)] Taking semaphore...
+    [INFO ] [ThreadId(1)@RunqueueId(2)] Taking semaphore...
+    [INFO ] [ThreadId(2)@RunqueueId(1)] Giving semaphore...
+    [INFO ] [ThreadId(0)@RunqueueId(3)] Done.
+    [INFO ] [ThreadId(2)@RunqueueId(1)] Give semaphore returned.
+    [INFO ] [ThreadId(2)@RunqueueId(1)] Giving semaphore...
+    [INFO ] [ThreadId(1)@RunqueueId(2)] Done.
+    [INFO ] [ThreadId(2)@RunqueueId(1)] Give semaphore returned.
+    [INFO ] [ThreadId(2)@RunqueueId(1)] Giving semaphore...
+    [INFO ] [ThreadId(2)@RunqueueId(1)] Give semaphore returned.
+    [INFO ] [ThreadId(2)@RunqueueId(1)] Taking semaphore...
+    [INFO ] [ThreadId(2)@RunqueueId(1)] Done.
+    [INFO ] [ThreadId(2)@RunqueueId(1)] All three threads should have reported "Done.". exiting.

--- a/examples/threading-semaphore/laze.yml
+++ b/examples/threading-semaphore/laze.yml
@@ -1,0 +1,10 @@
+apps:
+  - name: threading-semaphore
+    selects:
+      - sw/threading
+      - "context::stm32c031c6":
+          - too-little-memory
+    conflicts:
+      # This example uses three threads with the default stack size of 2KiB,
+      # which is too much for the smallest MCUs.
+      - ram-tiny

--- a/examples/threading-semaphore/src/main.rs
+++ b/examples/threading-semaphore/src/main.rs
@@ -1,0 +1,49 @@
+#![no_main]
+#![no_std]
+
+use ariel_os::debug::{ExitCode, log::*};
+use ariel_os::thread::{ThreadId, sync::Semaphore};
+
+static SEMAPHORE: Semaphore = Semaphore::new(0, 10);
+
+fn waiter() {
+    let my_id = ariel_os::thread::current_tid().unwrap();
+    let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
+
+    info!("[{:?}@{:?}] Taking semaphore...", my_id, my_prio);
+
+    SEMAPHORE.take();
+
+    info!("[{:?}@{:?}] Done.", my_id, my_prio);
+}
+
+#[ariel_os::thread(autostart, priority = 3)]
+fn thread0() {
+    waiter();
+}
+
+#[ariel_os::thread(autostart, priority = 2)]
+fn thread1() {
+    waiter();
+}
+
+#[ariel_os::thread(autostart, priority = 1)]
+fn thread2() {
+    let my_id = ariel_os::thread::current_tid().unwrap();
+    let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
+
+    for i in 0..3 {
+        info!("[{:?}@{:?}] Giving semaphore...", my_id, my_prio);
+        SEMAPHORE.give();
+        info!("[{:?}@{:?}] Give semaphore returned.", my_id, my_prio);
+    }
+    waiter();
+
+    if SEMAPHORE.current_count() == 0 {
+        info!(
+            "[{:?}@{:?}] All three threads should have reported \"Done.\". exiting.",
+            my_id, my_prio
+        );
+        ariel_os::debug::exit(ExitCode::SUCCESS);
+    }
+}

--- a/src/ariel-os-threads/src/sync/mod.rs
+++ b/src/ariel-os-threads/src/sync/mod.rs
@@ -3,8 +3,10 @@ mod channel;
 mod event;
 mod lock;
 mod mutex;
+mod semaphore;
 
 pub use channel::Channel;
 pub use event::Event;
 pub use lock::Lock;
 pub use mutex::{Mutex, MutexGuard};
+pub use semaphore::Semaphore;

--- a/src/ariel-os-threads/src/sync/semaphore.rs
+++ b/src/ariel-os-threads/src/sync/semaphore.rs
@@ -1,0 +1,105 @@
+//! This module provides a Semaphore implementation.
+
+use core::cell::UnsafeCell;
+
+use crate::{ThreadState, threadlist::ThreadList};
+
+struct SemaphoreInner {
+    current: usize,
+    max: usize,
+    wait_list: ThreadList,
+}
+
+impl SemaphoreInner {
+    /// Creates new Semaphore.
+    #[must_use]
+    const fn new(initial: usize, max: usize) -> Self {
+        Self {
+            current: initial,
+            max,
+            wait_list: ThreadList::new(),
+        }
+    }
+
+    fn current_count(&self) -> usize {
+        self.current
+    }
+
+    fn try_give(&mut self) -> bool {
+        if self.current < self.max {
+            self.current += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn try_take(&mut self) -> bool {
+        if self.current > 0 {
+            self.current -= 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// A counting semaphore.
+pub struct Semaphore {
+    inner: UnsafeCell<SemaphoreInner>,
+}
+
+unsafe impl Sync for Semaphore {}
+unsafe impl Send for Semaphore {}
+
+impl Semaphore {
+    /// Creates new Semaphore.
+    #[must_use]
+    pub const fn new(initial: usize, max: usize) -> Self {
+        Self {
+            inner: UnsafeCell::new(SemaphoreInner::new(initial, max)),
+        }
+    }
+
+    /// Return the currently available resources.
+    pub fn current_count(&self) -> usize {
+        critical_section::with(|_| {
+            let inner = unsafe { &*self.inner.get() };
+            inner.current_count()
+        })
+    }
+
+    /// Unlock the semaphore.
+    pub fn give(&self) -> bool {
+        critical_section::with(|cs| {
+            let inner = unsafe { &mut *self.inner.get() };
+            // If there is a waiter, wake it up, no need to fiddle with the count.
+            // Otherwise, `try_give()` to check if we'd go over the maximum.
+            inner.wait_list.pop(cs).is_some() || inner.try_give()
+        })
+    }
+
+    /// Try getting the semaphore (non-blocking).
+    pub fn try_take(&self) -> bool {
+        critical_section::with(|_| {
+            let inner = unsafe { &mut *self.inner.get() };
+            inner.try_take()
+        })
+    }
+
+    /// Get the semaphore (blocking).
+    ///
+    /// # Panics
+    ///
+    /// Panics when called from an interrupt context.
+    pub fn take(&self) {
+        critical_section::with(|cs| {
+            let inner = unsafe { &mut *self.inner.get() };
+            if !inner.try_take() {
+                inner
+                    .wait_list
+                    .put_current(cs, ThreadState::SemaphoreBlocked);
+            }
+        });
+    }
+}

--- a/src/ariel-os-threads/src/thread.rs
+++ b/src/ariel-os-threads/src/thread.rs
@@ -54,6 +54,8 @@ pub enum ThreadState {
     ChannelRxBlocked(usize),
     /// Waiting to send on a [`crate::sync::Channel`], i.e. waiting for the receiver.
     ChannelTxBlocked(usize),
+    // Waiting on a [`crate::sync::Semaphore`].
+    SemaphoreBlocked,
 }
 
 impl Thread {


### PR DESCRIPTION
# Description

This PR introduces a counting semaphore primitive.
Needed at least for bumping esp_radio.

<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Needed for #1328.

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

This does not yet provide `MutexGuard` like RAII API, as esp_rtos needs it this "raw".
Also, not mitigating priority inversion, yet.

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
