### PR TITLE
chore: update embassy HALs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-internal"
 version = "0.3.0"
-source = "git+https://github.com/ariel-os/embassy?rev=0feffeb3c90748112a64c6570a39e1251311accb#0feffeb3c90748112a64c6570a39e1251311accb"
+source = "git+https://github.com/ariel-os/embassy?rev=b292e1e2eaf54804c95e8cdc8bbcb11e03452538#b292e1e2eaf54804c95e8cdc8bbcb11e03452538"
 dependencies = [
  "cortex-m",
  "critical-section",

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -21,8 +21,8 @@ opt-level = 3
 # includes bt-hci 0.6.0 update
 cyw43 = { git = "https://github.com/ariel-os/embassy", rev = "603583d9" }
 
-# branch = "embassy-hal-internal-v0.3.0+ariel-os"
-embassy-hal-internal = { git = "https://github.com/ariel-os/embassy", rev = "0feffeb3c90748112a64c6570a39e1251311accb" }
+# branch = "embassy-hal-internal-v0.4.0+ariel-os"
+embassy-hal-internal = { git = "https://github.com/ariel-os/embassy", rev = "b292e1e2eaf54804c95e8cdc8bbcb11e03452538" }
 # branch = "embassy-nrf-v0.8.0+ariel-os"
 embassy-nrf = { git = "https://github.com/ariel-os/embassy", rev = "3940a79a29ae578a35625cae949bea473abf21d1" }
 # branch = "embassy-net-v0.7.1+ariel-os"


### PR DESCRIPTION
# Description

For #1696, I need the latest version of embassy-nrf (possibly even main, but at least 0.9). This would also be nice because it'll eventually pull in @nponsard's work on the RNGs for nRF91 and nRF53.

This is currently troublesome, as the only HAL that depends on hal-internal 0.4.0 has been released by embassy is stm32. (So we might actually consider whether we *can* get away with having different (patched) versions of that crate).

## Branches created for this

In our embassy clone at https://github.com/ariel-os/embassy:

* embassy-hal-internal-v0.4.0+ariel-os
* embassy-stm32-v0.5.0+ariel-os
* embassy-nrf-v0.9.0+ariel-os (actually a bit off topic b/c only post 0.9 the hal-internal 0.4 was used; still, good to have it, as cherry-picking the OptionalPeripherals commit needed manual merge conflict work)

## Testing

So far, this doesn't even build -- but at least STM32 gets past the point of not complaining about mismatched dependencies, "just" about no chip feture being selected, probably b/c the stm32 HAL update changed something there.

## Issues/PRs References

Contributes-to: #1696

## Open Questions

* [ ] Will it blend?

## Change Checklist

- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
