### PR TITLE
fix(esp): enable log on esp-radio-rtos-driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,6 +2741,7 @@ dependencies = [
  "cfg-if",
  "defmt 1.0.1",
  "esp-sync",
+ "log",
  "portable-atomic",
 ]
 

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -131,7 +131,7 @@ defmt = [
   "fugit?/defmt",
 ]
 ## Enables log support.
-log = ["esp-hal/log-04", "esp-radio?/log-04"]
+log = ["esp-hal/log-04", "esp-radio-rtos-driver?/log-04", "esp-radio?/log-04"]
 
 # Enables USB support.
 usb = []


### PR DESCRIPTION
# Description

This is a small error I found, it's handled when `defmt` is selected but not when `log` is selected

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

Check if an example using with build (or runs with #1698) while disabling `defmt` (will use `log` instead): 

```
laze -C examples/http-client/ build -b espressif-esp32-s3-devkitc-1 -d defmt
``` 

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
