### PR TITLE
ci: autosquash before running Lint Commits

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -37,6 +37,7 @@ jobs:
           # Workaround-For: https://github.com/actions/checkout/issues/416
           git fetch origin "${GITHUB_BASE_REF}"
           git branch baseref origin/"${GITHUB_BASE_REF}"
+
           git config --global user.name "Committer of temporary autosquashes"
           git rebase baseref --autosquash --keep-base
 


### PR DESCRIPTION
# Description

Currently, whenever fixups/squashes are present, Lint Commits is not helpful in two ways:

* It always fails, and users won't even look into it because "sure it fails because there are fixups".
* Even if they look in it, they'll need to look hard between all the fixup complaints to find if evern, and then which, text upset the check.

By rebasing before checking, fixups are removed -- that does introduce a source of errors, but then, if the fixups don't autosquash, that *is* an error to be addressed anyway.

## Testing

No clue; just hope and verify later by observing behavior?

[edit, added]: Tested in this PR, [see comment](https://github.com/ariel-os/ariel-os/pull/1791#issuecomment-3926626950).

## Open questions

Can we do that for DCO as well? I don't even find where that is in our CI steps.

[edit, added]: [No](https://github.com/ariel-os/ariel-os/pull/1791#issuecomment-3877435783), that'll just stay red as long as we use GitHub's tools for it.

## Issues/PRs References

Workarund-for: https://github.com/crate-ci/committed/issues/392

(which didn't really have any satisfactory conclusion, but then I also didn't read all the comments)

## Change Checklist

- [x] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.

  self-review yes, I'd need help testing.

- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
