### PR TITLE
feat: choose correct gdb for each architecture

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -159,7 +159,9 @@ contexts:
 
       gdb:
         cmd:
-          - arm-none-eabi-gdb -ex "target extended-remote localhost:1337" ${out} $@
+          # On debian, install gdb-multiarch and do
+          # alias gdb=gdb-multiarch
+          - gdb -ex "target extended-remote localhost:1337" ${out} $@
         build: false
         ignore_ctrl_c: true
 


### PR DESCRIPTION
# Description

This PR updates the `gdb` task to use the gdb executable that corresponds to the MCU's architecture.

`probe-rs` gdb server is not yet available for Xtensa

## Testing

Can be tested with `probe-rs` compatible MCUs: 

- first flash an example, cancel the execution when the firmware started:
   ```
   laze -C examples/blinky build -b <board> -s probe-rs run
   ```
- Start the gdb server: 
   ```
   laze -C examples/blinky build -b <board> -s probe-rs debug
   ```
- In another terminal, connect to the gdb server: 
   ```
   laze -C examples/blinky build -b <board> -s probe-rs gdb
   ```
 

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

Does this need to be more documented ? 

I chose the name `GDB_EXEC` to be more explicit than just "`GDB`", is this the right variable name ?

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
