### PR TITLE
fix(rt): only provide the panic handler on embedded architectures

### DIFF
--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -130,8 +130,7 @@ mod isr_stack {
 
 #[cfg(all(
     feature = "_panic-handler",
-    not(feature = "_test"),
-    not(context = "native")
+    any(context = "esp", context = "nrf", context = "rp", context = "stm32"),
 ))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This changes under which condition the panic handler is provided. This should fix issues that arise when trying to use other tools, in which case two panic handlers end up being provided, which result in a conflict.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Tested the following successfully:

```sh
laze -C src/ariel-os-identity/ build -b stm32u083c-dk test
```

```sh
laze -C examples/log build -b espressif-esp32-c6-devkitc-1 run
```

```sh
laze -C examples/log build -b nrf52840dk run
```

```sh
laze -C examples/log build -b rpi-pico2-w run
```

```sh
laze -C examples/log build -b stm32u083c-dk run
```

```sh
laze -C examples/log build -b native run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencielaze -C src/ariel-os-identity/ build -b stm32u083c-dk tests on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Needed for #1615

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
The custom panic handler is now only provided on embedded architectures. This fixes potential issues when running host tests or generating documentation.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
