### PR TITLE
refactor(esp): keep the app descriptor static private

### DIFF
--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -7,7 +7,9 @@
 #[cfg(feature = "wifi")]
 extern crate alloc;
 
-esp_bootloader_esp_idf::esp_app_desc!();
+mod app_desc {
+    esp_bootloader_esp_idf::esp_app_desc!();
+}
 
 pub mod gpio;
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This moves the `esp_app_desc!()` macro call introduced by #1328 into a private module to keep the generated static private.

## How to review this PR

The `ESP_APP_DESC` item no longer shows up in the docs of `ariel_os_esp` (accessible through `ariel_os::hal`).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested on espressif-esp32-c6-devkitc-1 and espressif-esp32-s3-devkitc-1 by flashing the `log` example. Removing the macro call does show an error:

```
ESP-IDF App Descriptor […] missing in your`esp-hal` application.
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
