### PR TITLE
docs(book): remove the pin on `espflash` in the Getting Started

### DIFF
--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -60,7 +60,7 @@ It explains how to compile and run the `hello-word` example to verify your setup
    ```sh
    cargo install espup --locked
    espup install
-   cargo install espflash@3.3.0 --locked
+   cargo install espflash --locked
    ```
 
    There is no need to actively source the `~/export-esp.sh` file which `espup` produces:


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
The appropriate descriptors are now provided since #1328, this removes the pin on espflash as it is now unnecessary:

https://github.com/ariel-os/ariel-os/blob/2cab2507aa0784e916a131641d9031f703880df1/src/ariel-os-esp/src/lib.rs#L10

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
