### PR TITLE
refactor(threading): document `yield_same()` as available on infini-core

### DIFF
--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -737,8 +737,11 @@ fn cleanup() -> ! {
 }
 
 /// "Yields" to another thread with the same priority.
-#[cfg(not(feature = "infini-core"))]
 pub fn yield_same() {
+    // Nothing to do for infini-core, because all threads run in *parallel* from the point of view
+    // of Ariel OS.
+
+    #[cfg(not(feature = "infini-core"))]
     SCHEDULER.with_mut(|mut scheduler| {
         #[allow(unused_variables, reason = "prio only used outside clippy")]
         let Some(&mut Thread {
@@ -775,12 +778,6 @@ pub fn yield_same() {
             }
         }
     });
-}
-
-#[allow(missing_docs)]
-#[cfg(feature = "infini-core")]
-pub fn yield_same() {
-    // Not much to do here.
 }
 
 /// Suspends/ pauses the current thread's execution.


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This slightly refactors `thread::yield_same()` to fix the documentation with `infini-core`: `yield_same()` is incorrectly documented as *not* available with `infini-core` (and therefore on native), while it is actually available (and just a no-op).

This is how it looks currently:

<img width="564" height="165" alt="screenshot of yield_same rustdoc docs" src="https://github.com/user-attachments/assets/60bfad63-faaf-4b0e-8523-286ce991dc24" />

## How to review this PR

The docs preview shows that there is no mention of `infini-core` in the `cfg` flair of `thread::yield_same()`.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested by appending the following to `thread0` from the `threading` example:

```rust
    ariel_os::thread::yield_same();
    info!("Hello again from thread 0");
```

Tested on native and nrf52840dk.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
