### PR TITLE
fix(rt): disable esp watchdog in init()

### DIFF
--- a/src/ariel-os-rt/src/xtensa.rs
+++ b/src/ariel-os-rt/src/xtensa.rs
@@ -7,7 +7,30 @@ fn main() -> ! {
     crate::startup();
 }
 
-pub fn init() {}
+pub fn init() {
+    disable_watchdog();
+}
+
+// Disables the esp watchdogs.
+//
+// `esp-hal::init()` actually does this already, but our initial stack painting needs to run before
+// that, and with some log messages before that, it takes enough time to trigger the watchdog and
+// reboot.
+fn disable_watchdog() {
+    ariel_os_debug::log::debug!("ariel-os-rt: disabling watchdog timers");
+    // RTC domain must be enabled before we try to disable
+    // SAFETY: creating an LPWR instance out of thin air here, dropping it later.
+    let mut rtc = unsafe { esp_hal::rtc_cntl::Rtc::new(esp_hal::peripherals::LPWR::steal()) };
+
+    // Disable watchdog timers
+    #[cfg(not(any(context = "esp32", context = "esp32s2")))]
+    rtc.swd.disable();
+
+    rtc.rwdt.disable();
+
+    esp_hal::timer::timg::Wdt::<esp_hal::peripherals::TIMG0<'static>>::new().disable();
+    esp_hal::timer::timg::Wdt::<esp_hal::peripherals::TIMG1<'static>>::new().disable();
+}
 
 /// Returns the current stack pointer register value
 pub(crate) fn sp() -> usize {


### PR DESCRIPTION
# Description

It seems like with some output and the initial stack painting, the esp wdt (enabled by the bootloader IIUC) triggers before `esp_hal::init()` disables it. So, disable it early.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
