### PR TITLE
fix: set TARGET_CC and TARGET_CFLAGS for our Xtensa targets

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -484,8 +484,8 @@ contexts:
       CARGO_TARGET_PREFIX: CARGO_TARGET_XTENSA_ESP32S3_NONE_ELF
       CC: xtensa-esp32s3-elf-gcc
       CARGO_ENV:
-      - TARGET_CC="${CC}"
-      - TARGET_CFLAGS="${CFLAGS}"
+        - TARGET_CC="${CC}"
+        - TARGET_CFLAGS="${CFLAGS}"
 
   - name: esp32s3fx8
     parent: esp32s3


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This PR set `TARGET_CC` and `TARGET_CFLAGS` explicitly for our 3 xtensa targets (`esp32`, `esp32s2` and `esp32s3`).
This means that applications that use C dependencies compiled with the `cc` or `cmake` crates will now correctly compile.
## Testing

Trying to compile the following code (by copying it in any example) should fail on main and work with this PR for all three above targets
```rust
#![no_main]
#![no_std]

use ariel_os::debug::{ExitCode, exit, log::*};
use core::ffi::c_char;
// This is needed for the C code to be compiled. Otherwise the build will fail at the linking stage 
// because the symbol `snprintf` is never defined
extern crate tinyrlibc;

unsafe extern "C" {
    fn snprintf(buf: *mut c_char, len: usize, fmt: *const c_char, ...) -> i32;
}

#[ariel_os::task(autostart)]
async fn main() {
    info!("Hello World!");

    let mut buf: [c_char; 256] = [0; 256];
    let fmt: c_char = 61;

    unsafe {
        snprintf(buf.as_mut_ptr(), 256, &fmt);
    }
    exit(ExitCode::SUCCESS);
}
```
`tinyrlibc = "*"` needs to be added to the `Cargo.toml`. 

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
