### PR TITLE
feat(uart): forward BufRead implementation

### DIFF
--- a/src/ariel-os-embassy-common/src/uart.rs
+++ b/src/ariel-os-embassy-common/src/uart.rs
@@ -117,6 +117,21 @@ macro_rules! impl_async_uart_for_driver_enum {
         }
 
 
+        impl embedded_io_async::BufRead for $driver_enum<'_> {
+            async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+                match self {
+                    $( Self::$peripheral(uart) => embedded_io_async::BufRead::fill_buf(&mut uart.uart).await, )*
+                }
+            }
+
+            fn consume(&mut self, amt: usize) {
+                match self {
+                    $( Self::$peripheral(uart) => embedded_io_async::BufRead::consume(&mut uart.uart, amt), )*
+                }
+            }
+        }
+
+
         impl embedded_io_async::ReadReady for $driver_enum<'_> {
             fn read_ready(&mut self) -> Result<bool, Self::Error> {
                 match self {


### PR DESCRIPTION
# Description

The embedded-io-async Read trait is not zero-copy, but our UARTs are buffered. Applications that consume data on the fly (such as upcoming slipmux integration) still need to allocate their receive buffer, even if it's just 1 byte long, and keep reading into that.

The embedded-io-async family offers a better trait, BufRead, that suspends until the producer has collected any number of bytes in its internal buffer (it returns when there is one, but with fast interfaces or under load it can be more), offers the user a view into the buffer, with explicit consumption of the buffer. (In other contexts this might be called peeking into the buffer, just for searchability).

As our UART setup involves buffers in all current implementations (not by a trait, and that's something we should fix, but by the drop-in-replacement-safe `::new()` method of the UART types), it's safe to say that not just the current but also future types have some level of buffering. (And it doesn't matter if it's just 4 byte: Even then, the API is no worse than reading into a local buffer, but it automatically enhances on larger-buffered devices).

## Testing

I've done some testing with nRF on a to-be-created PR around slipmux, but this is best checked by the compiler and code review, because in the end it will exclusively depend on any BufRead implementations of the backing HALs to be correct.

## Change Checklist

- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
  * This would be documented if we had traits for the things we drop-in-replace; I'd like to change that at some point to make things like this actually documented, but either way, it is visible automatically in traits implemented by a type.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
