### PR TITLE
feat(sensors): add custom reading signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,10 +530,13 @@ name = "ariel-os-sensors"
 version = "0.1.0"
 dependencies = [
  "ariel-os-macros",
+ "critical-section",
  "defmt 1.0.1",
+ "embassy-futures",
  "embassy-sync 0.6.2",
  "linkme",
  "pin-project",
+ "static_cell",
 ]
 
 [[package]]

--- a/src/ariel-os-sensors/Cargo.toml
+++ b/src/ariel-os-sensors/Cargo.toml
@@ -16,6 +16,11 @@ embassy-sync = { workspace = true }
 linkme = { workspace = true }
 pin-project = { workspace = true }
 
+[dev-dependencies]
+critical-section = { workspace = true, features = ["std"] }
+embassy-futures = { workspace = true }
+static_cell = { workspace = true }
+
 [features]
 defmt = ["dep:defmt"]
 

--- a/src/ariel-os-sensors/src/lib.rs
+++ b/src/ariel-os-sensors/src/lib.rs
@@ -66,6 +66,7 @@ mod measurement_unit;
 pub mod registry;
 mod sample;
 pub mod sensor;
+pub mod signal;
 
 pub use category::Category;
 pub use label::Label;

--- a/src/ariel-os-sensors/src/signal.rs
+++ b/src/ariel-os-sensors/src/signal.rs
@@ -1,0 +1,183 @@
+//! This module contains a custom [`Signal`] struct meant to be used in the [`ariel-os-sensors`][ariel-os-sensors] ecosystem
+
+use core::{
+    cell::Cell,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+};
+
+use embassy_sync::blocking_mutex::{Mutex, raw::CriticalSectionRawMutex};
+
+#[derive(Debug, Default)]
+enum SignalState<T> {
+    #[default]
+    None,
+    Waiting(Waker),
+    Ready(T),
+}
+
+/// Custom signal struct inspired by [`embassy_sync::signal::Signal`] and [`embassy_sync::channel::Channel`]
+///
+/// This is meant for single-producer and single-consumer signaling.
+///
+/// This struct has been created for the [`ariel-os-sensors`][ariel-os-sensors] ecosystem.
+///
+/// [ariel-os-sensors]: crate
+// This struct exists for multiple reasons:
+// - Get a lightweight [`Future`] that can be easily stored in a struct like [`ReadingWaiter`][crate::sensor::ReadingWaiter]
+// - Keep a stable API that doesn't change with [`embassy_sync`] versions
+pub struct Signal<T> {
+    inner: Mutex<CriticalSectionRawMutex, Cell<SignalState<T>>>,
+}
+
+impl<T> Default for Signal<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Signal<T> {
+    /// Create a new empty [`Signal`]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            inner: Mutex::new(Cell::new(SignalState::<T>::None)),
+        }
+    }
+
+    /// Signal that a new value is available and will replace the previous value if it wasn't read.
+    pub fn signal(&self, new: T) {
+        self.inner.lock(|cell| {
+            let state = cell.take();
+            match state {
+                SignalState::None => {
+                    cell.set(SignalState::Ready(new));
+                }
+                SignalState::Ready(_prev) => {
+                    cell.set(SignalState::Ready(new));
+                }
+                SignalState::Waiting(read_waker) => {
+                    cell.set(SignalState::Ready(new));
+                    read_waker.wake();
+                }
+            }
+        });
+    }
+
+    /// Returns a future that will return once a value is available.
+    ///
+    /// This is not meant to have multiple tasks waiting for a signal. If multiple tasks are waiting
+    /// then a signal sent with [`Self::signal`] will reach only one task at random.
+    pub fn wait(&'static self) -> ReceiveFuture<'static, T> {
+        ReceiveFuture { signaling: self }
+    }
+
+    fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<T> {
+        self.inner.lock(|cell| {
+            let state = cell.take();
+            match state {
+                SignalState::None => {
+                    cell.set(SignalState::Waiting(cx.waker().clone()));
+                    Poll::Pending
+                }
+
+                // Multiple tasks waiting for a reading, this shouldn't happen
+                SignalState::Waiting(prev_waker) => {
+                    if prev_waker.will_wake(cx.waker()) {
+                        cell.set(SignalState::Waiting(prev_waker));
+                    } else {
+                        cell.set(SignalState::Waiting(cx.waker().clone()));
+
+                        // We can't store multiple wakers, they will fight eachother until some data
+                        // is sent.
+                        // This should happen only if multiple tasks are waiting for a measurement.
+                        prev_waker.wake();
+                    }
+                    Poll::Pending
+                }
+                SignalState::Ready(res) => Poll::Ready(res),
+            }
+        })
+    }
+}
+
+/// A future that will resolve once a signal is sent.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct ReceiveFuture<'ch, T> {
+    signaling: &'ch Signal<T>,
+}
+
+impl<T> Future for ReceiveFuture<'_, T> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        self.signaling.poll_wait(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use static_cell::StaticCell;
+
+    #[test]
+    fn future_returns() {
+        static SIGNAL: StaticCell<Signal<u8>> = StaticCell::new();
+        let signal = SIGNAL.init(Signal::new());
+        let future = signal.wait();
+
+        let wanted = 42u8;
+
+        embassy_futures::block_on(async {
+            embassy_futures::join::join(
+                async {
+                    signal.signal(wanted);
+                },
+                async {
+                    assert_eq!(future.await, wanted);
+                },
+            )
+            .await;
+        });
+    }
+
+    #[test]
+    fn manual_poll() {
+        static SIGNAL: StaticCell<Signal<u8>> = StaticCell::new();
+        let signal = &*SIGNAL.init(Signal::new());
+
+        let mut receive_future = signal.wait();
+        let wanted = 31;
+
+        // arbitrary amount of polling, should always return Poll::Pending
+        assert_eq!(
+            embassy_futures::poll_once(&mut receive_future),
+            Poll::Pending
+        );
+        assert_eq!(
+            embassy_futures::poll_once(&mut receive_future),
+            Poll::Pending
+        );
+
+        signal.signal(wanted);
+
+        assert_eq!(
+            embassy_futures::poll_once(receive_future),
+            Poll::Ready(wanted)
+        );
+    }
+
+    #[test]
+    fn override_value() {
+        static SIGNAL: StaticCell<Signal<u8>> = StaticCell::new();
+        let signal = &*SIGNAL.init(Signal::new());
+        let future = signal.wait();
+        let wanted = 42u8;
+
+        signal.signal(2);
+        signal.signal(wanted);
+
+        assert_eq!(embassy_futures::block_on(future), wanted);
+    }
+}


### PR DESCRIPTION
# Description

This is a custom Signal type to provide better API stability.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

Currently if `receive_reading` is called multiple times without `send_reading` being called in between, multiple `Futures` will be handed out but only one will per `send_reading` call. This could lead to code waiting forever for a signal, should an error be returned by `receive_reading` when a `Future` has already been handed out and not resolved ?

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
