### PR TITLE
docs(support): mark USB supported on ESP32-S3

### DIFF
--- a/book/src/boards/espressif-esp32-s3-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-s3-devkitc-1.md
@@ -21,7 +21,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
-|User USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^usb-does-not-enumerate][^see-also-https-github-com-ariel-os-ariel-os-issues-903]|
+|User USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
@@ -52,6 +52,4 @@ dt, dd {
 }
 </style>
 
-[^usb-does-not-enumerate]: USB does not enumerate.
-[^see-also-https-github-com-ariel-os-ariel-os-issues-903]: See also: https://github.com/ariel-os/ariel-os/issues/903.
 [^requires-partitioning-support]: Requires partitioning support.

--- a/book/src/boards/heltec-wifi-lora-32-v3.md
+++ b/book/src/boards/heltec-wifi-lora-32-v3.md
@@ -21,7 +21,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
-|User USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^usb-does-not-enumerate][^see-also-https-github-com-ariel-os-ariel-os-issues-903]|
+|User USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
@@ -52,6 +52,4 @@ dt, dd {
 }
 </style>
 
-[^usb-does-not-enumerate]: USB does not enumerate.
-[^see-also-https-github-com-ariel-os-ariel-os-issues-903]: See also: https://github.com/ariel-os/ariel-os/issues/903.
 [^requires-partitioning-support]: Requires partitioning support.

--- a/book/src/chips/esp32s3.md
+++ b/book/src/chips/esp32s3.md
@@ -14,7 +14,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
-|User USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^usb-does-not-enumerate][^see-also-https-github-com-ariel-os-ariel-os-issues-903]|
+|User USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
@@ -45,6 +45,4 @@ dt, dd {
 }
 </style>
 
-[^usb-does-not-enumerate]: USB does not enumerate.
-[^see-also-https-github-com-ariel-os-ariel-os-issues-903]: See also: https://github.com/ariel-os/ariel-os/issues/903.
 [^requires-partitioning-support]: Requires partitioning support.

--- a/book/src/chips/esp32s3fx8.md
+++ b/book/src/chips/esp32s3fx8.md
@@ -14,7 +14,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
-|User USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^usb-does-not-enumerate][^see-also-https-github-com-ariel-os-ariel-os-issues-903]|
+|User USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
@@ -45,6 +45,4 @@ dt, dd {
 }
 </style>
 
-[^usb-does-not-enumerate]: USB does not enumerate.
-[^see-also-https-github-com-ariel-os-ariel-os-issues-903]: See also: https://github.com/ariel-os/ariel-os/issues/903.
 [^requires-partitioning-support]: Requires partitioning support.

--- a/book/src/support_matrix_tier1.html
+++ b/book/src/support_matrix_tier1.html
@@ -87,7 +87,7 @@
       <td class="support-cell" title="needs testing">🚦</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       <td class="support-cell" title="supported">✅</td>

--- a/book/src/support_matrix_tier3.html
+++ b/book/src/support_matrix_tier3.html
@@ -87,7 +87,7 @@
       <td class="support-cell" title="needs testing">🚦</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       <td class="support-cell" title="supported">✅</td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -409,11 +409,7 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      user_usb:
-        status: not_currently_supported
-        comments:
-          - USB does not enumerate
-          - "See also: https://github.com/ariel-os/ariel-os/issues/903"
+      user_usb: supported
       ethernet_over_usb: not_currently_supported
       wifi: supported
 
@@ -433,11 +429,7 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      user_usb:
-        status: not_currently_supported
-        comments:
-          - USB does not enumerate
-          - "See also: https://github.com/ariel-os/ariel-os/issues/903"
+      user_usb: supported
       ethernet_over_usb: not_currently_supported
       wifi: supported
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Following recent testing in #903, the `usb-serial` example indeed works as expected. This therefore updates the support info to reflect this.

Ethernet over USB is still unsupported on that chip however.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
I was able to test the `usb-serial` example successfully on an ESP32-S3-based board. That board only has one USB port, that is connected to `USB_D-`/`USB_D+`, and I get a "broken pipe" error from espflash after flashing, as the firmware is seemingly taking over the serial port; that is however unrelated and the firmware echoes bytes sent on the serial port as expected.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
(ESP32-S3) USB is now supported on this MCU.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
