### PR TITLE
docs(ble): enable ble in API docs

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -63,7 +63,7 @@ jobs:
       # faster generation.
       - name: Build rustdoc docs
         run: |
-          RUSTDOCFLAGS='--cfg nightly' cargo doc \
+          RUSTDOCFLAGS='--cfg nightly -Z unstable-options --extern-html-root-url trouble_host=https://docs.embassy.dev/trouble-host/0.5.0 ' cargo doc \
               --no-deps \
               -p ariel-os \
               -p coapcore \

--- a/src/ariel-os-embassy/src/ble.rs
+++ b/src/ariel-os-embassy/src/ble.rs
@@ -1,3 +1,14 @@
+//! Provides control over the system BLE stack.
+//!
+//! All interactions happen through the [`trouble_host::Stack`] struct that can be obtained using
+//! [`ble_stack()`].
+//!
+//! The address of the device is randomly generated at boot and may be rotated during execution.
+//!
+//! # Current implementation
+//!
+//! The address is not currently rotated during execution; however this behavior may not be relied upon.
+
 use trouble_host::{
     Address,
     prelude::{AddrKind, BdAddr},

--- a/src/ariel-os-hal/src/hal/dummy/ble.rs
+++ b/src/ariel-os-hal/src/hal/dummy/ble.rs
@@ -13,6 +13,14 @@ impl Peripherals {
     }
 }
 
+/// Returns the system BLE stack, [`trouble_host::Stack`].
+///
+/// # Panics
+///
+/// For this function to succeed, it can only be called from the system executor, and only once:
+///
+/// - Panics if the stack was already taken.
+/// - Panics when not called from the system executor.
 pub async fn ble_stack() -> &'static Stack<'static, DummyController, DefaultPacketPool> {
     async { unimplemented!() }.await
 }


### PR DESCRIPTION
# Description

Documents the ble module in the hosted api docs. This issue was found by @chrysn 

## Testing

Check the published docs for this PR and see that `ble` is available https://ariel-os-docs-preview-pr1763.surge.sh/dev/docs/api/ariel_os/

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

Should trouble_host be reexported ?

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
