### PR TITLE
fix: pin embedded-nal-coap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ embedded-hal = { version = "1.0.0", default-features = false }
 embedded-hal-async = { version = "1.0.0", default-features = false }
 embedded-io = { version = "0.6.1", default-features = false }
 embedded-io-async = { version = "0.6.1", default-features = false }
-embedded-nal-coap = "0.1.0-alpha.5"
+embedded-nal-coap = "=0.1.0-alpha.5"
 embedded-storage = { version = "0.3.1" }
 embedded-storage-async = { version = "0.4.1" }
 embedded-test = { version = "0.7.0", default-features = false, features = [


### PR DESCRIPTION
# Description

The alpha versions do still have breaking changes (in particular, 0.1.0-alpha.6 is bumping the embedded-nal-async version), and should have been pinned in the first place.

## Testing

* Remove Cargo.lock (which is a reasonably good approximation for what an out-of-tree user sees, or what happens in a cargo update)
* `CONFIG_WIFI_NETWORK=a CONFIG_WIFI_PASSWORD=b laze -C examples/coap-server/ build -b rpi-pico2-w`

## Related issues

I should probably bump the nal version on both sides, that'd fix things too, but this is the precise fix for what went wrong.

## Open Questions

* This would be important to have applied to the cargo-generate template -- can we just bump that after this is merged?

## Changelog Entry

<!-- changelog:begin -->
Dependency on `embedded-nal-coap` has been pinned due to its alpha status and known breakage in its version `0.1.0-alpha.6`.
<!-- changelog:end -->

## Change Checklist

- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
