### PR TITLE
feat(macros): enable using `config!` in internal crates

### DIFF
--- a/src/ariel-os-macros/src/config.rs
+++ b/src/ariel-os-macros/src/config.rs
@@ -39,8 +39,8 @@
 ///
 /// # Panics
 ///
-/// This macro panics when the `ariel-os` crate cannot be found as a dependency of the crate where
-/// this macro is used.
+/// The `ariel-os` crate (or `ariel-os-embassy`, for use in crates which `ariel-os` depends on)
+/// must be a dependency of the crate where this macro is used, otherwise this macro panics.
 #[proc_macro_attribute]
 pub fn config(args: TokenStream, item: TokenStream) -> TokenStream {
     #[allow(clippy::wildcard_imports)]
@@ -55,7 +55,7 @@ pub fn config(args: TokenStream, item: TokenStream) -> TokenStream {
     let config_const = syn::parse_macro_input!(item as syn::ItemConst);
     let config_const_name = &config_const.ident;
 
-    let ariel_os_crate = utils::ariel_os_crate();
+    let ariel_os_crate = utils::ariel_os_crate_or_internal(Some("ariel-os-embassy"));
 
     let (config_fn_name, return_type) = match attrs.kind {
         Some(ConfigKind::Network) => (


### PR DESCRIPTION
# Description

This enables using the `config!` macro in crates that can not include ariel-os due to circular dependencies. If any internal module that makes large changes to the USB config needs to set override-usb-config, it now can.

Sure, on the long run I'd like to use descriptive controls to build up the USB config. But until that is in place, this generalizes the existing mechanism by a simple extension.

## Testing

I tried this in an upcoming PR for updating the USB configuration (yet to be linked back) -- but this should be an "if it builds, it is fine" situation.

## Issues/PRs References

This follows a pattern established in <https://github.com/ariel-os/ariel-os/pull/759>.

## Change Checklist

- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
