### PR TITLE
fix(esp): don't force frame pointers on xtensa

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -384,8 +384,6 @@ contexts:
       RUSTFLAGS:
         # linkall first
         - -Clink-arg=-Tlinkall.x
-        # this might be needed for backtraces. it is needed for probe-rs.
-        - -C force-frame-pointers
 
   - name: esp32
     parent: esp
@@ -866,6 +864,8 @@ modules:
         # riscv needs a bit more isr stack.
         isr_stacksize_required_default: "4096"
         RUSTFLAGS:
+          # this might be needed for backtraces. it is needed for probe-rs.
+          - -C force-frame-pointers
           - --cfg context=\"riscv\"
           - -Clink-arg=-Tisr_stack.x
           - -Clink-arg=-Tlinkme-region-alias.x


### PR DESCRIPTION
# Description

As suggested by @MabezDev, don't enable force-frame-pointers on xtensa.

<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
