### PR TITLE
feat(examples): Add USB ethernet option to the http-server example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
  "embassy-nrf",
  "embassy-stm32",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embassy-time-queue-utils",
  "embassy-usb",
  "embedded-hal 1.0.0",
@@ -316,7 +316,7 @@ dependencies = [
  "const-sha1",
  "defmt 1.0.1",
  "embassy-executor",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "fugit",
@@ -423,7 +423,7 @@ dependencies = [
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-net-tuntap",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-hal-async",
  "getrandom 0.2.16",
  "rand 0.9.2",
@@ -538,7 +538,7 @@ dependencies = [
  "ariel-os-sensors",
  "ariel-os-sensors-utils",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-hal-async",
  "portable-atomic",
 ]
@@ -551,7 +551,7 @@ dependencies = [
  "ariel-os-sensors",
  "ariel-os-sensors-utils",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-hal-async",
  "portable-atomic",
 ]
@@ -567,7 +567,7 @@ dependencies = [
  "embassy-executor",
  "embassy-futures",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-hal-async",
  "portable-atomic",
 ]
@@ -607,7 +607,7 @@ version = "0.1.0"
 dependencies = [
  "ariel-os-sensors",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "portable-atomic",
 ]
 
@@ -648,7 +648,7 @@ dependencies = [
  "arrayvec",
  "cfg-if",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-storage-async",
  "postcard",
  "sequential-storage",
@@ -670,7 +670,7 @@ dependencies = [
  "critical-section",
  "defmt 1.0.1",
  "embassy-rp",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embassy-time-driver",
  "esp-hal",
  "linkme",
@@ -1671,7 +1671,7 @@ dependencies = [
  "embassy-futures",
  "embassy-net-driver-channel",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-hal 1.0.0",
  "embedded-io-async 0.6.1",
  "futures",
@@ -1950,6 +1950,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "edge-dhcp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ccd3a181a33c710e07c3f04623d7a11e9969b1e44a7276ead7873b049720cb"
+dependencies = [
+ "edge-nal",
+ "edge-raw",
+ "embassy-futures",
+ "embassy-time 0.4.0",
+ "heapless 0.8.0",
+ "num_enum 0.7.3",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "edge-nal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac19c3edcdad839c71cb919cd09a632d9915d630760b37f0b74290188c08f248"
+dependencies = [
+ "embassy-time 0.4.0",
+ "embedded-io-async 0.6.1",
+]
+
+[[package]]
+name = "edge-nal-embassy"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252f89adf4f0016631977bec3ba50d768263a3a9fa9f023b4087088a619568ce"
+dependencies = [
+ "edge-nal",
+ "embassy-futures",
+ "embassy-net",
+ "embedded-io-async 0.6.1",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "edge-raw"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6207c84e9bc8df8ef3c155196df290f2a51f010bd60c2e78366e51979988bdb5"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,7 +2028,7 @@ dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -2053,7 +2097,7 @@ dependencies = [
  "document-features",
  "embassy-net-driver",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-io-async 0.6.1",
  "embedded-nal-async",
  "heapless 0.8.0",
@@ -2108,7 +2152,7 @@ dependencies = [
  "embassy-embedded-hal",
  "embassy-hal-internal",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embassy-time-driver",
  "embassy-time-queue-utils",
  "embassy-usb-driver",
@@ -2142,7 +2186,7 @@ dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embassy-time-driver",
  "embassy-time-queue-utils",
  "embassy-usb-driver",
@@ -2187,7 +2231,7 @@ dependencies = [
  "embassy-hal-internal",
  "embassy-net-driver",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embassy-time-driver",
  "embassy-time-queue-utils",
  "embassy-usb-driver",
@@ -2243,6 +2287,22 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "heapless 0.8.0",
+]
+
+[[package]]
+name = "embassy-time"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "document-features",
+ "embassy-time-driver",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "futures-util",
 ]
 
 [[package]]
@@ -3689,6 +3749,9 @@ version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
+ "edge-dhcp",
+ "edge-nal",
+ "edge-nal-embassy",
  "embassy-sync 0.7.2",
  "picoserve",
  "serde",
@@ -4731,7 +4794,7 @@ dependencies = [
  "const-sha1",
  "data-encoding",
  "embassy-net",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-io-async 0.6.1",
  "futures-util",
  "heapless 0.8.0",
@@ -5795,7 +5858,7 @@ source = "git+https://codeberg.org/AudaciousAxiom/stm32-lcd-driver.git?rev=7ebcb
 dependencies = [
  "critical-section",
  "embassy-stm32",
- "embassy-time",
+ "embassy-time 0.5.0",
  "stm32-metapac",
 ]
 
@@ -6254,7 +6317,7 @@ dependencies = [
  "defmt 1.0.1",
  "embassy-futures",
  "embassy-sync 0.7.2",
- "embassy-time",
+ "embassy-time 0.5.0",
  "embedded-io 0.6.1",
  "futures",
  "heapless 0.9.1",

--- a/examples/http-server/Cargo.toml
+++ b/examples/http-server/Cargo.toml
@@ -7,6 +7,11 @@ publish = false
 [dependencies]
 ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
+edge-dhcp = { version = "0.6", optional = true }
+edge-nal = { version = "0.5", optional = true }
+edge-nal-embassy = { version = "0.6", default-features = false, features = [
+  "all",
+], optional = true }
 embassy-sync = { workspace = true }
 picoserve = { version = "0.14.1", default-features = false, features = [
   "embassy",
@@ -15,6 +20,7 @@ serde = { workspace = true, optional = true }
 
 [features]
 button-reading = ["dep:serde"]
+dhcp-server = ["dep:edge-dhcp", "dep:edge-nal", "dep:edge-nal-embassy"]
 
 [lints]
 workspace = true

--- a/examples/http-server/README.md
+++ b/examples/http-server/README.md
@@ -15,4 +15,13 @@ expose a JSON endpoint at <http://10.42.0.61/button> reporting on the state of
 a connected push button if present, otherwise the endpoint will not be exposed
 at all.
 
+## Using USB Ethernet
+
+You can run this example with USB Ethernet by running
+
+    laze build -b esp32-s3-devkitc-1 -s use-usb-ethernet run
+
+This will configure the example to set up a DHCP server for the connected PC. The
+device will have a static IP address, and will serve the HTML site at <http://10.42.0.61/>.
+
 Look [here](../README.md#networking) for more information about network configuration.

--- a/examples/http-server/laze.yml
+++ b/examples/http-server/laze.yml
@@ -20,3 +20,13 @@ modules:
       global:
         FEATURES:
           - button-reading
+
+  - name: use-usb-ethernet
+    selects:
+      - usb-ethernet
+      - network-config-ipv4-static
+    env:
+      global:
+        network_max_concurrent_sockets: "5"
+        FEATURES:
+          - dhcp-server

--- a/examples/http-server/src/main.rs
+++ b/examples/http-server/src/main.rs
@@ -49,6 +49,41 @@ async fn web_task(task_id: usize, app: &'static picoserve::Router<routes::AppRou
     .await
 }
 
+#[cfg(feature = "dhcp-server")]
+#[ariel_os::task]
+async fn dhcp_server_task() {
+    let stack = net::network_stack().await.unwrap();
+    use core::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    use edge_dhcp::io::{self, DEFAULT_SERVER_PORT};
+    use edge_dhcp::server::{Server, ServerOptions};
+    use edge_nal::UdpBind;
+    use edge_nal_embassy::{Udp, UdpBuffers};
+
+    let mut buf = [0; 1500];
+    let udp_socket_buffers = UdpBuffers::<1, 1472, 1472, 2>::new();
+    let ip = Ipv4Addr::new(192, 168, 2, 1);
+    let mut gw_buf = [Ipv4Addr::UNSPECIFIED];
+
+    let udp = Udp::new(stack, &udp_socket_buffers);
+
+    let mut socket = udp
+        .bind(SocketAddr::V4(SocketAddrV4::new(
+            Ipv4Addr::UNSPECIFIED,
+            DEFAULT_SERVER_PORT,
+        )))
+        .await
+        .unwrap();
+
+    io::server::run(
+        &mut Server::<_, 64>::new_with_et(ip), // Will give IP addresses in the range 10.42.0.50 - 10.42.0.200, subnet 255.255.255.0
+        &ServerOptions::new(ip, Some(&mut gw_buf)),
+        &mut socket,
+        &mut buf,
+    )
+    .await
+    .unwrap();
+}
+
 #[ariel_os::spawner(autostart, peripherals)]
 fn main(spawner: Spawner, peripherals: Peripherals) {
     #[cfg(feature = "button-reading")]
@@ -63,6 +98,11 @@ fn main(spawner: Spawner, peripherals: Peripherals) {
     let _ = peripherals;
 
     let app = APP.init_with(|| routes::AppBuilder.build_app());
+
+    #[cfg(feature = "dhcp-server")]
+    {
+        spawner.spawn(dhcp_server_task()).unwrap();
+    }
 
     for task_id in 0..WEB_TASK_POOL_SIZE {
         spawner.spawn(web_task(task_id, app)).unwrap();

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -52,6 +52,7 @@ contexts:
           CARGO_TARGET_DIR=${relroot}/${build-dir}/bin/${builder}/cargo
           CONFIG_EXECUTOR_STACKSIZE=${CONFIG_EXECUTOR_STACKSIZE}
           CONFIG_ISR_STACKSIZE=${CONFIG_ISR_STACKSIZE}
+          CONFIG_NETWORK_MAX_CONCURRENT_SOCKETS=${CONFIG_NETWORK_MAX_CONCURRENT_SOCKETS}
       PROFILE: release
       PROFILE_DIR: $(if("${PROFILE}"=="dev", "debug", "${PROFILE}"))
       QEMU_SYSTEM_ARM: >-
@@ -76,6 +77,12 @@ contexts:
         - ${isr_stacksize_required_default}
       CONFIG_EXECUTOR_STACKSIZE: $(max (0, ${executor_stacksize_required}))
       CONFIG_ISR_STACKSIZE: $(max (0, ${isr_stacksize_required}))
+
+      # Network config
+      network_max_concurrent_sockets_default: "4"
+      network_max_concurrent_sockets:
+        - ${network_max_concurrent_sockets_default}
+      CONFIG_NETWORK_MAX_CONCURRENT_SOCKETS: $(max (4, ${network_max_concurrent_sockets}))
 
     var_options:
       # this turns ${FEATURES} from a list to "--features=feature1,feature2"


### PR DESCRIPTION
This PR adds the `use-usb-ethernet` module to the http-server example. The module selects the usb-ethernet network interface and configures the device to use a static IP, and starts a DHCP server so the host side can get an IP.