### PR TITLE
feat(nrf): add support for cryptocell hwrng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
  "embedded-io 0.6.1",
  "embedded-io-async 0.6.1",
  "futures-intrusive",
- "heapless 0.8.0",
+ "heapless 0.9.1",
 ]
 
 [[package]]
@@ -1842,7 +1842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2218,8 +2218,8 @@ dependencies = [
 
 [[package]]
 name = "embassy-nrf"
-version = "0.8.0"
-source = "git+https://github.com/ariel-os/embassy?rev=3940a79a29ae578a35625cae949bea473abf21d1#3940a79a29ae578a35625cae949bea473abf21d1"
+version = "0.9.0"
+source = "git+https://github.com/nponsard/embassy-ariel?rev=fadbbb47002dbdad82f2ac192a3c8c9b6c02ddf2#fadbbb47002dbdad82f2ac192a3c8c9b6c02ddf2"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -2229,6 +2229,7 @@ dependencies = [
  "defmt 1.1.0",
  "document-features",
  "embassy-embedded-hal",
+ "embassy-futures",
  "embassy-hal-internal",
  "embassy-sync 0.7.2",
  "embassy-time",
@@ -4508,8 +4509,9 @@ dependencies = [
 [[package]]
 name = "nrf-mpsl"
 version = "0.3.0"
-source = "git+https://github.com/alexmoon/nrf-sdc?rev=e64ad081a6948b3439d1e811da36d39a5785dbda#e64ad081a6948b3439d1e811da36d39a5785dbda"
+source = "git+https://github.com/alexmoon/nrf-sdc?rev=d4d244d5ce21f59fa2263333cb1d8f2a5d997145#d4d244d5ce21f59fa2263333cb1d8f2a5d997145"
 dependencies = [
+ "cfg-if",
  "cortex-m",
  "defmt 1.1.0",
  "embassy-nrf",
@@ -4523,7 +4525,7 @@ dependencies = [
 [[package]]
 name = "nrf-mpsl-sys"
 version = "0.2.1"
-source = "git+https://github.com/alexmoon/nrf-sdc?rev=e64ad081a6948b3439d1e811da36d39a5785dbda#e64ad081a6948b3439d1e811da36d39a5785dbda"
+source = "git+https://github.com/alexmoon/nrf-sdc?rev=d4d244d5ce21f59fa2263333cb1d8f2a5d997145#d4d244d5ce21f59fa2263333cb1d8f2a5d997145"
 dependencies = [
  "bindgen 0.72.1",
  "doxygen-rs",
@@ -4531,9 +4533,8 @@ dependencies = [
 
 [[package]]
 name = "nrf-pac"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d334027d6703534f2a80de0794ae435c0e029358d28278533d3935e69b221b01"
+version = "0.2.0"
+source = "git+https://github.com/embassy-rs/nrf-pac.git?rev=074935b9b24ab302fe812f91725937f57cd082cf#074935b9b24ab302fe812f91725937f57cd082cf"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -4542,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "nrf-sdc"
 version = "0.4.0"
-source = "git+https://github.com/alexmoon/nrf-sdc?rev=e64ad081a6948b3439d1e811da36d39a5785dbda#e64ad081a6948b3439d1e811da36d39a5785dbda"
+source = "git+https://github.com/alexmoon/nrf-sdc?rev=d4d244d5ce21f59fa2263333cb1d8f2a5d997145#d4d244d5ce21f59fa2263333cb1d8f2a5d997145"
 dependencies = [
  "bt-hci",
  "critical-section",
@@ -4560,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "nrf-sdc-sys"
 version = "0.2.1"
-source = "git+https://github.com/alexmoon/nrf-sdc?rev=e64ad081a6948b3439d1e811da36d39a5785dbda#e64ad081a6948b3439d1e811da36d39a5785dbda"
+source = "git+https://github.com/alexmoon/nrf-sdc?rev=d4d244d5ce21f59fa2263333cb1d8f2a5d997145#d4d244d5ce21f59fa2263333cb1d8f2a5d997145"
 dependencies = [
  "bindgen 0.72.1",
  "doxygen-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ embassy-futures = { version = "0.1.2", default-features = false }
 embassy-hal-internal = { version = "0.3.0", default-features = false }
 embassy-net = { version = "0.9.1", default-features = false }
 embassy-net-driver-channel = { version = "0.3.2", default-features = false }
-embassy-nrf = { version = "0.8.0", default-features = false }
+embassy-nrf = { version = "0.9.0", default-features = false }
 embassy-rp = { version = "0.8", default-features = false }
 embassy-stm32 = { version = "0.4", default-features = false }
 embassy-sync = { version = "0.7.2", default-features = false }
@@ -184,7 +184,7 @@ trouble-host = { version = "0.5.0" }
 
 # nrf-sdc 0.4.0 has not been released, yet. need it for bt-hci 0.6 bump
 #nrf-sdc = { version = "0.4.0" }
-nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc", rev = "e64ad081a6948b3439d1e811da36d39a5785dbda" }
+nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc", rev = "d4d244d5ce21f59fa2263333cb1d8f2a5d997145" }
 
 futures-util = { version = "0.3.32", default-features = false }
 nrf-modem = { version = "0.10.2" }

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -23,8 +23,8 @@ cyw43 = { git = "https://github.com/ariel-os/embassy", rev = "603583d9" }
 
 # branch = "embassy-hal-internal-v0.3.0+ariel-os"
 embassy-hal-internal = { git = "https://github.com/ariel-os/embassy", rev = "0feffeb3c90748112a64c6570a39e1251311accb" }
-# branch = "embassy-nrf-v0.8.0+ariel-os"
-embassy-nrf = { git = "https://github.com/ariel-os/embassy", rev = "3940a79a29ae578a35625cae949bea473abf21d1" }
+# branch = "embassy-nrf-v0.9.0+ariel-os+cryptocell"
+embassy-nrf = { git = "https://github.com/nponsard/embassy-ariel", rev = "fadbbb47002dbdad82f2ac192a3c8c9b6c02ddf2" }
 # branch = "embassy-net-v0.9.1+ariel-os": backport of https://github.com/embassy-rs/embassy/pull/6195
 embassy-net = { git = "https://github.com/ariel-os/embassy", rev = "37683fe299f12028e5a77af9f742f496da08afcd" }
 # branch = "embassy-rp-v0.8.0+ariel-os"

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -266,6 +266,7 @@ contexts:
       - cortex-m33f
     provides:
       - has_storage_support
+      - has_hwrng
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
 
@@ -299,6 +300,7 @@ contexts:
     provides:
       - has_nrf91_modem
       - has_storage_support
+      - has_hwrng
     env:
       PROBE_RS_CHIP: nRF9160_xxAA
 
@@ -307,6 +309,7 @@ contexts:
     provides:
       - has_nrf91_modem
       - has_storage_support
+      - has_hwrng
     env:
       # FIXME: probe-rs does not support the nRF9151_xxAA yet, because there is
       # no CMSIS-Pack available

--- a/src/ariel-os-nrf/src/hwrng.rs
+++ b/src/ariel-os-nrf/src/hwrng.rs
@@ -20,6 +20,17 @@ pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {
 
             ariel_os_random::construct_rng(&mut ariel_os_random::RngAdapter(&mut rng));
         }
+        any(context = "nrf91", context = "nrf5340-app") => {
+            let p =
+                peripherals
+                    .CC_RNG
+                    .take()
+                    .expect("CC_RNG has not been previously used");
+
+            let mut cc_rng = embassy_nrf::cryptocell::rng::CcRng::new(p, Irqs);
+
+            ariel_os_random::construct_rng(&mut ariel_os_random::RngAdapter(&mut cc_rng));
+        }
         context = "ariel-os" => {
             compile_error!("hardware RNG is not supported on this MCU family");
         }

--- a/src/ariel-os-nrf/src/irqs.rs
+++ b/src/ariel-os-nrf/src/irqs.rs
@@ -5,8 +5,10 @@
 use embassy_nrf::bind_interrupts;
 
 bind_interrupts!(pub(crate) struct Irqs {
-    #[cfg(feature = "hwrng")]
+    #[cfg(all(feature = "hwrng", any(context = "nrf51", context = "nrf52", context = "nrf5340-net")))]
     RNG => embassy_nrf::rng::InterruptHandler<embassy_nrf::peripherals::RNG>;
+    #[cfg(all(feature = "hwrng", any(context = "nrf91", context = "nrf5340-app")))]
+    CRYPTOCELL => embassy_nrf::cryptocell::rng::InterruptHandler<embassy_nrf::peripherals::CC_RNG>;
 
     #[cfg(feature = "usb")]
     USBD => embassy_nrf::usb::InterruptHandler<embassy_nrf::peripherals::USBD>;


### PR DESCRIPTION
# Description

Adds support for cryptocell HWRNG for nrf9151, nrf9160 and nrf5340-app.

Currently using a custom `embassy-nrf` branch with backported patches. Would need to wait for the next embassy upgrade.

## Testing

```
laze -C examples/random/ build -b nrf5340dk-app run -- --allow-erase-all --no-catch-reset
```
```
laze -C examples/random/ build -b nrf9160dk-nrf9160 run     
```
```
laze -C examples/random/ build -b nrf9151-dk run  
```

## Issues/PRs References

- Fixes #372
- Depends on #2128 

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

When should I push the branch with backports to `ariel-os/embassy` ?

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
HWRNG support has been added for `nrf9151`, `nrf9160` and `nrf5340-app` using the CryptoCell system.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
