### PR TITLE
chore(clippy): allow `too_many_lines`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ indexing_slicing = "deny"
 missing_safety_doc = { level = "warn" }
 pedantic = { level = "warn", priority = -1 }
 too_long_first_doc_paragraph = "warn"
+too_many_lines = "allow"
 unused_result_ok = "deny"
 unused_trait_names = "warn"
 undocumented_unsafe_blocks = "warn"

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -202,7 +202,6 @@ fn init() {
 }
 
 #[embassy_executor::task]
-#[allow(clippy::too_many_lines)]
 async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     let spawner = asynch::Spawner::for_current_executor().await;
     asynch::set_spawner(spawner.make_send());

--- a/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
+++ b/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
@@ -4,7 +4,6 @@
 /// One single type must be defined so that it can be used in the Future returned by sensor
 /// drivers, which must be the same for every sensor driver so it can be part of the `Sensor`
 /// trait.
-#[expect(clippy::too_many_lines)]
 #[proc_macro]
 pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
     use quote::quote;

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -89,7 +89,6 @@ fn board_config(config: &mut Config) {
 }
 
 // TODO: find better place for this
-#[expect(clippy::too_many_lines)]
 fn rcc_config() -> embassy_stm32::rcc::Config {
     #[allow(unused_mut, reason = "conditional compilation")]
     let mut rcc = embassy_stm32::rcc::Config::default();

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -57,7 +57,6 @@
 #![no_std]
 #![cfg_attr(feature = "_nightly_docs", feature(doc_cfg))]
 #![deny(missing_docs)]
-#![allow(clippy::too_many_lines)]
 #![allow(rust_2018_idioms)]
 #![expect(clippy::unused_trait_names)]
 #![expect(clippy::doc_paragraphs_missing_punctuation)]

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -1040,7 +1040,6 @@ impl<
     type BuildResponseError<M: MinimalWritableMessage> =
         OrInner<Result<CoAPError, M::UnionError>, H::BuildResponseError<M>>;
 
-    #[expect(clippy::too_many_lines, reason = "no good refactoring point known")]
     fn extract_request_data<M: ReadableMessage>(
         &mut self,
         request: &M,


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This allows `clippy::too_many_lines` at workspace level, which is part of `clippy::pedantic`. My main motivation is that this lint can make otherwise-orthogonal refactors non-commutative when `expect`ed on a function.

We're already aware that it is generally a good thing to keep functions short, but the limit is arbitrary (100 lines by default, even though of course configurable) and readability is better enforced by code review imo anyway.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Makes #1641 slightly easier.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
