### PR TITLE
ci(renovate): change configuration to reflect current patches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,23 +18,26 @@
     {
       // Disable renovate for the packages we have patches for
       "matchPackageNames": [
-        "embassy-embedded-hal",
-        "embassy-executor",
-        "embassy-executor-macros",
+        // embassy forks
+        "cyw43",
         "embassy-hal-internal",
         "embassy-nrf",
         "embassy-net",
         "embassy-rp",
         "embassy-stm32",
         "embassy-time",
+
+        // esp hal forks
         "esp-alloc",
+        "esp-bootloader-esp-idf",
         "esp-hal",
-        "esp-hal-embassy",
+        "esp-metadata-generated",
         "esp-println",
-        "esp-wifi",
-        "xtensa-lx-rt",
-        "try-lock",
-        "embedded-test"
+        "esp-radio",
+        "esp-radio-rtos-driver",
+        "esp-rom-sys",
+        "esp-sync",
+        "xtensa-lx-rt"
       ],
       "enabled": false
     },


### PR DESCRIPTION
# Description
This PR changes to renovate configuration to reflect our patches. 
This PR changes the package we disable renovate on. 
This PR is made directly from the main repo instead of a fork to reflect the procedure that renovate describes [here](https://docs.renovatebot.com/getting-started/installing-onboarding/#reconfigure-via-pr)
<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
