### PR TITLE
docs(support): fix the case of the RP235xA chip name

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -62,7 +62,7 @@
   - [nRF9151](./chips/nrf9151.md)
   - [nRF9160](./chips/nrf9160.md)
   - [RP2040](./chips/rp2040.md)
-  - [RP235xa](./chips/rp235xa.md)
+  - [RP235xA](./chips/rp235xa.md)
   - [STM32C031C6](./chips/stm32c031c6.md)
   - [STM32F042K6](./chips/stm32f042k6.md)
   - [STM32F401RE](./chips/stm32f401re.md)

--- a/book/src/boards/raspberry-pi-pico-2-w.md
+++ b/book/src/boards/raspberry-pi-pico-2-w.md
@@ -10,7 +10,7 @@ For more information on laze builders, check out [this page](../build-system.md#
 ### `rpi-pico2-w`
 
 - **Tier:** 1
-- **Chip:** [RP235xa](../chips/rp235xa.md)
+- **Chip:** [RP235xA](../chips/rp235xa.md)
 - **Chip Ariel OS Name:** `rp235xa`
 
 To target this laze builder, run the following command in the root of your Ariel OS app:

--- a/book/src/boards/raspberry-pi-pico-2.md
+++ b/book/src/boards/raspberry-pi-pico-2.md
@@ -10,7 +10,7 @@ For more information on laze builders, check out [this page](../build-system.md#
 ### `rpi-pico2`
 
 - **Tier:** 1
-- **Chip:** [RP235xa](../chips/rp235xa.md)
+- **Chip:** [RP235xA](../chips/rp235xa.md)
 - **Chip Ariel OS Name:** `rp235xa`
 
 To target this laze builder, run the following command in the root of your Ariel OS app:

--- a/book/src/chips/index.md
+++ b/book/src/chips/index.md
@@ -33,7 +33,7 @@ Here is the list of supported chips in Ariel OS.
 ## Raspberry Pi
   
 - [RP2040](./rp2040.md)
-- [RP235xa](./rp235xa.md)
+- [RP235xA](./rp235xa.md)
 
 ## STMicroelectronics
   

--- a/book/src/chips/rp235xa.md
+++ b/book/src/chips/rp235xa.md
@@ -1,4 +1,4 @@
-# RP235xa
+# RP235xA
 
 ## Chip Info
 

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -252,7 +252,7 @@ chips:
       ble: not_available
 
   rp235xa:
-    name: RP235xa
+    name: RP235xA
     manufacturer: Raspberry Pi
     support:
       gpio: supported


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This makes the "A" in the RP235xA variant name uppercase in the hardware support documentation.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
