### PR TITLE
fix(stack-painting): inline reporting methods to not bias the result

### DIFF
--- a/src/ariel-os-rt/src/stack.rs
+++ b/src/ariel-os-rt/src/stack.rs
@@ -1,6 +1,10 @@
 //! Stack usage helpers.
 
 #![expect(unsafe_code)]
+#![expect(
+    clippy::inline_always,
+    reason = "otherwise usage reporting functions influence the result"
+)]
 
 use core::{marker::PhantomData, ptr::write_volatile};
 
@@ -94,18 +98,21 @@ impl Stack {
 
     /// Returns the total size of the current stack.
     #[must_use]
+    #[inline(always)]
     pub fn size(&self) -> usize {
         self.highest - self.lowest
     }
 
     /// Returns the amount of currently free stack space.
     #[must_use]
+    #[inline(always)]
     pub fn free(&self) -> usize {
         self.size() - self.used()
     }
 
     /// Returns the amount of currently used stack space.
     #[must_use]
+    #[inline(always)]
     pub fn used(&self) -> usize {
         self.highest - sp()
     }
@@ -135,6 +142,7 @@ impl Stack {
     ///
     /// This re-calculates and thus runs in `O(n)`!
     #[must_use]
+    #[inline(always)]
     pub fn used_max(&self) -> usize {
         self.size() - self.free_min()
     }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This makes a best effort attempt at inlining the `Stack` `pub` methods that report on stack usage, as their execution otherwise influence the results.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
The change of behavior is observable using the test from #1577.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
