### PR TITLE
docs(esp): mark i2c on esp32s3 as supported

### DIFF
--- a/book/src/boards/espressif-esp32-s3-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-s3-devkitc-1.md
@@ -26,7 +26,7 @@ laze build -b espressif-esp32-s3-devkitc-1
 |Debug Output|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
 |GPIO|<span title="supported">✅</span>|
-|I2C Controller Mode|<span title="needs testing">🚦</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="supported">✅</span>|

--- a/book/src/boards/heltec-wifi-lora-32-v3.md
+++ b/book/src/boards/heltec-wifi-lora-32-v3.md
@@ -26,7 +26,7 @@ laze build -b heltec-wifi-lora-32-v3
 |Debug Output|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
 |GPIO|<span title="supported">✅</span>|
-|I2C Controller Mode|<span title="needs testing">🚦</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="not available on this piece of hardware">–</span>|

--- a/book/src/chips/esp32s3.md
+++ b/book/src/chips/esp32s3.md
@@ -11,7 +11,7 @@
 |Debug Output|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
 |GPIO|<span title="supported">✅</span>|
-|I2C Controller Mode|<span title="needs testing">🚦</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="supported">✅</span>|
@@ -88,7 +88,7 @@ Boards using this chip.
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
@@ -109,7 +109,7 @@ Boards using this chip.
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>

--- a/book/src/chips/esp32s3fx8.md
+++ b/book/src/chips/esp32s3fx8.md
@@ -11,7 +11,7 @@
 |Debug Output|<span title="supported">✅</span>|
 |Logging|<span title="supported">✅</span>|
 |GPIO|<span title="supported">✅</span>|
-|I2C Controller Mode|<span title="needs testing">🚦</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="needs testing">🚦</span>|

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -97,7 +97,7 @@
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
@@ -691,7 +691,7 @@
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="needs testing">🚦</td>
+		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -469,7 +469,7 @@ chips:
       gpio: supported
       debug_output: supported
       hwrng: supported
-      i2c_controller: needs_testing
+      i2c_controller: supported
       spi_main: needs_testing
       uart: supported
       logging: supported
@@ -489,7 +489,7 @@ chips:
       gpio: supported
       debug_output: supported
       hwrng: supported
-      i2c_controller: needs_testing
+      i2c_controller: supported
       spi_main: needs_testing
       uart: supported
       logging: supported


### PR DESCRIPTION
# Description

1. Did a quick test using my fosdem demo with an sht31 on the esp32-s3-devkit

<!-- A summary of your changes and why you made them. -->

## Testing

I used https://github.com/kaspar030/hello-fosdem-2026, modified to use `GPIO16` and `GPIO17` for i2c on esp32s3. This is based on Ariel OS commit 90f0d025 (`main` from a couple of days ago).

```
// ...
I (137) boot: Disabling RNG early entropy source...                                                                                                            
[INFO ] temp: 23.8 °C, rel. hum.: 36.2 %                                                                                                                       
 (hello_fosdem hello-fosdem/src/main.rs:89)                                                                                                                    
```

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Supersedes https://github.com/ariel-os/ariel-os/pull/1762.

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(ESP32-S3) I2C is now marked as supported on this MCU.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
