### PR TITLE
fix(esp): enable idle threads on xtensa

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -827,6 +827,8 @@ modules:
       - esp32
       - esp32s2
       - esp32s3
+    selects:
+      - idle-threads # Needed to avoid a stack overflow with wifi https://github.com/ariel-os/ariel-os/issues/1721
     provides_unique:
       - cargo-toolchain
       - nightly
@@ -1599,6 +1601,13 @@ modules:
           - ${esp_wifi_heapsize_required}
         FEATURES:
           - ariel-os/wifi-esp
+
+  - name: idle-threads
+    help: create idle-threads to be taken when no other threads are ready
+    env:
+      global:
+        FEATURES:
+          - ariel-os/idle-threads
 
   - name: executor-thread
     help: use embassy executor within ariel-os-threads thread


### PR DESCRIPTION
# Description

This enables idle threads on xtensa to avoid issues where interrupts gets nested and lead to a stack overflow.

## Testing

Tested for 25 minutes using the procedure described in #1721

## Issues/PRs References

Fixes #1721 

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
