### PR TITLE
docs(tcp): add tcp-client example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5737,6 +5737,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
+name = "tcp-client"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "embedded-io-async 0.6.1",
+]
+
+[[package]]
 name = "tcp-echo"
 version = "0.0.0"
 dependencies = [

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -24,6 +24,7 @@ subdirs:
   - random
   - sensors-debug
   - storage
+  - tcp-client
   - tcp-echo
   - testing
   - thermometer

--- a/examples/tcp-client/Cargo.toml
+++ b/examples/tcp-client/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tcp-client"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os", features = ["tcp", "time"] }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+embedded-io-async = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/tcp-client/README.md
+++ b/examples/tcp-client/README.md
@@ -1,0 +1,20 @@
+# tcp-client
+
+## About
+
+This application is testing basic
+[Embassy](https://github.com/embassy-rs/embassy) _networking_ usage with Ariel OS.
+
+## How to run
+
+In this directory, run
+
+    laze build -b rpi-pico-w run
+
+The application will try to connect to [tcpbin.com](https://tcpbin.com/), a simple echo server using TCP.
+
+Look [here](../README.md#networking) for more information about network configuration.
+
+If everything goes well, you should see the server's response:
+
+    [INFO ] txd: Hello world!

--- a/examples/tcp-client/laze.yml
+++ b/examples/tcp-client/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: tcp-client
+    selects:
+      - network

--- a/examples/tcp-client/src/main.rs
+++ b/examples/tcp-client/src/main.rs
@@ -1,0 +1,57 @@
+// modification of https://github.com/embassy-rs/embassy/blob/main/examples/nrf9160/src/bin/modem_tcp_client.rs
+
+#![no_main]
+#![no_std]
+
+use core::str::FromStr as _;
+
+use embedded_io_async::Write as _;
+
+use ariel_os::time::Timer;
+use ariel_os::{
+    debug::log::{info, warn},
+    net,
+    reexports::embassy_net,
+    time::Duration,
+};
+
+#[ariel_os::task(autostart)]
+async fn tcp_echo() {
+    let stack = net::network_stack().await.unwrap();
+
+    // Increase the buffer size if you want to send bigger packets.
+    let mut rx_buffer = [0; 256];
+    let mut tx_buffer = [0; 256];
+
+    info!("waiting for interface to come up...");
+    stack.wait_config_up().await;
+
+    loop {
+        let mut socket = embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        socket.set_timeout(Some(Duration::from_secs(10)));
+
+        info!("Connecting...");
+        // Connect to https://tcpbin.com/ without using DNS
+        let host_addr = embassy_net::Ipv4Address::from_str("45.79.112.203").unwrap();
+        if let Err(e) = socket.connect((host_addr, 4242)).await {
+            warn!("connect error: {:?}", e);
+            Timer::after_secs(10).await;
+            continue;
+        }
+        info!("Connected to {:?}", socket.remote_endpoint());
+
+        let msg = b"Hello world!\n";
+        for _ in 0..10 {
+            #[allow(unused_variables, reason = "log macro sometimes doesn't use this")]
+            if let Err(e) = socket.write_all(msg).await {
+                warn!("write error: {:?}", e);
+                break;
+            }
+            // We put trust in the server to return a valid utf8 string
+            info!("txd: {}", core::str::from_utf8(msg).unwrap());
+            Timer::after_secs(1).await;
+        }
+
+        Timer::after_secs(4).await;
+    }
+}


### PR DESCRIPTION
# Description

This PR adds a simple TCP client example allowing to test connectivity without needing `hwrng`. 

## Testing

Ran on `rpi-pico-w` as wifi is broken on ESP: 

```
CONFIG_WIFI_NETWORK=<ssid> CONFIG_WIFI_PASSWORD=<password> laze -C examples/tcp-client build -b rpi-pico-w run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
A `tcp-client` example is now available: it makes it easy to test Internet connectivity without requiring a HWRNG.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
