### PR TITLE
docs(esp32s3): fix user USB support info on ESP32-S3-based boards

### DIFF
--- a/book/src/boards/heltec-wifi-lora-32-v3.md
+++ b/book/src/boards/heltec-wifi-lora-32-v3.md
@@ -21,7 +21,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
-|User USB|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|

--- a/book/src/chips/esp32s3fx8.md
+++ b/book/src/chips/esp32s3fx8.md
@@ -14,7 +14,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
-|User USB|<span title="supported">✅</span>|
+|User USB|<span title="needs testing">🚦</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|

--- a/book/src/support_matrix_tier3.html
+++ b/book/src/support_matrix_tier3.html
@@ -109,7 +109,7 @@
       <td class="support-cell" title="needs testing">🚦</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="supported">✅</td>
+      <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -462,7 +462,6 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      user_usb: supported
       ethernet_over_usb: not_currently_supported
       wifi: supported
       ble: not_currently_supported
@@ -483,7 +482,7 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      user_usb: supported
+      user_usb: needs_testing # This should be moved to a board when one is added.
       ethernet_over_usb: not_currently_supported
       wifi: supported
       ble: not_currently_supported
@@ -938,6 +937,7 @@ boards:
     chip: esp32s3
     tier: "1"
     support:
+      user_usb: supported
 
   heltec-wifi-lora-32-v3:
     name: Heltec WiFi LoRa 32 V3
@@ -945,6 +945,7 @@ boards:
     chip: esp32s3
     tier: "3"
     support:
+      user_usb: not_available
 
   seeedstudio-xiao-esp32c6:
     name: Seeed Studio XIAO ESP32C6


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Following #1561 and https://github.com/ariel-os/ariel-os/pull/1658#discussion_r2672375175, this fixes the support info about user USB on ESP32-S3 chips and boards: `user_usb` requires a user USB *port* and therefore can only be marked as supported on boards.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
