### PR TITLE
build: make the MSRV 1.91 and bump the toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Install stable toolchain
         if: steps.should-skip.outputs.result != 'true'
         # configure MSRV here:
-        uses: dtolnay/rust-toolchain@1.90
+        uses: dtolnay/rust-toolchain@1.91.1
         with:
           targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,thumbv6m-none-eabi,thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf,thumbv8m.main-none-eabi,thumbv8m.main-none-eabihf
           # rust-src: Used for -Zbuild-std.
@@ -226,7 +226,7 @@ jobs:
         # No tag yet after https://github.com/esp-rs/xtensa-toolchain/pull/38 (will probably be @v1.5.5)
         uses: esp-rs/xtensa-toolchain@main
         with:
-          version: "1.90.0.0"
+          version: "1.91.1.0"
           buildtargets: esp32,esp32s2,esp32s3
           override: false
           export: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ default-members = ["examples/hello-world"]
 edition = "2024"
 # This should be the Ariel OS MSRV.
 # Some crates may have a different MSRV.
-rust-version = "1.90"
+rust-version = "1.91"
 repository = "https://github.com/ariel-os/ariel-os"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Multiple resources are available to learn Ariel OS:
 
 ## Minimum Supported Rust Version (MSRV) and Policy
 
-Ariel OS compiles with stable Rust version 1.90 and up.
+Ariel OS compiles with stable Rust version 1.91 and up.
 The MSRV can be increased in patch version updates.
 
 ## Security


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This bumps the MSRV to 1.91.
This is in particular required for #1653 to be able to compile the latest `reqwest` version, even though it is only used in an example.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
- I've grepped for `1.90` in the codebase, the other occurences are from sensor-related crates whose MSRV we don't want to bump.
- Successfully tested the `log` example on nrf52840dk and on espressif-esp32-s3-devkitc-1.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- The previous MSRV bump was #1593 for reference.

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog entry

<!-- changelog:begin -->
Ariel OS's MSRV is now 1.91. `laze build install-toolchain` can be used to update the toolchains.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
