### PR TITLE
refactor(threads): make idle threads a feature

### DIFF
--- a/src/ariel-os-threads/Cargo.toml
+++ b/src/ariel-os-threads/Cargo.toml
@@ -68,8 +68,10 @@ multi-core = [
   "dep:rp-pac",
   "dep:embassy-rp",
   "embassy-rp/fifo-handler",
+  "idle-threads",
 ]
 infini-core = []
 core-affinity = ["multi-core"]
+idle-threads = []
 
 _test = ["single-core"]

--- a/src/ariel-os-threads/src/arch/mod.rs
+++ b/src/ariel-os-threads/src/arch/mod.rs
@@ -4,6 +4,10 @@ use crate::Thread;
 pub trait Arch {
     const DEFAULT_THREAD_DATA: Self::ThreadData;
 
+    /// Stack size for the idle threads.
+    #[cfg(feature = "idle-threads")]
+    const IDLE_THREAD_STACK_SIZE: usize = 256;
+
     type ThreadData;
 
     /// Sets up the stack for newly created threads and returns the sp.

--- a/src/ariel-os-threads/src/arch/xtensa.rs
+++ b/src/ariel-os-threads/src/arch/xtensa.rs
@@ -13,6 +13,9 @@ pub struct Cpu;
 impl Arch for Cpu {
     type ThreadData = TrapFrame;
     const DEFAULT_THREAD_DATA: Self::ThreadData = default_trap_frame();
+    /// Stack size for the idle threads.
+    #[cfg(feature = "idle-threads")]
+    const IDLE_THREAD_STACK_SIZE: usize = 2048;
 
     fn schedule() {
         #[cfg(not(feature = "multi-core"))]

--- a/src/ariel-os-threads/src/smp/esp32s3.rs
+++ b/src/ariel-os-threads/src/smp/esp32s3.rs
@@ -22,7 +22,6 @@ pub struct Chip;
 
 impl Multicore for Chip {
     const CORES: u32 = 2;
-    const IDLE_THREAD_STACK_SIZE: usize = 2048;
     type Stack = Stack<ISR_STACKSIZE_CORE1>;
 
     fn core_id() -> CoreId {

--- a/src/ariel-os-threads/src/smp/mod.rs
+++ b/src/ariel-os-threads/src/smp/mod.rs
@@ -48,8 +48,6 @@ impl CoreId {
 pub trait Multicore {
     /// Number of available core.
     const CORES: u32;
-    /// Stack size for the idle threads.
-    const IDLE_THREAD_STACK_SIZE: usize = 256;
     type Stack;
 
     /// Returns the ID of the current core.

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -228,6 +228,9 @@ executor-thread = ["ariel-os-embassy/executor-thread", "threading"]
 # *Used for internal testing only.*
 executor-none = ["ariel-os-embassy/executor-none"]
 
+# Enables idle threads. Selected by laze if needed.
+idle-threads = ["ariel-os-threads/idle-threads"]
+
 # features needed for `cargo test`
 _test = [
   "i2c",


### PR DESCRIPTION
# Description

This refactors idle-threads to be a cargo feature of `ariel-os-threads`, and selects it unconditionally if `multi-core` is enabled. It is also available for single core MCUs if needed.

We need this for e.g., esp, to avoid nested interrupts there.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Split out of #1328.

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
