### PR TITLE
build(doc): add laze task to generate documentation

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -2020,14 +2020,14 @@ builders:
           - >-
             cargo doc
             --no-deps
+            -p ariel-os-stm32
             --features "
                 embassy-stm32/stm32wb55rg,
                 external-interrupts,
                 i2c,
                 spi,
                 uart,
-                "
-            -p ariel-os-stm32 $@
+                " $@
 
   - name: bbc-microbit
     parent: bbc-microbit-base


### PR DESCRIPTION
# Description

This adds tasks to laze to generate the documentation with the same settings as done currently by the CI. This makes it easier to generate documentation locally, the magic incantation doesn't have to be grabbed from the CI files anymore. For example `laze build doc --open` builds and opens the api docs.

Next step is to use these tasks also in the CI, to guarantee the same process is used.

The esp documentation ends up in `./target/riscv…/doc`. I haven't found a good way to have it also end up in the same directory as the rest. `mv` would be a crude solution, but currently `laze build doc-esp --open` works, and adding the `mv` would break that

## Testing

Added tasks that need a look
 - `laze build doc`
 - `laze build doc-esp`
 - `laze build doc-nrf`
 - `laze build doc-rp`
 - `laze build doc-stm32`

## Issues/PRs References

None

## Open Questions

None

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Building documentation locally is now possible via `laze build doc`. Documentation for microcontroller families can now be built by appending the family name: `laze build doc-esp`.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
