### PR TITLE
fix(rt): sleep instead of busy-looping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "ld-memory",
  "linkme",
  "portable-atomic",
+ "riscv",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ featurecomb = "0.2.0"
 portable-atomic = { version = "1.11.0", default-features = false, features = [
   "require-cas",
 ] }
+riscv = { version = "0.15.0", default-features = false }
 semihosting = { version = "0.1.24", default-features = false }
 
 embassy-embedded-hal = { version = "0.5.0", default-features = false }

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -40,6 +40,9 @@ portable-atomic = { workspace = true }
 [target.'cfg(context = "nrf")'.dependencies]
 cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 
+[target.'cfg(context = "riscv")'.dependencies]
+riscv = { workspace = true }
+
 [target.'cfg(context = "stm32")'.dependencies]
 cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 

--- a/src/ariel-os-rt/src/cortexm.rs
+++ b/src/ariel-os-rt/src/cortexm.rs
@@ -218,6 +218,11 @@ pub fn init() {
     }
 }
 
+#[allow(dead_code, reason = "conditional compilation")]
+pub fn wfi() {
+    cortex_m::asm::wfi();
+}
+
 /// Returns a `Stack` handle for the currently active thread.
 pub(crate) fn stack() -> crate::stack::Stack {
     #[cfg(feature = "threading")]

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -44,6 +44,7 @@ cfg_if::cfg_if! {
             use crate::stack::Stack;
 
             pub fn init() {}
+            pub fn wfi() {}
             pub fn sp() -> usize { 0 }
             pub fn stack() -> Stack { Stack::default() }
         }
@@ -187,8 +188,10 @@ fn startup() -> ! {
     {
         #[cfg(test)]
         test_main();
-        #[allow(clippy::empty_loop)]
-        loop {}
+
+        loop {
+            arch::wfi();
+        }
     }
 }
 

--- a/src/ariel-os-rt/src/riscv.rs
+++ b/src/ariel-os-rt/src/riscv.rs
@@ -9,6 +9,11 @@ fn main() -> ! {
 
 pub fn init() {}
 
+#[allow(dead_code, reason = "conditional compilation")]
+pub fn wfi() {
+    riscv::asm::wfi();
+}
+
 /// Returns the current `SP` register value.
 pub(crate) fn sp() -> usize {
     let sp: usize;

--- a/src/ariel-os-rt/src/xtensa.rs
+++ b/src/ariel-os-rt/src/xtensa.rs
@@ -9,6 +9,16 @@ fn main() -> ! {
 
 pub fn init() {}
 
+#[allow(dead_code, reason = "conditional compilation")]
+pub fn wfi() {
+    // The options are similar to those used for wfi on RISC-V and Cortex-M:
+    // the instruction does not modify memory or the stack, and does preserve flags.
+    // SAFETY: executing `waiti 0` is sound.
+    unsafe {
+        core::arch::asm!("waiti 0", options(nomem, nostack, preserves_flags));
+    }
+}
+
 /// Returns the current stack pointer register value
 pub(crate) fn sp() -> usize {
     let sp: usize;


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This makes sure that the loop inside `ariel-os-rt` doesn't busy-loop when not using multithreading.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Testing involves adding a log statement [inside the loop](https://github.com/ariel-os/ariel-os/blob/d5329fffc983517d2ff9bd2bbcf0965f26045bd1/src/ariel-os-rt/src/lib.rs#L191) (e.g., `ariel_os_debug::log::info!("looping");`) and checking that it gets printed way fewer times with this PR, for instance in the `minimal` example (be aware that testing this on main might crash your terminal given how many log lines will be printed). How often the printing happens depends on the HAL used (not just the processor architecture) because on STM32 the (enabled-by-default) time driver seems to be triggering more wake-ups for instance.

Testing this is more fun when mixing it with #1809.

Tested on:

- nrf52840dk
- stm32u083c-dk

I'm not sure how to test this on RISC-V and Xtensa as the only implementations we have are on ESP32s, on which we don't provide an SWI, which the `executor-interrupt` requires.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #1809

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The internal runtime loop is now not busy-looping anymore when using the `executor-interrupt` flavor. This may bring significant power consumption improvements when using that executor flavor.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
