### PR TITLE
refactor(sensors): replace `pin-project` with `pin-project-lite`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
  "defmt 1.0.1",
  "embassy-futures",
  "embassy-sync 0.6.2",
- "pin-project",
+ "pin-project-lite",
  "static_cell",
 ]
 
@@ -4419,26 +4419,6 @@ name = "picoserve_derive"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a7350bdbef1ef80e4f058b89ca974dcc6526b04ac4d2095763b69760abf7ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ once_cell = { version = "1.21.3", default-features = false, features = [
   "critical-section",
 ] }
 paste = { version = "1.0" }
-pin-project = "1.1.10"
+pin-project-lite = "0.2.16"
 rand = { version = "0.9.2", default-features = false }
 rand_core = { version = "0.9.3", default-features = false }
 rtt-target = { version = "0.6.0" }

--- a/src/ariel-os-sensors/Cargo.toml
+++ b/src/ariel-os-sensors/Cargo.toml
@@ -13,7 +13,7 @@ license.workspace = true
 ariel-os-macros = { workspace = true }
 defmt = { workspace = true, optional = true }
 embassy-sync = { workspace = true }
-pin-project = { workspace = true }
+pin-project-lite = { workspace = true }
 
 [dev-dependencies]
 critical-section = { workspace = true, features = ["std"] }

--- a/src/ariel-os-sensors/src/sensor.rs
+++ b/src/ariel-os-sensors/src/sensor.rs
@@ -138,17 +138,19 @@ impl Future for ReadingWaiter {
     }
 }
 
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-#[pin_project::pin_project(project = ReadingWaiterInnerProj)]
-enum ReadingWaiterInner {
-    Waiter {
-        #[pin]
-        waiter: signal::ReceiveFuture<'static, ReadingResult<Samples>>,
-    },
-    Resolved,
-    Err {
-        err: ReadingError,
-    },
+pin_project_lite::pin_project! {
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    #[project = ReadingWaiterInnerProj]
+    enum ReadingWaiterInner {
+        Waiter {
+            #[pin]
+            waiter: signal::ReceiveFuture<'static, ReadingResult<Samples>>,
+        },
+        Err {
+            err: ReadingError,
+        },
+        Resolved,
+    }
 }
 
 impl Future for ReadingWaiterInner {


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This replaces `pin-project` with `pin-project-lite`, for the one usage in the `ariel-os-sensors` crate. Both crates are from the same author, but `pin-project-lite` only uses declarative macros instead of a proc-macro, participating to reducing the dependencies of sensor driver crates (as does #1641). See [the docs](https://docs.rs/pin-project-lite/latest/pin_project_lite/) for more about the trade-offs of `pin-project` vs `pin-project-lite` (I'm not aware of any downsides in our case, except it needed a tiny refactor to be usable).

`pin-project-lite` is also a dependency of `futures-util` which is in many places of our tree, so this isn't a new dependency (and it's already vetted). 

## How to review this PR

This PR is better reviewed commit by commit.

Hiding whitespace in the diff might also be useful.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested the following:

```sh
laze -C examples/sensors-debug/ build -b st-steval-mkboxpro run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
