### PR TITLE
docs(esp): bring back the HAL-specific `peripherals` module

### DIFF
--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -48,8 +48,9 @@ pub mod wifi;
 #[doc(hidden)]
 pub mod peripheral {}
 
-#[doc(hidden)]
 pub mod peripherals {
+    //! Types for the peripheral singletons.
+
     pub use esp_hal::peripherals::*;
 }
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This brings back the `peripherals` module in the docs of `ariel_os_esp`. It seems it was mistakenly made [`doc(hidden)` in #1328](https://github.com/ariel-os/ariel-os/pull/1328/changes#diff-d1eed5d70d3c0eedc001ac1466ca991f4aecd656f7a1f5193d27b8641835df6dR49).

## How to review this PR

There [was such a module in v0.2.0](https://github.com/ariel-os/ariel-os/blob/8654c83505770800a3ea590e7b63ccd94e81a99c/src/ariel-os-esp/src/lib.rs#L47-L48), consistent with other HALs which have a similar `peripherals` module.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
It's a doc-only change.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
