### PR TITLE
ci(clippy): disable the unneeded verbose mode to clean up the logs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,6 @@ jobs:
         uses: clechasseur/rs-clippy-check@286fd9545eb133adad54b4af34bcb642e266ddd1 # v5
         with:
           args: |
-            --verbose
             --locked
             --features "
                 ble,
@@ -167,7 +166,6 @@ jobs:
         uses: clechasseur/rs-clippy-check@286fd9545eb133adad54b4af34bcb642e266ddd1 # v5
         with:
           args: |
-            --verbose
             --locked
             --target=riscv32imac-unknown-none-elf
             --features "
@@ -187,7 +185,6 @@ jobs:
         uses: clechasseur/rs-clippy-check@286fd9545eb133adad54b4af34bcb642e266ddd1 # v5
         with:
           args: |
-            --verbose
             --locked
             --features "
                 ble,
@@ -207,7 +204,6 @@ jobs:
         uses: clechasseur/rs-clippy-check@286fd9545eb133adad54b4af34bcb642e266ddd1 # v5
         with:
           args: |
-            --verbose
             --locked
             --features "
                 ble-central,
@@ -227,7 +223,6 @@ jobs:
         uses: clechasseur/rs-clippy-check@286fd9545eb133adad54b4af34bcb642e266ddd1 # v5
         with:
           args: |
-            --verbose
             --locked
             --features "
                 embassy-nrf/nrf9160-s,
@@ -247,7 +242,6 @@ jobs:
         uses: clechasseur/rs-clippy-check@286fd9545eb133adad54b4af34bcb642e266ddd1 # v5
         with:
           args: |
-            --verbose
             --locked
             --features "
                 embassy-stm32/stm32wb55rg,


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
I had enabled Clippy's `--verbose` mode when originally integrating Clippy in CI in https://github.com/ariel-os/ariel-os/pull/103, hoping that it would help diagnose issues if needed; however this has never been useful and just makes the CI logs way too noisy.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
