### PR TITLE
fix(nrf): use non-lfxo pins for nrf5340

### DIFF
--- a/examples/sensors-debug/src/pins.rs
+++ b/examples/sensors-debug/src/pins.rs
@@ -14,7 +14,11 @@ pub type SensorI2c = i2c::controller::TWISPI0;
 pub type SensorI2c = i2c::controller::SERIAL0;
 #[cfg(all(
     context = "nrf",
-    not(any(context = "bbc-microbit-v2", context = "nordic-thingy-91-x-nrf9151"))
+    not(any(
+        context = "bbc-microbit-v2",
+        context = "nordic-thingy-91-x-nrf9151",
+        context = "nrf5340"
+    ))
 ))]
 ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: P0_00,
@@ -24,6 +28,11 @@ ariel_os::hal::define_peripherals!(Peripherals {
 ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: P0_16,
     i2c_scl: P0_08,
+});
+#[cfg(context = "nrf5340")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    i2c_sda: P0_20,
+    i2c_scl: P0_22,
 });
 #[cfg(context = "nordic-thingy-91-x-nrf9151")]
 ariel_os::hal::define_peripherals!(Peripherals {

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -35,8 +35,8 @@ ariel_os::hal::define_peripherals!(ButtonPeripherals {
 
 #[cfg(context = "nrf5340")]
 ariel_os::hal::define_peripherals!(ButtonPeripherals {
-    btn_0: P0_00,
-    btn_1: P0_01,
+    btn_0: P0_20,
+    btn_1: P0_22,
     btn_2: P0_04,
     btn_3: P0_05,
     btn_4: P0_06,

--- a/tests/gpio/src/pins.rs
+++ b/tests/gpio/src/pins.rs
@@ -18,8 +18,8 @@ ariel_os::hal::define_peripherals!(Peripherals {
 
 #[cfg(context = "nrf5340")]
 ariel_os::hal::define_peripherals!(Peripherals {
-    pin_0: P0_00,
-    pin_1: P0_01,
+    pin_0: P0_20,
+    pin_1: P0_22,
     pin_2: P0_04,
     pin_3: P0_05,
 });

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -14,7 +14,11 @@ pub type SensorI2c = i2c::controller::TWISPI0;
 pub type SensorI2c = i2c::controller::SERIAL0;
 #[cfg(all(
     context = "nrf",
-    not(any(context = "bbc-microbit-v2", context = "nordic-thingy-91-x-nrf9151"))
+    not(any(
+        context = "bbc-microbit-v2",
+        context = "nordic-thingy-91-x-nrf9151",
+        context = "nrf5340"
+    ))
 ))]
 ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: P0_00,
@@ -29,6 +33,11 @@ ariel_os::hal::define_peripherals!(Peripherals {
 ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: P0_09,
     i2c_scl: P0_08,
+});
+#[cfg(context = "nrf5340")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    i2c_sda: P1_02,
+    i2c_scl: P1_03,
 });
 
 #[cfg(context = "rp")]


### PR DESCRIPTION
# Description

`P0_00` and `P0_01` are gated behind lxfo. just use others.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Split out of #1328.
<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
