### PR TITLE
chore(ariel-os-macros): bump proc-macros2 to 1.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4621,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b3997d62ff36d1d0e5616f1e00c4b071680eb3769d56102663c1f0886971e1"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro-crate = "3.1.0"
-proc-macro2 = "1.0.78"
+proc-macro2 = "1.0.103"
 quote = "1.0.35"
 syn = { version = "2.0.47", features = ["full"] }
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -314,8 +314,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.proc-macro2]]
-version = "1.0.99"
-when = "2025-08-16"
+version = "1.0.103"
+when = "2025-10-23"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"


### PR DESCRIPTION
# Description

Bump the `proc-macros2` dep in the `ariel-os-macros` crate to 1.0.103.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Linked to #1243.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
