### PR TITLE
refactor(sensors-debug): use `cast_unsigned()` where possible

### DIFF
--- a/examples/sensors-debug/src/main.rs
+++ b/examples/sensors-debug/src/main.rs
@@ -98,9 +98,9 @@ fn print_sample(sensor: &dyn Sensor, sample: Sample, reading_channel: ReadingCha
 
     let channel_scaling = reading_channel.scaling();
     let value = if channel_scaling < 0 {
-        value as f32 / 10i32.pow(-channel_scaling as u32) as f32
+        value as f32 / 10i32.pow(u32::from((-channel_scaling).cast_unsigned())) as f32
     } else {
-        value as f32 * 10i32.pow(channel_scaling as u32) as f32
+        value as f32 * 10i32.pow(u32::from(channel_scaling.cast_unsigned())) as f32
     };
 
     match sample.metadata() {
@@ -113,9 +113,9 @@ fn print_sample(sensor: &dyn Sensor, sample: Sample, reading_channel: ReadingCha
                 .max((i16::from(bias) - i16::from(deviation)).abs())
                 as f32;
             let accuracy = if scaling < 0 {
-                raw_accuracy / 10i32.pow(-scaling as u32) as f32
+                raw_accuracy / 10i32.pow(u32::from((-scaling).cast_unsigned())) as f32
             } else {
-                raw_accuracy * 10i32.pow(scaling as u32) as f32
+                raw_accuracy * 10i32.pow(u32::from(scaling.cast_unsigned())) as f32
             };
 
             info!(


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This rewrites `as u32` casts to use [`cast_unsigned()`](https://doc.rust-lang.org/stable/std/primitive.i32.html#method.cast_unsigned), newly stabilized in Rust 1.87 (which we can use as our MSRV is now 1.90). This makes the intent of these casts clearer, and makes these casts more robust (as the source type cannot silently change).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
I grepped for `as u32` in the codebase (remaining occurrences have different semantics).

Successfully tested the `sensor-debug` example on an st-steval-mkboxpro: the STTS22H driver uses a channel scaling of `-2` currently, which allows to test this change:

https://github.com/ariel-os/ariel-os/blob/b753ff941b0617122c270b8c4a5e8460f5416052/src/sensors/ariel-os-sensor-stts22h/src/i2c.rs#L230-L236

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
