### PR TITLE
fix(stts22h-sensor): fix `wait_for_reading()`'s cancel safety

### DIFF
--- a/src/sensors/ariel-os-sensor-stts22h/src/i2c.rs
+++ b/src/sensors/ariel-os-sensor-stts22h/src/i2c.rs
@@ -176,10 +176,10 @@ impl<I2C: I2c + Send> Stts22h<I2C> {
 
 impl<I2C: Send> Sensor for Stts22h<I2C> {
     fn trigger_measurement(&self) -> Result<(), TriggerMeasurementError> {
+        self.reading.clear();
+
         match self.state.get() {
-            State::Measuring => {
-                self.reading.clear();
-            }
+            State::Measuring => {}
             State::Enabled => {
                 self.state.set(State::Measuring);
             }
@@ -456,7 +456,7 @@ mod tests {
                 let reading = STTS22H.wait_for_reading().await.unwrap();
                 let (_channel, sample) = reading.sample();
 
-                assert_eq!(sample.value(), Ok(2500));
+                assert_eq!(sample.value(), Ok(1800));
             })
             .await
         });


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Following https://github.com/ariel-os/ariel-os/pull/1431#discussion_r2626628049, this adds a test checking the cancel safety of `wait_for_reading()`.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
CI will do it for the test.

Successfully tested the following:

```sh
laze -C examples/sensors-debug/ build -b stm32u083c-dk run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
