### PR TITLE
feat(sensors): Add sample Label and MeasurementUnit for Co2 sensor

### DIFF
--- a/src/ariel-os-sensors/src/label.rs
+++ b/src/ariel-os-sensors/src/label.rs
@@ -23,6 +23,8 @@ pub enum Label {
     AngularVelocityY,
     /// Angular velocity about the Z axis.
     AngularVelocityZ,
+    /// CO<sub>2</sub> concentration.
+    Co2,
     /// Ground speed.
     GroundSpeed,
     /// Latitude.
@@ -57,6 +59,7 @@ impl core::fmt::Display for Label {
             Self::AngularVelocityX => write!(f, "Angular velocity X"),
             Self::AngularVelocityY => write!(f, "Angular velocity Y"),
             Self::AngularVelocityZ => write!(f, "Angular velocity Z"),
+            Self::Co2 => write!(f, "CO2 concentration"),
             Self::GroundSpeed => write!(f, "Ground speed"),
             Self::Latitude => write!(f, "Latitude"),
             Self::Longitude => write!(f, "Longitude"),

--- a/src/ariel-os-sensors/src/measurement_unit.rs
+++ b/src/ariel-os-sensors/src/measurement_unit.rs
@@ -63,6 +63,8 @@ pub enum MeasurementUnit {
     Newton,
     /// Ohm (Ω).
     Ohm,
+    /// Parts per million (ppm).
+    PartsPerMillion,
     /// Pascal (Pa).
     Pascal,
     /// Percent (%).
@@ -119,6 +121,7 @@ macro_rules! provide_unit_fmt {
             Self::Mole => write!($f, "mol"),
             Self::Newton => write!($f, "N"),
             Self::Ohm => write!($f, "Ω"),
+            Self::PartsPerMillion => write!($f, "ppm"),
             Self::Pascal => write!($f, "Pa"),
             Self::Percent => write!($f, "%"),
             Self::PercentageRelativeHumidity => write!($f, "%RH"),


### PR DESCRIPTION
# Description
As mentioned in #1626 , there is currently no sample `Label` and `MeasurementUnit` unit for Co2. This PR adds a `Label` and `MeasurementUnit`.
<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
