### PR TITLE
refactor(net): decorrelate `network-config-override` and the ariel-os provided `network-config-*`

### DIFF
--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -162,8 +162,8 @@ timer-generic-queue-64 = ["embassy-time?/generic-queue-64"]
 ## Generic Queue with 128 timers
 timer-generic-queue-128 = ["embassy-time?/generic-queue-128"]
 
-network-config-ipv4-static = ["network-config-override"]
-network-config-ipv6-static = ["network-config-override"]
+network-config-ipv4-static = []
+network-config-ipv6-static = []
 network-config-override = []
 override-usb-config = []
 rcc-config-override = ["ariel-os-hal/rcc-config-override"]

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -87,11 +87,8 @@ pub(crate) fn config() -> embassy_net::Config {
                 fn __ariel_os_network_config() -> embassy_net::Config;
             }
             unsafe { __ariel_os_network_config() }
-        } else if #[cfg(feature = "dhcpv4")] {
-            embassy_net::Config::dhcpv4(embassy_net::DhcpConfig::default())
-        } else if #[cfg(not(context = "ariel-os"))] {
-            // For platform-independent tooling.
-            embassy_net::Config::default()
+        } else {
+            ariel_os_network_config()
         }
     }
 }
@@ -171,15 +168,9 @@ impl embassy_net::driver::RxToken for DummyDriver {
     }
 }
 
-#[cfg(any(
-    feature = "network-config-ipv4-static",
-    feature = "network-config-ipv6-static"
-))]
-// SAFETY: the compiler prevents from defining multiple functions with the same name in the
-// same crate; the function signature is checked by the compiler as it is in the same crate as the
-// FFI declaration.
-#[unsafe(no_mangle)]
-fn __ariel_os_network_config() -> embassy_net::Config {
+#[cfg(not(feature = "network-config-override"))]
+fn ariel_os_network_config() -> embassy_net::Config {
+    #[allow(unused_mut, reason = "conditional compilation")]
     let mut config = embassy_net::Config::default();
 
     cfg_if::cfg_if! {


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This PR refactors the network configuration to decorrelate the `network-config-override` laze module and feature from the configuration presets of ariel OS (i.e. `network-config-ipv4-static`, `network-config-ipv6-static` and `network-config-ipv4-dhcp`).
This was done through:
- Removing `__ariel_os_network_config` which was declared here despite being supposed to be generated using the  `#[ariel_os::config(network)]` macro. 
- Changes the function `ariel-os-embassy::net::config` to choose with `cfg_if` between:
  - `__ariel_os_network_config` when `network-config-override` is used 
  - a new `ariel_os_network_config` when `context = "ariel-os"` that initializes the network configuration
  - `embassy_net::Config::default()` otherwise
- Remove the dependency on  `network-config-override` for  `network-config-ipv4-static` and `network-config-ipv6-static`
## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
`laze build -b nrf52840dk -s network-config-ipv4-static -C examples/udp-echo`
`laze build -b nrf52840dk -s ipv4 -s ipv6 -C examples/udp-echo`

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
