### PR TITLE
fix(threads): re-add missing armv6 jump in PendSV

### DIFF
--- a/src/ariel-os-threads/src/arch/cortex_m.rs
+++ b/src/ariel-os-threads/src/arch/cortex_m.rs
@@ -241,6 +241,7 @@ global_asm!(
         //
         // In both cases, storing and loading of r4-r11 can be skipped.
         cmp r0, #0
+        beq 99f
 
         //stmia r1!, {{r4-r7}}
         str r4, [r0, #16]


### PR DESCRIPTION
# Description

In the Cortex-M armv6 `PendSV`, we `cmp` but don't act on it. Somehow the jump must have gone missing when last refactoring this.

This fixes #1553 for me (tested on the `st-nucleo-f031c6`).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Fixes https://github.com/ariel-os/ariel-os/issues/1553.
<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
