### PR TITLE
feat(sensors): implement `core::error::Error` on every `*Error` type

### DIFF
--- a/src/ariel-os-sensors/src/sample.rs
+++ b/src/ariel-os-sensors/src/sample.rs
@@ -11,6 +11,17 @@ pub enum SampleError {
     ChannelDisabled,
 }
 
+impl core::fmt::Display for SampleError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::TemporarilyUnavailable => write!(f, "sample is temporarily unavailable"),
+            Self::ChannelDisabled => write!(f, "channel is disabled"),
+        }
+    }
+}
+
+impl core::error::Error for SampleError {}
+
 #[expect(clippy::doc_markdown)]
 /// Represents a value obtained from a sensor device, along with its metadata.
 ///


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This makes sure `core::error::Error` is implemented on every type in `ariel-os-sensors` whose name ends with `Error` (and therefore is an error type). That trait was actually only missing on `SampleError`.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

Tested the following (which doesn't actually rely on the `Error` trait):

```sh
laze -C examples/sensors-debug/ build -b st-steval-mkboxpro run
```

More testing should happen in #1683.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
Found when looking at #1683.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
