### PR TITLE
ci: add job to check if `changelog:skip` is respected

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,28 @@
+name: Check changelog
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, edited, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Check changelog label"
+        if: "!contains(github.event.pull_request.labels.*.name, 'changelog:skip')"
+        run: |
+          # The following regex looks for at least one line between the
+          # placeholders that contain a non whitespace character (or more).
+          # Using [\s\S] instead of . because it does not match newlines.
+          if ! echo "${GITHUB_EVENT_PULL_REQUEST_BODY}" | grep -q --null-data -P '<!-- changelog:begin -->[\s\S]*\n\S+[\s\S]*<!-- changelog:end -->'; then
+            echo 'The "changelog:skip" label is not attached, so a small entry that could be included in a changelog is required.'
+            echo 'You can ignore this if you are an external contributor.'
+            exit 1
+          fi
+        env:
+          GITHUB_EVENT_PULL_REQUEST_BODY: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
# Description

This PR adds a job in our CI to make sure that PRs that do not have the changelog:skip label have an changelog entry in the PR template.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html