### PR TITLE
docs(laze): fix incomplete sentence

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1902,7 +1902,7 @@ modules:
     help: |
       Expect that the Nordic MCU's radio core runs the DECT variant of vendor firmware.
 
-      This must match
+      Whether this is set or not must match what is installed in the chip; it is not tested at startup.
     # No `provides-unique: [nrf-radiocore-firmware]` because this is the exotic
     # option, and because nrf-modem too only does the selection in one way.
     context:


### PR DESCRIPTION
# Description

A sentence I wrote in a laze description was incomplete when I submitted the

## Testing

Just look at the diff.

## Issues/PRs References

Thanks @ROMemories for having an extra look at https://github.com/ariel-os/ariel-os/pull/1819#discussion_r2871278751

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
