### PR TITLE
refactor(threads)!: move `blocker` into ariel-os-threads

### DIFF
--- a/examples/thread-async-interop/README.md
+++ b/examples/thread-async-interop/README.md
@@ -44,4 +44,4 @@ In this directory, run
     INFO  main(): all good, exiting.
 
 [`signal`]: https://ariel-os.github.io/ariel-os/dev/docs/api/embassy_sync/signal/struct.Signal.html
-[`block_on`]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/blocker/fn.block_on.html
+[`block_on`]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/thread/fn.block_on.html

--- a/examples/thread-async-interop/src/main.rs
+++ b/examples/thread-async-interop/src/main.rs
@@ -4,8 +4,9 @@
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 
 use ariel_os::{
-    asynch::{blocker, spawner},
+    asynch::spawner,
     debug::{ExitCode, exit, log::*},
+    thread::block_on,
     time::{Instant, Timer},
 };
 
@@ -36,7 +37,7 @@ fn main() {
     for _ in 0..10 {
         // With `block_on()`, async functions can be called from a thread.
         // This way, async primitives like `Signal` can be used.
-        let counter = blocker::block_on(SIGNAL.wait());
+        let counter = block_on(SIGNAL.wait());
 
         // Get time since boot
         let now = Instant::now().as_millis();

--- a/examples/threading-timers/src/main.rs
+++ b/examples/threading-timers/src/main.rs
@@ -2,8 +2,8 @@
 #![no_std]
 
 use ariel_os::{
-    asynch::blocker::block_on,
     debug::{ExitCode, exit, log::info},
+    thread::block_on,
     time::Timer,
 };
 

--- a/src/ariel-os-embassy/src/asynch.rs
+++ b/src/ariel-os-embassy/src/asynch.rs
@@ -9,9 +9,6 @@ use core::cell::OnceCell;
 
 use embassy_sync::blocking_mutex::CriticalSectionMutex;
 
-#[cfg(feature = "threading")]
-pub mod blocker;
-
 pub use embassy_executor::{SendSpawner, Spawner};
 pub use embassy_futures::yield_now;
 

--- a/src/ariel-os-threads/src/blocker.rs
+++ b/src/ariel-os-threads/src/blocker.rs
@@ -2,9 +2,10 @@
 
 #![expect(unsafe_code)]
 
-use ariel_os_threads::{ThreadId, current_tid, flags, flags::ThreadFlags};
 use core::pin::Pin;
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+use crate::{ThreadId, current_tid, flags, flags::ThreadFlags};
 
 const THREAD_FLAG_WAKER: ThreadFlags = 1; // TODO: find more appropriate value
 

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -36,6 +36,7 @@
 
 mod arch;
 mod autostart_thread;
+mod blocker;
 mod ensure_once;
 mod thread;
 mod threadlist;
@@ -62,6 +63,7 @@ pub mod events {
 }
 
 pub use ariel_os_runqueue::{RunqueueId, ThreadId};
+pub use blocker::block_on;
 pub use thread_flags as flags;
 
 #[cfg(feature = "core-affinity")]


### PR DESCRIPTION
# Description

This moves the `block_on()` implementation into `ariel-os-threads`, making it available to more internal crates (e.g., hals).

Within `ariel_os`, it is now in `ariel_os::thread::block_on()` (moved from `ariel_os::asynch::blocker::block_on`), making this a breaking change.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
The `ariel_os::asynch::blocker::block_on()` function has been moved into `ariel_os::thread` and is now `ariel_os::thread::block_on()`.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
