### PR TITLE
docs(examples): add tcp-client and threading-timers examples to the readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,7 @@ This directory contains example applications that showcase how to use Ariel OS.
 - [threading-channel/](./threading-channel): How to use `ariel_os::thread::sync::Channel` for passing messages between threads
 - [threading-event/](./threading-event): How to use `ariel_os::thread::sync::Event`
 - [threading-multicore/](./threading-multicore): Demonstrates basic threading on multicore
+- [threading-timers/](./threading-timers): Demonstrates how to use timers with threads
 - [udp-echo/](./udp-echo): UDP echo example
 - [usb-keyboard/](./usb-keyboard): USB HID example
 - [usb-serial/](./usb-serial): USB serial example


### PR DESCRIPTION
# Description

Both the tcp-client and the threading-timers examples are not mentioned in the README in the examples directory. This PR fixes that.

## Testing

Check if the urls work and the descriptions make sense

## Issues/PRs References

Follow-up to #1690 and #1552

## Open Questions

None

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
