### PR TITLE
docs(stm32u585): document that storage does not support removing items

### DIFF
--- a/book/src/boards/steval-mkboxpro.md
+++ b/book/src/boards/steval-mkboxpro.md
@@ -34,7 +34,7 @@ laze build -b st-steval-mkboxpro
 |Bluetooth Low Energy|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^usb-does-not-enumerate][^see-also-https-github-com-embassy-rs-embassy-issues-2376][^workaround-in-https-github-com-ariel-os-ariel-os-pull-1126]|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
-|Persistent Storage|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported with some caveats">☑️</span>[^removing-items-not-supported]|
 
 <p>Legend:</p>
 
@@ -66,3 +66,4 @@ dt, dd {
 [^usb-does-not-enumerate]: USB does not enumerate.
 [^see-also-https-github-com-embassy-rs-embassy-issues-2376]: See also: https://github.com/embassy-rs/embassy/issues/2376.
 [^workaround-in-https-github-com-ariel-os-ariel-os-pull-1126]: Workaround in: https://github.com/ariel-os/ariel-os/pull/1126.
+[^removing-items-not-supported]: Removing items not supported.

--- a/book/src/chips/stm32u585ai.md
+++ b/book/src/chips/stm32u585ai.md
@@ -19,7 +19,7 @@
 |Bluetooth Low Energy|<span title="not available on this piece of hardware">–</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^usb-does-not-enumerate][^see-also-https-github-com-embassy-rs-embassy-issues-2376][^workaround-in-https-github-com-ariel-os-ariel-os-pull-1126]|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
-|Persistent Storage|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported with some caveats">☑️</span>[^removing-items-not-supported]|
 
 <p>Legend:</p>
 
@@ -49,3 +49,4 @@ dt, dd {
 [^usb-does-not-enumerate]: USB does not enumerate.
 [^see-also-https-github-com-embassy-rs-embassy-issues-2376]: See also: https://github.com/embassy-rs/embassy/issues/2376.
 [^workaround-in-https-github-com-ariel-os-ariel-os-pull-1126]: Workaround in: https://github.com/ariel-os/ariel-os/pull/1126.
+[^removing-items-not-supported]: Removing items not supported.

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -751,7 +751,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported with some caveats">☑️</td>
       </tr>
 	  </tbody>
 	<tbody class="odd">

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -717,7 +717,10 @@ chips:
       spi_main: supported
       uart: supported
       logging: supported
-      storage: supported
+      storage:
+        status: supported_with_caveats
+        comments:
+          - removing items not supported
       wifi: not_available
       ble: not_available
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Removing items from persistent storage is supported on none of the STM32 MCUs.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
