### PR TITLE
refactor(esp32): mark that MCU as disabled until we fix linking

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -390,6 +390,7 @@ contexts:
     parent: esp
     selects:
       - xtensa
+      - currently-broken # `isr_stack` is not placed at the right location
     env:
       RUSTC_TARGET: xtensa-esp32-none-elf
       CARGO_TARGET_PREFIX: CARGO_TARGET_XTENSA_ESP32_NONE_ELF


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Temporarily disables building for thr (plain) ESP32 as linking of `isr_stack` is broken on it.

This is not a breaking change as it is not currently working.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Checked with the following command that nothing gets built:

```sh
laze build --global -s 'context::esp32'
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Unblocks #1454 

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
