### PR TITLE
docs(github): avoid flip-flop on PR checkbox between orderly fixups and squashing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,10 +46,11 @@ Please make sure that:
 - The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
   - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
 -->
-- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
+- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
 - [ ] I have followed the [Coding Conventions][coding-conventions].
 - [ ] I have tested and performed a self-review of my own code.
 - [ ] I have made corresponding changes to the documentation.
 
 [conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
 [coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
+[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash


### PR DESCRIPTION
# Description

As [recently discussed](https://matrix.to/#/!cINbgbHLemsitmThSh:matrix.org/$1cbM61woxf2MHe2ASPFI9ODuLaCsH4nyZdduGR9yY08?via=matrix.org&via=utwente.io&via=fehler-in-der-matrix.de), the first PR checkbox's intention is not "are there, at present, fixup commits in the commit history" (which flip-flops through reviewing and rebasing), but "is the history clean enough that when CI is happy (i.e. no more fixups are there because they have been autosquashed), the commit messages are as they should be".

## Change Checklist

- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
