### PR TITLE
chore: remove RIOTCORE_KERNEL_VERSION from panic handler

### DIFF
--- a/src/ariel-os-rt/src/cortexm.rs
+++ b/src/ariel-os-rt/src/cortexm.rs
@@ -82,7 +82,6 @@ unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
 
     panic!(
         "{} HardFault.\r\n\
-         \tKernel version {}\r\n\
          \tr0  0x{:x}\r\n\
          \tr1  0x{:x}\r\n\
          \tr2  0x{:x}\r\n\
@@ -120,7 +119,6 @@ unsafe fn HardFault(ef: &ExceptionFrame) -> ! {
          \tBus Fault Address:       (valid: {}) {:#010X}\r\n\
          ",
         mode_str,
-        option_env!("RIOTCORE_KERNEL_VERSION").unwrap_or("unknown"),
         ef.r0(),
         ef.r1(),
         ef.r2(),


### PR DESCRIPTION
# Description

This removes the old RIOTCORE_KERNEL_VERSION from the panic handler

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Open Questions

Could be replaced with our own version number in the future.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
