### PR TITLE
docs(esp): Mark USB ethernet supported on ESP32-Sx

### DIFF
--- a/book/src/boards/espressif-esp32-s2-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-s2-devkitc-1.md
@@ -31,7 +31,7 @@ laze build -b espressif-esp32-s2-devkitc-1
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="supported">✅</span>|
-|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="not available on this piece of hardware">–</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|

--- a/book/src/boards/espressif-esp32-s3-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-s3-devkitc-1.md
@@ -31,7 +31,7 @@ laze build -b espressif-esp32-s3-devkitc-1
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="supported">✅</span>|
-|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|

--- a/book/src/boards/heltec-wifi-lora-32-v3.md
+++ b/book/src/boards/heltec-wifi-lora-32-v3.md
@@ -31,7 +31,7 @@ laze build -b heltec-wifi-lora-32-v3
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="not available on this piece of hardware">–</span>|
-|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|

--- a/book/src/chips/esp32s2.md
+++ b/book/src/chips/esp32s2.md
@@ -15,7 +15,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="supported">✅</span>|
-|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="not available on this piece of hardware">–</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
@@ -92,7 +92,7 @@ Boards using this chip.
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="supported">✅</td>

--- a/book/src/chips/esp32s2fx2.md
+++ b/book/src/chips/esp32s2fx2.md
@@ -15,7 +15,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="supported">✅</span>|
-|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="not available on this piece of hardware">–</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|

--- a/book/src/chips/esp32s2fx4.md
+++ b/book/src/chips/esp32s2fx4.md
@@ -15,7 +15,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="supported">✅</span>|
-|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="not available on this piece of hardware">–</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|

--- a/book/src/chips/esp32s2fx4r2.md
+++ b/book/src/chips/esp32s2fx4r2.md
@@ -15,7 +15,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="supported">✅</span>|
-|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="not available on this piece of hardware">–</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|

--- a/book/src/chips/esp32s3.md
+++ b/book/src/chips/esp32s3.md
@@ -15,7 +15,7 @@
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
 |User USB|<span title="supported">✅</span>|
-|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|
@@ -92,7 +92,7 @@ Boards using this chip.
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="supported">✅</td>
@@ -113,7 +113,7 @@ Boards using this chip.
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="supported">✅</td>

--- a/book/src/chips/esp32s3fx8.md
+++ b/book/src/chips/esp32s3fx8.md
@@ -14,8 +14,8 @@
 |I2C Controller Mode|<span title="supported">✅</span>|
 |SPI Main Mode|<span title="needs testing">🚦</span>|
 |UART|<span title="supported">✅</span>|
-|User USB|<span title="needs testing">🚦</span>|
-|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|User USB|<span title="supported">✅</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
 |Wi-Fi|<span title="supported">✅</span>|
 |Bluetooth Low Energy|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |Hardware Random Number Generator|<span title="supported">✅</span>|

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -101,7 +101,7 @@
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="supported">✅</td>
@@ -695,7 +695,7 @@
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="supported">✅</td>
@@ -716,7 +716,7 @@
 		  <td class="support-cell" title="needs testing">🚦</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="not available on this piece of hardware">–</td>
-		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
 		  <td class="support-cell" title="supported">✅</td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -382,9 +382,8 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      user_usb:
-        status: supported
-      ethernet_over_usb: not_currently_supported
+      user_usb: supported
+      ethernet_over_usb: supported
       wifi: supported
       ble: not_available
 
@@ -404,9 +403,8 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      user_usb:
-        status: supported
-      ethernet_over_usb: not_currently_supported
+      user_usb: supported
+      ethernet_over_usb: supported
       wifi: supported
       ble: not_available
 
@@ -426,9 +424,8 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      user_usb:
-        status: supported
-      ethernet_over_usb: not_currently_supported
+      user_usb: supported
+      ethernet_over_usb: supported
       wifi: supported
       ble: not_available
 
@@ -448,9 +445,8 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      user_usb:
-        status: supported
-      ethernet_over_usb: not_currently_supported
+      user_usb: supported
+      ethernet_over_usb: supported
       wifi: supported
       ble: not_available
 
@@ -469,7 +465,8 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      ethernet_over_usb: not_currently_supported
+      user_usb: supported
+      ethernet_over_usb: supported
       wifi: supported
       ble: not_currently_supported
 
@@ -489,8 +486,8 @@ chips:
         status: not_currently_supported
         comments:
           - requires partitioning support
-      user_usb: needs_testing # This should be moved to a board when one is added.
-      ethernet_over_usb: not_currently_supported
+      user_usb: supported
+      ethernet_over_usb: supported
       wifi: supported
       ble: not_currently_supported
 
@@ -987,13 +984,13 @@ builders:
     chip: esp32s3
     tier: "1"
     support:
-      user_usb: supported
 
   heltec-wifi-lora-32-v3:
     chip: esp32s3
     tier: "3"
     support:
       user_usb: not_available
+      ethernet_over_usb: not_available
 
   seeedstudio-xiao-esp32c6:
     chip: esp32c6fx4

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1370,9 +1370,6 @@ modules:
       - network_device
     selects:
       - usb
-    conflicts:
-      # there is an issue on esp32s3, the only esp32 that we have usb support for.
-      - xtensa
     env:
       global:
         FEATURES:


### PR DESCRIPTION
Tested using https://github.com/ariel-os/ariel-os/pull/1784 on both S2 and S3 DevKitC-1 boards

## Changelog Entry

<!-- changelog:begin -->
(ESP32) USB CDC-NCM (Ethernet over USB) is now supported on ESP32-S2 and ESP32-S3.
<!-- changelog:end -->