### PR TITLE
fix(sensors): make `Reading::samples()` a guaranteed `FusedIterator`

### DIFF
--- a/src/ariel-os-sensors/src/sample.rs
+++ b/src/ariel-os-sensors/src/sample.rs
@@ -143,7 +143,9 @@ pub trait Reading: core::fmt::Debug {
     ///
     /// The default implementation must be overridden on types containing multiple
     /// [`Sample`]s.
-    fn samples(&self) -> impl ExactSizeIterator<Item = (ReadingChannel, Sample)> {
+    fn samples(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (ReadingChannel, Sample)> + core::iter::FusedIterator {
         [self.sample()].into_iter()
     }
 }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This was the intent of #1226 but was missed in there, and only found in the refactor of #1641 where the "impl trait in impl method signature does not match trait method signature" warning shows up on the `Samples` implementation of `Reading` (the compiler wasn't warning about this before because the implementation was provided by a proc-macro).

This is not a breaking change as neither the `ariel-os-sensors` or `ariel-os` crates have been released since the introduction of `Reading`.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
CI is sufficient for testing this, but still successfully tested the following:

```sh
laze -C examples/sensors-debug/ build -b st-steval-mkboxpro run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
