### PR TITLE
docs(gen-book): sort laze builders by tier then alpha

### DIFF
--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -26,69 +26,6 @@
   <tbody>
 	<tbody class="odd">
       <tr>
-	    <td rowspan="2"><a href="boards/adafruit-feather-nrf52840-express.html">Adafruit Feather nRF52840 Express</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>adafruit-feather-nrf52840-express</code></td>
-		<td style="text-align: center;">2</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-      </tr>
-	  </tbody>
-	<tbody class="even">
-      <tr>
-	    <td rowspan="2"><a href="boards/adafruit-feather-nrf52840-sense.html">Adafruit Feather nRF52840 Sense</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>adafruit-feather-nrf52840-sense</code></td>
-		<td style="text-align: center;">3</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-      </tr>
-	  </tbody>
-	<tbody class="odd">
-      <tr>
-	    <td rowspan="2"><a href="boards/bbc-micro-bit-v1.html">BBC micro:bit V1</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>bbc-microbit-v1</code></td>
-		<td style="text-align: center;">3</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-      </tr>
-	  </tbody>
-	<tbody class="even">
-      <tr>
 	    <td rowspan="2"><a href="boards/bbc-micro-bit-v2.html">BBC micro:bit V2</a></td>
 	  </tr>
 	  <tr>
@@ -108,49 +45,7 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
-      <tr>
-	    <td rowspan="2"><a href="boards/dfrobot-firebeetle-2-esp32-c6.html">DFRobot FireBeetle 2 ESP32-C6</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>dfrobot-firebeetle2-esp32-c6</code></td>
-		<td style="text-align: center;">2</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-      </tr>
-	  </tbody>
 	<tbody class="even">
-      <tr>
-	    <td rowspan="2"><a href="boards/espressif-esp32-c3-devkit-rust-1.html">Espressif ESP32-C3-DevKit-RUST-1</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>espressif-esp32-c3-devkit-rust-1</code></td>
-		<td style="text-align: center;">3</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-      </tr>
-	  </tbody>
-	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/espressif-esp32-c3-lcdkit.html">Espressif ESP32-C3-LCDkit</a></td>
 	  </tr>
@@ -171,7 +66,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/espressif-esp32-c6-devkitc-1.html">Espressif ESP32-C6-DevKitC-1</a></td>
 	  </tr>
@@ -188,27 +83,6 @@
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-      </tr>
-	  </tbody>
-	<tbody class="odd">
-      <tr>
-	    <td rowspan="2"><a href="boards/espressif-esp32-s2-devkitc-1.html">Espressif ESP32-S2-DevKitC-1</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>espressif-esp32-s2-devkitc-1</code></td>
-		<td style="text-align: center;">3</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
@@ -236,27 +110,6 @@
 	  </tbody>
 	<tbody class="odd">
       <tr>
-	    <td rowspan="2"><a href="boards/heltec-wifi-lora-32-v3.html">Heltec WiFi LoRa 32 V3</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>heltec-wifi-lora-32-v3</code></td>
-		<td style="text-align: center;">3</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-      </tr>
-	  </tbody>
-	<tbody class="even">
-      <tr>
 	    <td rowspan="2"><a href="boards/native.html">native</a></td>
 	  </tr>
 	  <tr>
@@ -276,49 +129,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
-      <tr>
-	    <td rowspan="2"><a href="boards/nordic-thingy-91-x.html">Nordic Thingy:91 X</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>nordic-thingy-91-x-nrf9151</code></td>
-		<td style="text-align: center;">2</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-      </tr>
-	  </tbody>
 	<tbody class="even">
-      <tr>
-	    <td rowspan="2"><a href="boards/nrf52-dk.html">nRF52-DK</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>nrf52dk</code></td>
-		<td style="text-align: center;">2</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-      </tr>
-	  </tbody>
-	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/nrf52840-dk.html">nRF52840-DK</a></td>
 	  </tr>
@@ -339,7 +150,7 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="3"><a href="boards/nrf5340-dk.html">nRF5340-DK</a></td>
 	  </tr>
@@ -376,49 +187,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
-      <tr>
-	    <td rowspan="2"><a href="boards/nrf9151-dk.html">nRF9151-DK</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>nrf9151-dk</code></td>
-		<td style="text-align: center;">2</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-      </tr>
-	  </tbody>
 	<tbody class="even">
-      <tr>
-	    <td rowspan="2"><a href="boards/nrf9160-dk.html">nRF9160-DK</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>nrf9160dk-nrf9160</code></td>
-		<td style="text-align: center;">2</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-      </tr>
-	  </tbody>
-	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/raspberry-pi-pico.html">Raspberry Pi Pico</a></td>
 	  </tr>
@@ -439,7 +208,7 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/raspberry-pi-pico-2.html">Raspberry Pi Pico 2</a></td>
 	  </tr>
@@ -460,7 +229,7 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
 	    <td rowspan="2"><a href="boards/raspberry-pi-pico-2-w.html">Raspberry Pi Pico 2 W</a></td>
 	  </tr>
@@ -481,7 +250,7 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/raspberry-pi-pico-w.html">Raspberry Pi Pico W</a></td>
 	  </tr>
@@ -502,25 +271,214 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
-	    <td rowspan="2"><a href="boards/seeed-studio-lora-e5-mini.html">Seeed Studio LoRa-E5 mini</a></td>
+	    <td rowspan="2"><a href="boards/st-nucleo-c031c6.html">ST NUCLEO-C031C6</a></td>
 	  </tr>
 	  <tr>
-	    <td><code>seeedstudio-lora-e5-mini</code></td>
-		<td style="text-align: center;">3</td>
+	    <td><code>st-nucleo-c031c6</code></td>
+		<td style="text-align: center;">1</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      </tr>
+	  </tbody>
+	<tbody class="odd">
+      <tr>
+	    <td rowspan="2"><a href="boards/st-nucleo-h755zi-q.html">ST NUCLEO-H755ZI-Q</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>st-nucleo-h755zi-q</code></td>
+		<td style="text-align: center;">1</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported with some caveats">☑️</td>
+      </tr>
+	  </tbody>
+	<tbody class="even">
+      <tr>
+	    <td rowspan="2"><a href="boards/st-nucleo-wb55rg.html">ST NUCLEO-WB55RG</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>st-nucleo-wb55</code></td>
+		<td style="text-align: center;">1</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported with some caveats">☑️</td>
+      </tr>
+	  </tbody>
+	<tbody class="odd">
+      <tr>
+	    <td rowspan="2"><a href="boards/stm32u083c-dk.html">STM32U083C-DK</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>stm32u083c-dk</code></td>
+		<td style="text-align: center;">1</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported with some caveats">☑️</td>
+      </tr>
+	  </tbody>
+	<tbody class="even">
+      <tr>
+	    <td rowspan="2"><a href="boards/adafruit-feather-nrf52840-express.html">Adafruit Feather nRF52840 Express</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>adafruit-feather-nrf52840-express</code></td>
+		<td style="text-align: center;">2</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+      </tr>
+	  </tbody>
+	<tbody class="odd">
+      <tr>
+	    <td rowspan="2"><a href="boards/dfrobot-firebeetle-2-esp32-c6.html">DFRobot FireBeetle 2 ESP32-C6</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>dfrobot-firebeetle2-esp32-c6</code></td>
+		<td style="text-align: center;">2</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      </tr>
+	  </tbody>
+	<tbody class="even">
+      <tr>
+	    <td rowspan="2"><a href="boards/nordic-thingy-91-x.html">Nordic Thingy:91 X</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>nordic-thingy-91-x-nrf9151</code></td>
+		<td style="text-align: center;">2</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+      </tr>
+	  </tbody>
+	<tbody class="odd">
+      <tr>
+	    <td rowspan="2"><a href="boards/nrf52-dk.html">nRF52-DK</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>nrf52dk</code></td>
+		<td style="text-align: center;">2</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+      </tr>
+	  </tbody>
+	<tbody class="even">
+      <tr>
+	    <td rowspan="2"><a href="boards/nrf9151-dk.html">nRF9151-DK</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>nrf9151-dk</code></td>
+		<td style="text-align: center;">2</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported with some caveats">☑️</td>
+      </tr>
+	  </tbody>
+	<tbody class="odd">
+      <tr>
+	    <td rowspan="2"><a href="boards/nrf9160-dk.html">nRF9160-DK</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>nrf9160dk-nrf9160</code></td>
+		<td style="text-align: center;">2</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
 	<tbody class="even">
@@ -567,15 +525,15 @@
 	  </tbody>
 	<tbody class="even">
       <tr>
-	    <td rowspan="2"><a href="boards/st-nucleo-c031c6.html">ST NUCLEO-C031C6</a></td>
+	    <td rowspan="2"><a href="boards/st-nucleo-f401re.html">ST NUCLEO-F401RE</a></td>
 	  </tr>
 	  <tr>
-	    <td><code>st-nucleo-c031c6</code></td>
-		<td style="text-align: center;">1</td>
+	    <td><code>st-nucleo-f401re</code></td>
+		<td style="text-align: center;">2</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
@@ -588,10 +546,136 @@
 	  </tbody>
 	<tbody class="odd">
       <tr>
-	    <td rowspan="2"><a href="boards/st-nucleo-f042k6.html">ST NUCLEO-F042K6</a></td>
+	    <td rowspan="2"><a href="boards/steval-mkboxpro.html">STEVAL-MKBOXPRO</a></td>
 	  </tr>
 	  <tr>
-	    <td><code>st-nucleo-f042k6</code></td>
+	    <td><code>st-steval-mkboxpro</code></td>
+		<td style="text-align: center;">2</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported with some caveats">☑️</td>
+      </tr>
+	  </tbody>
+	<tbody class="even">
+      <tr>
+	    <td rowspan="2"><a href="boards/adafruit-feather-nrf52840-sense.html">Adafruit Feather nRF52840 Sense</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>adafruit-feather-nrf52840-sense</code></td>
+		<td style="text-align: center;">3</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+      </tr>
+	  </tbody>
+	<tbody class="odd">
+      <tr>
+	    <td rowspan="2"><a href="boards/bbc-micro-bit-v1.html">BBC micro:bit V1</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>bbc-microbit-v1</code></td>
+		<td style="text-align: center;">3</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      </tr>
+	  </tbody>
+	<tbody class="even">
+      <tr>
+	    <td rowspan="2"><a href="boards/espressif-esp32-c3-devkit-rust-1.html">Espressif ESP32-C3-DevKit-RUST-1</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>espressif-esp32-c3-devkit-rust-1</code></td>
+		<td style="text-align: center;">3</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      </tr>
+	  </tbody>
+	<tbody class="odd">
+      <tr>
+	    <td rowspan="2"><a href="boards/espressif-esp32-s2-devkitc-1.html">Espressif ESP32-S2-DevKitC-1</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>espressif-esp32-s2-devkitc-1</code></td>
+		<td style="text-align: center;">3</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      </tr>
+	  </tbody>
+	<tbody class="even">
+      <tr>
+	    <td rowspan="2"><a href="boards/heltec-wifi-lora-32-v3.html">Heltec WiFi LoRa 32 V3</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>heltec-wifi-lora-32-v3</code></td>
+		<td style="text-align: center;">3</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      </tr>
+	  </tbody>
+	<tbody class="odd">
+      <tr>
+	    <td rowspan="2"><a href="boards/seeed-studio-lora-e5-mini.html">Seeed Studio LoRa-E5 mini</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>seeedstudio-lora-e5-mini</code></td>
 		<td style="text-align: center;">3</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
@@ -603,22 +687,22 @@
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported with some caveats">☑️</td>
       </tr>
 	  </tbody>
 	<tbody class="even">
       <tr>
-	    <td rowspan="2"><a href="boards/st-nucleo-f401re.html">ST NUCLEO-F401RE</a></td>
+	    <td rowspan="2"><a href="boards/st-nucleo-f042k6.html">ST NUCLEO-F042K6</a></td>
 	  </tr>
 	  <tr>
-	    <td><code>st-nucleo-f401re</code></td>
-		<td style="text-align: center;">2</td>
+	    <td><code>st-nucleo-f042k6</code></td>
+		<td style="text-align: center;">3</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
-		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
@@ -672,48 +756,6 @@
 	  </tbody>
 	<tbody class="odd">
       <tr>
-	    <td rowspan="2"><a href="boards/st-nucleo-h755zi-q.html">ST NUCLEO-H755ZI-Q</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>st-nucleo-h755zi-q</code></td>
-		<td style="text-align: center;">1</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported with some caveats">☑️</td>
-      </tr>
-	  </tbody>
-	<tbody class="even">
-      <tr>
-	    <td rowspan="2"><a href="boards/st-nucleo-wb55rg.html">ST NUCLEO-WB55RG</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>st-nucleo-wb55</code></td>
-		<td style="text-align: center;">1</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported with some caveats">☑️</td>
-      </tr>
-	  </tbody>
-	<tbody class="odd">
-      <tr>
 	    <td rowspan="2"><a href="boards/st-nucleo-wba55cg.html">ST NUCLEO-WBA55CG</a></td>
 	  </tr>
 	  <tr>
@@ -731,48 +773,6 @@
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-      </tr>
-	  </tbody>
-	<tbody class="even">
-      <tr>
-	    <td rowspan="2"><a href="boards/steval-mkboxpro.html">STEVAL-MKBOXPRO</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>st-steval-mkboxpro</code></td>
-		<td style="text-align: center;">2</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported with some caveats">☑️</td>
-      </tr>
-	  </tbody>
-	<tbody class="odd">
-      <tr>
-	    <td rowspan="2"><a href="boards/stm32u083c-dk.html">STM32U083C-DK</a></td>
-	  </tr>
-	  <tr>
-	    <td><code>stm32u083c-dk</code></td>
-		<td style="text-align: center;">1</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="supported with some caveats">☑️</td>
       </tr>
 	  </tbody>
   </tbody>

--- a/doc/gen_book.rs
+++ b/doc/gen_book.rs
@@ -104,8 +104,23 @@ impl SubCommandMatrix {
 
         let mut board_info = gen_board_functionalities(&matrix)?;
 
-        // TODO: read the order from the YAML file instead?
-        board_info.sort_unstable_by_key(|b| b.name.to_lowercase());
+        for board in board_info.iter_mut() {
+            board
+                .builders
+                .sort_unstable_by_key(|builder| builder.tier.clone());
+        }
+        board_info.sort_unstable_by_key(|board| {
+            (
+                board
+                    .builders
+                    .iter()
+                    .min_by_key(|builder| builder.tier.clone())
+                    .unwrap()
+                    .tier
+                    .clone(),
+                board.name.to_lowercase(),
+            )
+        });
 
         let mut env = Environment::new();
         env.add_template("matrix", &matrix_template).unwrap();


### PR DESCRIPTION
# Description

This PR sorts the support matrix in the "Overview" page of the book by laze builder tier, then alpha order.
For board that have more than one builder, only the builder with the lowest tier (meaning the highest level of testing) is considered.
Boards with multiple builders have their builders sorted by tier.

## Testing

## Issues/PRs References

Follow up to #1506.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
