### PR TITLE
docs: do reference release blockers in release checklist

### DIFF
--- a/book/src/development-processes.md
+++ b/book/src/development-processes.md
@@ -76,6 +76,7 @@ We may also introduce a [custom criteria][cargo-vet-custom-criteria] to reflect 
 
 The following steps must be followed when preparing a new release of `ariel-os`:
 
+1. Verify there are no [release blocking bugs](https://github.com/ariel-os/ariel-os/issues?q=state%3Aopen%20label%3Arelease-blocker).
 1. Check whether deprecated items should be removed, if any.
 1. Update the version numbers of the crates that need to be bumped.
 


### PR DESCRIPTION
# Description

As discussed in todays' weekly, checking for release critical issues is part of the release process.

We did also discuss how to treat them when "just fix them" is not an issue (rougly "if we can't fix it but still want to release, make a note in the book where that feature is described and downgrade the severity"), but I don't think that those are mature enough to go into the docs.

## Change Checklist

- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- n/a I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
