### PR TITLE
refactor(gpio): use anonymous type parameters in constructors

### DIFF
--- a/src/ariel-os-hal/src/gpio.rs
+++ b/src/ariel-os-hal/src/gpio.rs
@@ -66,10 +66,7 @@ pub struct Input {
 
 impl Input {
     /// Returns a configured [`Input`].
-    pub fn new<T: IntoPeripheral<'static, P>, P: HalInputPin + 'static>(
-        pin: T,
-        pull: Pull,
-    ) -> Self {
+    pub fn new<P: HalInputPin + 'static>(pin: impl IntoPeripheral<'static, P>, pull: Pull) -> Self {
         Self::builder(pin, pull).build()
     }
 
@@ -319,8 +316,8 @@ pub struct Output {
 
 impl Output {
     /// Returns a configured [`Output`].
-    pub fn new<T: IntoPeripheral<'static, P>, P: HalOutputPin + 'static>(
-        pin: T,
+    pub fn new<P: HalOutputPin + 'static>(
+        pin: impl IntoPeripheral<'static, P>,
         initial_level: Level,
     ) -> Self {
         Self::builder(pin, initial_level).build()


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This replaces the generics introduced in #1328 on the `Input` and `Output` constructors to use anonymous type parameters instead. This keeps these constructors in line with what we had before, is arguably easier to read, and makes these constructors consistent with those of I2C, SPI, and UART as done in #1737 and similar.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested the following:

```sh
laze -C examples/gpio/ build -b nrf52840dk run
```


## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
