### PR TITLE
build: bump MSRV to 1.93 and update CI toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Install stable toolchain
         if: steps.should-skip.outputs.result != 'true'
         # configure MSRV here:
-        uses: dtolnay/rust-toolchain@1.91.1
+        uses: dtolnay/rust-toolchain@1.93.1
         with:
           targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,thumbv6m-none-eabi,thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf,thumbv8m.main-none-eabi,thumbv8m.main-none-eabihf
           # rust-src: Used for -Zbuild-std.
@@ -226,7 +226,7 @@ jobs:
         # No tag yet after https://github.com/esp-rs/xtensa-toolchain/pull/38 (will probably be @v1.5.5)
         uses: esp-rs/xtensa-toolchain@main
         with:
-          version: "1.91.1.0"
+          version: "1.93.0.0"
           buildtargets: esp32,esp32s2,esp32s3
           override: false
           export: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ default-members = ["examples/hello-world"]
 edition = "2024"
 # This should be the Ariel OS MSRV.
 # Some crates may have a different MSRV.
-rust-version = "1.91"
+rust-version = "1.93"
 repository = "https://github.com/ariel-os/ariel-os"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Multiple resources are available to learn Ariel OS:
 
 ## Minimum Supported Rust Version (MSRV) and Policy
 
-Ariel OS compiles with stable Rust version 1.91 and up.
+Ariel OS compiles with stable Rust version 1.93 and up.
 The MSRV can be increased in patch version updates.
 
 ## Security


### PR DESCRIPTION
# Description

This bumps Ariel's toolchain to 1.93.
#1720 bumped it to 1.91 for getting #1653 in. Turns out the finally released picoserve version in that PR actually requires 1.93.

(I'm aware we'll be bumping again to 1.94 in a week.)

## Testing

Tested `http-client` on `st-nucleo-wb55` and `espressif-esp32-s3-devkitc-1`.

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Needed by #1653.

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Ariel OS's MSRV is now 1.93.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
