### PR TITLE
feat(debug): support using defmt-rtt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "ariel-os-utils",
  "const-str",
  "critical-section",
+ "defmt-rtt",
  "embassy-sync 0.6.2",
  "esp-println",
  "featurecomb",
@@ -1711,6 +1712,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "defmt-rtt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d5a25c99d89c40f5676bec8cefe0614f17f0f40e916f98e345dae941807f9e"
+dependencies = [
+ "critical-section",
+ "defmt 1.0.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ ariel-os-utils = { path = "src/ariel-os-utils", default-features = false }
 const_panic = { version = "0.2.8", default-features = false }
 const-str = "0.7.0"
 defmt = { version = "1.0.0" }
+defmt-rtt = { version = "1.1.0" }
 document-features = "0.2.8"
 fugit = { version = "0.3.7", default-features = false }
 heapless = { version = "0.8.0", default-features = false }

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1096,7 +1096,10 @@ modules:
     help: use probe-rs as runner
     selects:
       - ?debug-console
-      - ?rtt-target
+      - defmt:
+          - defmt-rtt
+      - log:
+          - rtt-target
     provides_unique:
       - embedded-test-runner
 
@@ -1678,6 +1681,15 @@ modules:
       global:
         FEATURES:
           - ariel-os/infini-core
+
+  - name: defmt-rtt
+    help: use defmt-rtt in ariel-os-debug
+    provides_unique:
+      - ariel-os-debug-backend
+    env:
+      global:
+        FEATURES:
+          - ariel-os/defmt-rtt
 
   - name: rtt-target
     help: use rtt-target in ariel-os-debug

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -22,6 +22,7 @@ ariel-os-debug-log = { workspace = true }
 ariel-os-utils = { workspace = true }
 const-str = { workspace = true }
 critical-section = { workspace = true, optional = true }
+defmt-rtt = { workspace = true, optional = true }
 embassy-sync = { workspace = true }
 featurecomb = { workspace = true }
 log = { workspace = true, optional = true }
@@ -68,6 +69,7 @@ log = ["dep:critical-section", "dep:log", "ariel-os-debug-log/log"]
 semihosting = ["dep:semihosting"]
 
 # Debug output backends
+defmt-rtt = ["dep:defmt-rtt"]
 esp-println = ["dep:esp-println"]
 rtt-target = ["dep:rtt-target"]
 std = []

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -85,6 +85,15 @@ pub fn print_panic(info: &core::panic::PanicInfo<'_>) {
     println!("panicked at {}:\n{}", location, message);
 }
 
+#[cfg(all(feature = "debug-console", feature = "defmt-rtt"))]
+mod backend {
+    pub use ariel_os_debug_log::println;
+    use defmt_rtt as _;
+
+    #[doc(hidden)]
+    pub fn init() {}
+}
+
 #[cfg(all(feature = "debug-console", feature = "rtt-target"))]
 mod backend {
     #[cfg(not(feature = "defmt"))]

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -210,6 +210,7 @@ no-boards = ["ariel-os-boards/no-boards", "executor-none"]
 # These are selected by laze
 debug-uart = ["ariel-os-debug/uart", "ariel-os-embassy/debug-uart"]
 rtt-target = ["ariel-os-debug/rtt-target"]
+defmt-rtt = ["ariel-os-debug/defmt-rtt"]
 esp-println = ["ariel-os-debug/esp-println"]
 semihosting = ["ariel-os-debug/semihosting"]
 


### PR DESCRIPTION
# Description

This adds `defmt-rtt` as another log backend, and makes it default if `defmt` is enabled.
This enables output via probe-rs & defmt on esp32.

Marking as draft as it doesn't actually seem to work on esp32 on main (it does on #1328).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Split out from #1328.

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
