### PR TITLE
fix(esp): pull in and adapt upstream `CompatSemaphore` impl

### DIFF
--- a/src/ariel-os-esp/src/wifi/esp_wifi.rs
+++ b/src/ariel-os-esp/src/wifi/esp_wifi.rs
@@ -1,4 +1,5 @@
 mod scheduler;
+mod semaphore;
 mod wait_queue;
 
 use ariel_os_debug::log::{debug, info};
@@ -11,7 +12,7 @@ use esp_radio::wifi::{
 use esp_radio_rtos_driver::{
     queue::CompatQueue, register_queue_implementation, register_scheduler_implementation,
     register_semaphore_implementation, register_timer_implementation,
-    register_wait_queue_implementation, semaphore::CompatSemaphore, timer::CompatTimer,
+    register_wait_queue_implementation, timer::CompatTimer,
 };
 
 use scheduler::ArielScheduler;
@@ -74,6 +75,6 @@ async fn connection(mut controller: WifiController<'static>) {
 
 register_scheduler_implementation!(static SCHEDULER: ArielScheduler = ArielScheduler{});
 register_wait_queue_implementation!(ArielWaitQueue);
-register_semaphore_implementation!(CompatSemaphore);
+register_semaphore_implementation!(semaphore::CompatSemaphore);
 register_timer_implementation!(CompatTimer);
 register_queue_implementation!(CompatQueue);

--- a/src/ariel-os-esp/src/wifi/esp_wifi/semaphore.rs
+++ b/src/ariel-os-esp/src/wifi/esp_wifi/semaphore.rs
@@ -1,0 +1,402 @@
+// taken from upstream esp_radio_rtos_driver, modified to use Ariel's `WaitQueue` directly.
+// Source: https://github.com/esp-rs/esp-hal/blob/f5a5a408bf117e116fd16485706477352824aa30/esp-radio-rtos-driver/src/semaphore.rs#L450
+// (Apache 2.0/MIT)
+//
+// This is mostly changing `CompatSemaphore::take_with_deadline()` to use Ariel's
+// `wait_until_with_check()`.
+// Upstream version was holding a critical section while initiating
+// `WaitQueue::with_timeout()`, which doesn't work with Ariel's `WaitQueue` implementation.
+// The actual change to `CompatSemaphore::take_with_deadline()` is pretty small. It required moving
+// the waitqueue handle (`waiting`) out of `inner` into the main `CompatSemaphore` struct.
+
+// Unfortunately upstream doesn't provide safety comments.
+#![expect(unsafe_code)]
+
+use alloc::boxed::Box;
+use core::ptr::NonNull;
+
+use ariel_os_debug::log::{debug, trace};
+use ariel_os_threads::sync::WaitQueue;
+use esp_radio_rtos_driver::{
+    ThreadPtr, current_task, now,
+    semaphore::{SemaphoreImplementation, SemaphoreKind, SemaphorePtr},
+};
+use esp_sync::NonReentrantMutex;
+
+// SAFETY: These must match the upstream interface.
+unsafe extern "Rust" {
+    fn esp_rtos_task_priority(task: ThreadPtr) -> u32;
+    fn esp_rtos_set_task_priority(task: ThreadPtr, priority: u32);
+}
+
+/// # Safety
+///
+/// The task pointer must be valid and point to a task that was created using
+/// [`task_create`].
+#[inline]
+unsafe fn task_priority(task: ThreadPtr) -> u32 {
+    // Safety: function defined above must match upstream definition.
+    unsafe { esp_rtos_task_priority(task) }
+}
+
+/// # Safety
+///
+/// The task pointer must be valid and point to a task that was created using
+/// [`task_create`].
+#[inline]
+unsafe fn set_task_priority(task: ThreadPtr, priority: u32) {
+    // Safety: function defined above must match upstream definition.
+    unsafe { esp_rtos_set_task_priority(task, priority) }
+}
+
+enum SemaphoreInner {
+    Counting {
+        current: u32,
+        max: u32,
+    },
+    Mutex {
+        recursive: bool,
+        owner: Option<ThreadPtr>,
+        original_priority: u32,
+        lock_counter: u32,
+    },
+}
+
+impl SemaphoreInner {
+    fn try_take(&mut self) -> bool {
+        match self {
+            SemaphoreInner::Counting { current, .. } => {
+                if *current > 0 {
+                    *current -= 1;
+                    true
+                } else {
+                    false
+                }
+            }
+            SemaphoreInner::Mutex {
+                recursive,
+                owner,
+                lock_counter,
+                original_priority,
+                ..
+            } => {
+                let current = current_task();
+                if let Some(owner) = *owner {
+                    if owner == current && *recursive {
+                        *lock_counter += 1;
+                        true
+                    } else {
+                        // We can't lock the mutex. Make sure the mutex holder has a high enough
+                        // priority to avoid priority inversion.
+                        let current_priority = unsafe { task_priority(current) };
+                        let owner_priority = unsafe { task_priority(owner) };
+                        if owner_priority < current_priority {
+                            unsafe { set_task_priority(owner, current_priority) };
+                        }
+                        false
+                    }
+                } else {
+                    *owner = Some(current);
+                    *lock_counter += 1;
+                    *original_priority = unsafe { task_priority(current) };
+                    true
+                }
+            }
+        }
+    }
+
+    fn try_take_from_isr(&mut self) -> bool {
+        match self {
+            SemaphoreInner::Counting { current, .. } => {
+                if *current > 0 {
+                    *current -= 1;
+                    true
+                } else {
+                    false
+                }
+            }
+            SemaphoreInner::Mutex {
+                recursive,
+                owner,
+                lock_counter,
+                ..
+            } => {
+                // In an ISR context we don't have a current task, so we can't implement
+                // priority inheritance an we have to conjure up an owner.
+                let current = NonNull::dangling();
+                if let Some(owner) = owner {
+                    if *owner == current && *recursive {
+                        *lock_counter += 1;
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    *owner = Some(current);
+                    *lock_counter += 1;
+                    true
+                }
+            }
+        }
+    }
+
+    fn try_give(&mut self) -> bool {
+        match self {
+            SemaphoreInner::Counting { current, max, .. } => {
+                if *current < *max {
+                    *current += 1;
+                    true
+                } else {
+                    false
+                }
+            }
+            SemaphoreInner::Mutex {
+                owner,
+                lock_counter,
+                original_priority,
+                ..
+            } => {
+                let current = current_task();
+
+                if *owner == Some(current) && *lock_counter > 0 {
+                    *lock_counter -= 1;
+                    if *lock_counter == 0
+                        && let Some(owner) = owner.take()
+                    {
+                        unsafe { set_task_priority(owner, *original_priority) };
+                    }
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn try_give_from_isr(&mut self) -> bool {
+        match self {
+            SemaphoreInner::Counting { current, max, .. } => {
+                if *current < *max {
+                    *current += 1;
+                    true
+                } else {
+                    false
+                }
+            }
+            SemaphoreInner::Mutex {
+                owner,
+                lock_counter,
+                ..
+            } => {
+                let current = NonNull::dangling();
+                if *owner == Some(current) && *lock_counter > 0 {
+                    *lock_counter -= 1;
+                    if *lock_counter == 0 {
+                        *owner = None;
+                    }
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn current_count(&mut self) -> u32 {
+        match self {
+            SemaphoreInner::Counting { current, .. } => *current,
+            SemaphoreInner::Mutex { .. } => {
+                panic!("RecursiveMutex does not support current_count")
+            }
+        }
+    }
+}
+
+/// Semaphore and mutex primitives.
+pub struct CompatSemaphore {
+    inner: NonReentrantMutex<SemaphoreInner>,
+    waiting: WaitQueue,
+}
+
+unsafe impl Sync for CompatSemaphore {}
+
+impl CompatSemaphore {
+    /// Create a new counting semaphore.
+    fn new_counting(initial: u32, max: u32) -> Self {
+        CompatSemaphore {
+            inner: NonReentrantMutex::new(SemaphoreInner::Counting {
+                current: initial,
+                max,
+            }),
+            waiting: WaitQueue::new(),
+        }
+    }
+
+    /// Create a new mutex.
+    ///
+    /// If `recursive` is true, the mutex can be locked multiple times by the same task.
+    fn new_mutex(recursive: bool) -> Self {
+        CompatSemaphore {
+            inner: NonReentrantMutex::new(SemaphoreInner::Mutex {
+                recursive,
+                owner: None,
+                lock_counter: 0,
+                original_priority: 0,
+            }),
+            waiting: WaitQueue::new(),
+        }
+    }
+
+    unsafe fn from_ptr<'a>(ptr: SemaphorePtr) -> &'a Self {
+        unsafe { ptr.cast::<Self>().as_ref() }
+    }
+
+    /// Try to take the semaphore.
+    ///
+    /// This is a non-blocking operation. The return value indicates whether the semaphore was
+    /// successfully taken.
+    fn try_take(&self) -> bool {
+        self.inner.with(|sem| sem.try_take())
+    }
+
+    /// Try to take the semaphore from an ISR.
+    ///
+    /// This is a non-blocking operation. The return value indicates whether the semaphore was
+    /// successfully taken.
+    fn try_take_from_isr(&self) -> bool {
+        self.inner.with(|sem| sem.try_take_from_isr())
+    }
+
+    /// Take the semaphore.
+    ///
+    /// This is a blocking operation.
+    ///
+    /// If the semaphore is already taken, the task will be blocked until the semaphore is
+    /// released. Recursive mutexes can be locked multiple times by the mutex owner
+    /// task.
+    fn take_with_deadline(&self, deadline: Option<u64>) -> bool {
+        let deadline = deadline.unwrap_or(u64::MAX);
+        let deadline_instant = embassy_time::Instant::from_micros(deadline);
+        loop {
+            // Ariel OS adaptation here:
+            let taken = self.waiting.wait_until_with_check(deadline_instant, |_cs| {
+                self.inner.with(|sem| sem.try_take())
+            });
+
+            if taken {
+                debug!("Semaphore - take - success");
+                return true;
+            }
+
+            if now() > deadline {
+                debug!("Semaphore - take - timed out");
+                return false;
+            }
+        }
+    }
+
+    /// Return the current count of the semaphore.
+    fn current_count(&self) -> u32 {
+        self.inner.with(|sem| sem.current_count())
+    }
+
+    /// Unlock the semaphore.
+    fn give(&self) -> bool {
+        self.inner.with(|sem| {
+            if sem.try_give() {
+                self.notify();
+                true
+            } else {
+                false
+            }
+        })
+    }
+
+    /// Try to unlock the semaphore from an ISR.
+    ///
+    /// The return value indicates whether the semaphore was successfully unlocked.
+    fn try_give_from_isr(&self, higher_priority_task_waken: Option<&mut bool>) -> bool {
+        self.inner.with(|sem| {
+            if sem.try_give_from_isr() {
+                self.notify_from_isr(higher_priority_task_waken);
+                true
+            } else {
+                false
+            }
+        })
+    }
+
+    fn notify(&self) {
+        trace!("Semaphore notify");
+        self.waiting.notify_one()
+    }
+
+    fn notify_from_isr(&self, _higher_prio_task_waken: Option<&mut bool>) {
+        trace!("Semaphore notify from ISR");
+        self.waiting.notify_one()
+    }
+}
+
+impl SemaphoreImplementation for CompatSemaphore {
+    fn create(kind: SemaphoreKind) -> SemaphorePtr {
+        let sem = Box::new(match kind {
+            SemaphoreKind::Counting { max, initial } => Self::new_counting(initial, max),
+            SemaphoreKind::Mutex => Self::new_mutex(false),
+            SemaphoreKind::RecursiveMutex => Self::new_mutex(true),
+        });
+        NonNull::from(Box::leak(sem)).cast()
+    }
+
+    unsafe fn delete(semaphore: SemaphorePtr) {
+        let sem = unsafe { Box::from_raw(semaphore.cast::<Self>().as_ptr()) };
+        core::mem::drop(sem);
+    }
+
+    unsafe fn take(semaphore: SemaphorePtr, timeout_us: Option<u32>) -> bool {
+        unsafe {
+            <Self as SemaphoreImplementation>::take_with_deadline(
+                semaphore,
+                timeout_us.map(|us| now() + us as u64),
+            )
+        }
+    }
+
+    unsafe fn take_with_deadline(semaphore: SemaphorePtr, deadline_instant: Option<u64>) -> bool {
+        let semaphore = unsafe { Self::from_ptr(semaphore) };
+
+        semaphore.take_with_deadline(deadline_instant)
+    }
+
+    unsafe fn give(semaphore: SemaphorePtr) -> bool {
+        let semaphore = unsafe { Self::from_ptr(semaphore) };
+
+        semaphore.give()
+    }
+
+    unsafe fn current_count(semaphore: SemaphorePtr) -> u32 {
+        let semaphore = unsafe { Self::from_ptr(semaphore) };
+
+        semaphore.current_count()
+    }
+
+    unsafe fn try_take(semaphore: SemaphorePtr) -> bool {
+        let semaphore = unsafe { Self::from_ptr(semaphore) };
+
+        semaphore.try_take()
+    }
+
+    unsafe fn try_give_from_isr(
+        semaphore: SemaphorePtr,
+        higher_priority_task_waken: Option<&mut bool>,
+    ) -> bool {
+        let semaphore = unsafe { Self::from_ptr(semaphore) };
+
+        semaphore.try_give_from_isr(higher_priority_task_waken)
+    }
+
+    unsafe fn try_take_from_isr(semaphore: SemaphorePtr, _hptw: Option<&mut bool>) -> bool {
+        let semaphore = unsafe { Self::from_ptr(semaphore) };
+
+        semaphore.try_take_from_isr()
+    }
+}

--- a/src/ariel-os-threads/src/sync/wait_queue.rs
+++ b/src/ariel-os-threads/src/sync/wait_queue.rs
@@ -66,6 +66,43 @@ impl WaitQueue {
         }
     }
 
+    /// Waits for this [`WaitQueue`] to be notified, with deadline and check fn (blocking).
+    ///
+    /// This function:
+    /// 1. calls `check()`
+    /// 2. if `check()` has returned true, returns true
+    /// 3. else, waits on `Self` until `deadline` (or notification)
+    /// 4. calls `check()` again, returns its result
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is called outside of a thread context.
+    pub fn wait_until_with_check(
+        &self,
+        deadline: embassy_time::Instant,
+        check: impl Fn(CriticalSection<'_>) -> bool,
+    ) -> bool {
+        ariel_os_debug::log::trace!("WaitQueue::wait_until_with_check()");
+        // Safety:
+        // `on_timeout` takes care of removing the thread from the threadlist.
+        unsafe {
+            crate::timeout::with_deadline_check(
+                deadline,
+                check,
+                |cs| {
+                    self.wait_cs(cs);
+                },
+                |cs| {
+                    ariel_os_debug::log::trace!("WaitQueue::wait_until_with_check() timeout");
+                    // Safety: the critical section is used to uphold aliasing rules.
+                    #[expect(unused_unsafe)]
+                    let waiters = unsafe { &mut *self.waiters.get() };
+                    waiters.remove_current(cs);
+                },
+            )
+        }
+    }
+
     /// Notify all waiters.
     pub fn notify_all(&self) {
         critical_section::with(|cs| {

--- a/src/ariel-os-threads/src/timeout.rs
+++ b/src/ariel-os-threads/src/timeout.rs
@@ -38,7 +38,7 @@ fn wake(ptr: *const ()) {
             }
         } else {
             ariel_os_debug::log::debug!(
-                "timer for {:?} now={:?} no deadline set)",
+                "timer for {:?} now={:?} (no deadline set)",
                 thread_id,
                 embassy_time_driver::now()
             );
@@ -143,6 +143,66 @@ pub(crate) unsafe fn with_deadline(
             on_timeout(cs)
         }
     })
+}
+
+/// Runs a custom wait function with check function.
+///
+/// 1. Calls `check()`. If that returns true, early out returning `true`
+/// 2. If `deadline` is in the past, return false
+/// 3. If `deadline` is in the future, set the thread's deadline and call `wait()`.
+/// 4. On return, if `deadline` has expired, call `on_timeout()`.
+/// 5. Call `check()`, return its result.
+///
+/// # Safety
+/// This will set the calling thread to `Runnable` after the timeout expires. Caller must ensure safety implications of that.
+pub(crate) unsafe fn with_deadline_check(
+    deadline: embassy_time::Instant,
+    check: impl Fn(CriticalSection<'_>) -> bool,
+    wait: impl FnOnce(CriticalSection<'_>),
+    on_timeout: impl FnOnce(CriticalSection<'_>),
+) -> bool {
+    let deadline = deadline.as_ticks();
+    let initial = critical_section::with(|cs| {
+        if check(cs) {
+            ariel_os_debug::log::debug!(
+                "with_deadline_check: initial check succeeded, early out for deadline={}",
+                deadline
+            );
+            Some(true)
+        } else if set_deadline(cs, deadline) {
+            ariel_os_debug::log::debug!(
+                "with_deadline_check: initial check failed, calling wait() for deadline={}",
+                deadline
+            );
+            wait(cs);
+            None
+        } else {
+            ariel_os_debug::log::debug!(
+                "with_deadline_check: initial check failed, deadline in past, early out for deadline={}",
+                deadline
+            );
+            Some(false)
+        }
+    });
+
+    match initial {
+        Some(val) => val,
+        None => critical_section::with(|cs| {
+            if clear_deadline(cs) {
+                ariel_os_debug::log::debug!(
+                    "with_deadline_check: timeout was not hit for deadline={}",
+                    deadline
+                );
+            } else {
+                ariel_os_debug::log::debug!(
+                    "with_deadline_check: timeout was hit for deadline={}, calling on_timeout",
+                    deadline
+                );
+                on_timeout(cs);
+            }
+            check(cs)
+        }),
+    }
 }
 
 /// Put the current thread to sleep for the given duration.


### PR DESCRIPTION
# Description

"The upstream Semaphore::take_with_deadline() calls our WaitQueue::wait_until() holding a critical section (through NonReentrantRawMutex), IIUC. The WaitQueue logic doesn't expect that, causing the call to never reschedule the calling thread."

This practically caused the esp-radio-rtos-driver timer thread to never trigger a timer.

Here's my branch where I'm trying to fix this.

I've copied over the upstream semaphore implementation and changed it to directly use our `WaitQueue` instead of going through the wrapper. I've then added a new `timeout::with_deadline()` variant that allows calling custom functions, which can be used to encode the "get semaphore with timeout" logic.

This PR should make WiFi work on Xtensa esp32(-s2, -s3). The RISC-V have some other issue still.

## Testing

My testing rig currently is `CONFIG_WIFI_NETWORK=foo CONFIG_WIFI_NETWORK=bar laze -Cexamples/http-client -b <some-esp-board> run`.

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

#1678

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

- [x] This seems to work fine on esp32 and esp32s3, but not at all on the c6. investigating. => turns out on esp risc-v there is another issue.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
