### PR TITLE
fix(typo): typo in network examples

### DIFF
--- a/examples/http-client/README.md
+++ b/examples/http-client/README.md
@@ -17,4 +17,4 @@ A GET request will be made every 3 seconds, even in case of failure and the
 response body will be printed as a string, along with some relevant HTTP
 response headers.
 
-Look [here](../README.md#networking) or more information about network configuration.
+Look [here](../README.md#networking) for more information about network configuration.

--- a/examples/http-server/README.md
+++ b/examples/http-server/README.md
@@ -15,4 +15,4 @@ expose a JSON endpoint at <http://10.42.0.61/button> reporting on the state of
 a connected push button if present, otherwise the endpoint will not be exposed
 at all.
 
-Look [here](../README.md#networking) or more information about network configuration.
+Look [here](../README.md#networking) for more information about network configuration.

--- a/examples/tcp-echo/README.md
+++ b/examples/tcp-echo/README.md
@@ -18,4 +18,4 @@ e.g., `telnet`:
 
     telnet 10.42.0.61 1234
 
-Look [here](../README.md#networking) or more information about network configuration.
+Look [here](../README.md#networking) for more information about network configuration.

--- a/examples/udp-echo/README.md
+++ b/examples/udp-echo/README.md
@@ -14,4 +14,4 @@ In this directory, run
 With the device USB cable connected, a USB Ethernet device should pop up.
 Ariel OS will reply to ping requests on 10.42.0.61.
 
-Look [here](../README.md#networking) or more information about network configuration.
+Look [here](../README.md#networking) for more information about network configuration.


### PR DESCRIPTION
# Description

This fixes a typo in examples with networking, spotted by the code review in #1690 

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
