### PR TITLE
fix(cargo): update the `include` value as the unstable schema changed

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
-include = "../ariel-os-cargo.toml"
+include = ["../ariel-os-cargo.toml"]
 
 [unstable]
 # This is needed for cbindgen to work in no_std cross compiles.


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This updates the value of the [unstable Cargo configuration `include` key](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#config-include) as the schema changed on nightly.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
The value of Cargo's `include` unstable configuration key has been updated to not use the now-unsupported string-only value. Existing applications need to update the value in their `.cargo/config.toml` configuration file to use the array or table types instead.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
