### PR TITLE
feat(boards): add green and blue LED channels to `nordic-thingy-91-x`

### DIFF
--- a/boards/nordic-thingy-91-x.yaml
+++ b/boards/nordic-thingy-91-x.yaml
@@ -4,6 +4,13 @@ boards:
     leds:
       led0:
         pin: P0_29
+        color: red
+      led1:
+        pin: P0_31
+        color: green
+      led2:
+        pin: P0_30
+        color: blue
     buttons:
       button0:
         pin: P0_26
@@ -13,6 +20,13 @@ boards:
     leds:
       led0:
         pin: P0_14
+        color: red
+      led1:
+        pin: P0_26
+        color: green
+      led2:
+        pin: P0_15
+        color: blue
     buttons:
       button0:
         pin: P0_24

--- a/src/ariel-os-boards/src/nordic-thingy-91-x-nrf5340-app.rs
+++ b/src/ariel-os-boards/src/nordic-thingy-91-x-nrf5340-app.rs
@@ -2,7 +2,9 @@
 
 pub mod pins {
     use ariel_os_hal::hal::peripherals;
-    ariel_os_hal::define_peripherals!(LedPeripherals { led0 : P0_14, });
+    ariel_os_hal::define_peripherals!(
+        LedPeripherals { led0 : P0_14, led1 : P0_26, led2 : P0_15, }
+    );
     ariel_os_hal::define_peripherals!(ButtonPeripherals { button0 : P0_24, });
 }
 #[allow(unused_variables)]

--- a/src/ariel-os-boards/src/nordic-thingy-91-x-nrf9151.rs
+++ b/src/ariel-os-boards/src/nordic-thingy-91-x-nrf9151.rs
@@ -2,7 +2,9 @@
 
 pub mod pins {
     use ariel_os_hal::hal::peripherals;
-    ariel_os_hal::define_peripherals!(LedPeripherals { led0 : P0_29, });
+    ariel_os_hal::define_peripherals!(
+        LedPeripherals { led0 : P0_29, led1 : P0_31, led2 : P0_30, }
+    );
     ariel_os_hal::define_peripherals!(ButtonPeripherals { button0 : P0_26, });
 }
 #[allow(unused_variables)]


### PR DESCRIPTION
# Description

This PR adds the pin information for the green and blue LED channels on the Nordic Thingy 91:X according to the [documentation](https://docs.nordicsemi.com/bundle/ug_thingy91x/page/UG/thingy91x/hw_description/leds.html). Currently, only the red channel is specified.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Follow to #1707.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
