### PR TITLE
chore(renovate): add a changelog:skip label by default on Renovate PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,7 +73,8 @@
     }
   ],
   // Add a 'renovate' label to every PR for the matrix bot
-  "addLabels": ["renovate"]
+  // and add 'changelog:skip' label for the check-changelog CI job
+  "addLabels": ["renovate", "changelog:skip"]
   // TODO: uncomment once confident that renovates works properly
   // "patch": {
   //   "automerge": true


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This PR changes the renovate configuration to add a `changelog:skip`  label to renovate PRs by default.
This PR also changes the extension of the renovate configuration file from `.json` to `.json5` so that editors stop complaining about the presence of comments in the renovate configuration file. 

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
