### PR TITLE
chore(rustdoc): only `warn` about `broken_intra_doc_links`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,4 +190,4 @@ unused_trait_names = "warn"
 undocumented_unsafe_blocks = "warn"
 
 [workspace.lints.rustdoc]
-broken_intra_doc_links = "deny"
+broken_intra_doc_links = "warn"


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This sets `broken_intra_doc_links` to `warn` after it was initially set to `deny` when introduced in #391. CI is already set to fail on warnings, and missing intra-doc links don't warrant completely preventing from generating the docs *locally*.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

- This partly mitigates #1610.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
