### PR TITLE
ci: Build documentation and book for older releases 

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -168,6 +168,26 @@ jobs:
           mdbook build
           mv book ../_site/dev/docs
 
+      - name: Checkout older docs and book
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: ariel-os/docs
+          ref: main
+          path: ./_older-docs
+
+      - name: Move older docs
+        if: github.event_name != 'pull_request'
+        run: |
+          for dir in ./_older-docs/tags/*/;
+          do
+            dir="${dir%*/}" # Remove trailing slash
+            tag="${dir##*/}" # Extract the release tag
+            mkdir -p "./_site/$tag/docs" # Create the directory for the versionned docs
+            mv "$dir/api" "./_site/$tag/docs/api" # Move the rustdoc API documentation
+            mv "$dir/book" "./_site/$tag/docs/book" # Move the book
+          done
+
       - name: Hash docs tree
         run: find ./_site -type f | xargs sha256sum | sha256sum > ./_hash && mv ./_hash ./_site/
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This PR changes the deploy docs CI to also retrieve the previous version located in [ariel-os/docs](https://github.com/ariel-os/docs). 

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Advances #1782 
<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->
* How are users expected to select between versions ? Currently, this can only be done manually by changing the `/dev/` in the URL to the correct tag. 

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->

<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
