### PR TITLE
ci: test all of our `network-config-*` options in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -353,8 +353,16 @@ jobs:
           echo "LAZE_BUILDERS=${LAZE_BUILDERS}"
           echo "LAZE_DISABLE=${LAZE_DISABLE}"
           laze build -mg info-boards | uniq
+          # This will test DHCP IPv4 as it is the default
           CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build -DCARGO_ARGS+='--locked' --global --partition hash:${{ matrix.partition }}
 
+      - name: "static IPv4/IPv6 compilation tests (default toolchain)"
+        if: steps.should-skip.outputs.result != 'true'
+        run: |
+          # Build the udp-echo example with static IPv4
+          CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build -DCARGO_ARGS+='--locked' --global --builders rpi-pico-w --partition hash:${{ matrix.partition }} --apps udp-echo -s network-config-ipv4-static
+          # Build the udp-echo example with static IPv6
+          CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' CONFIG_NET_IPV6_STATIC_ADDRESS='2001:db8::0' CONFIG_NET_IPV6_STATIC_GATEWAY_ADDRESS='2001:db8::1' laze build -DCARGO_ARGS+='--locked' --global --builders rpi-pico-w --partition hash:${{ matrix.partition }} --apps udp-echo -s ipv6 -s network-config-ipv6-static
       # cleanup previous build artifacts. do in background (no need to wait).
       - name: "cleanup stable build artifacts"
         if: github.event_name == 'schedule' && steps.should-skip.outputs.result != 'true'


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This PR adds a explicit check for the modules `ipv6` and `network-config-ipv4-static`. Together they lead to the function `ariel_os_network_config` being checked in CI which it previously wasn't.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
~~With the current main, this should fail because of a mismatch in the version of `heapless` between what we use and what is required by `embassy-net`. This was introduced in #1318.~~

## Issues/PRs References
This attempts to have CI check for bugs like the one reported in #1827 which is now fixed.
<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->
- [ ] Is this the best way to test this ? 
- [ ] Are there other functions that are never compiled and/or tested in the CI because of non default laze-modules ?

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
