### PR TITLE
chore: update stable Rust to 1.90

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Install stable toolchain
         if: steps.should-skip.outputs.result != 'true'
         # configure MSRV here:
-        uses: dtolnay/rust-toolchain@1.85
+        uses: dtolnay/rust-toolchain@1.90
         with:
           targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,thumbv6m-none-eabi,thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf,thumbv8m.main-none-eabi,thumbv8m.main-none-eabihf
           # rust-src: Used for -Zbuild-std.
@@ -209,7 +209,7 @@ jobs:
         # No tag yet after https://github.com/esp-rs/xtensa-toolchain/pull/38 (will probably be @v1.5.5)
         uses: esp-rs/xtensa-toolchain@main
         with:
-          version: "1.85.0.0"
+          version: "1.90.0.0"
           buildtargets: esp32,esp32s2,esp32s3
           override: false
           export: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 # This should be the Ariel OS MSRV.
 # Some crates may have a different MSRV.
-rust-version = "1.85"
+rust-version = "1.90"
 repository = "https://github.com/ariel-os/ariel-os"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Multiple resources are available to learn Ariel OS:
 
 ## Minimum Supported Rust Version (MSRV) and Policy
 
-Ariel OS compiles with stable Rust version 1.85 and up.
+Ariel OS compiles with stable Rust version 1.90 and up.
 The MSRV can be increased in patch version updates.
 
 ## Security


### PR DESCRIPTION
# Description

Our fixed Rust version is getting old, to the point where dependencies don't even work with that any more if we update them.

## Testing

We're building on nightly all the time, I don't see what can go wrong here.

## Issues/PRs References

Blocks: https://github.com/ariel-os/ariel-os/pull/1592 and thus transitively https://github.com/ariel-os/ariel-os/pull/1590

## Change Checklist

- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
