### PR TITLE
fix: typo for synopsys usb system

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -588,7 +588,7 @@ contexts:
       PROBE_RS_CHIP: STM32F401RE
       RUSTFLAGS:
         - --cfg capability=\"async-flash-driver\"
-        - --cfg capability=\"hw/stm32-usb-synopsis\"
+        - --cfg capability=\"hw/stm32-usb-synopsys\"
 
   - name: stm32f411re
     parent: stm32
@@ -622,7 +622,7 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-dual-core\"
         - --cfg capability=\"hw/stm32-hash-rng\"
-        - --cfg capability=\"hw/stm32-usb-synopsis\"
+        - --cfg capability=\"hw/stm32-usb-synopsys\"
 
   - name: stm32h753zi
     parent: stm32
@@ -635,7 +635,7 @@ contexts:
       PROBE_RS_CHIP: STM32H753ZITx
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-hash-rng\"
-        - --cfg capability=\"hw/stm32-usb-synopsis\"
+        - --cfg capability=\"hw/stm32-usb-synopsys\"
 
   - name: stm32l475vg
     parent: stm32
@@ -648,7 +648,7 @@ contexts:
       PROBE_RS_CHIP: STM32L475VG
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
-        - --cfg capability=\"hw/stm32-usb-synopsis\" # Needs an external 32.768 kHz crystal to have a stable clock
+        - --cfg capability=\"hw/stm32-usb-synopsys\" # Needs an external 32.768 kHz crystal to have a stable clock
 
   - name: stm32u073kc
     parent: stm32
@@ -689,7 +689,7 @@ contexts:
       PROBE_RS_CHIP: STM32U585AI
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
-        - --cfg capability=\"hw/stm32-usb-synopsis\"
+        - --cfg capability=\"hw/stm32-usb-synopsys\"
 
   - name: stm32wb55rg
     parent: stm32

--- a/src/ariel-os-embassy/src/usb.rs
+++ b/src/ariel-os-embassy/src/usb.rs
@@ -41,9 +41,9 @@ pub(crate) mod ethernet {
     #[embassy_executor::task]
     pub async fn usb_ncm_task(class: Runner<'static, UsbDriver, ETHERNET_MTU>) -> ! {
         {
-            // on stm32 with the synopsis-otg, usb ethernet fails to enumerate otherwise.
+            // on stm32 with the synopsys-otg, usb ethernet fails to enumerate otherwise.
             // See https://github.com/embassy-rs/embassy/issues/2376.
-            #[cfg(capability = "hw/stm32-usb-synopsis")]
+            #[cfg(capability = "hw/stm32-usb-synopsys")]
             crate::api::time::Timer::after_millis(3000).await;
         }
 

--- a/src/ariel-os-stm32/src/usb.rs
+++ b/src/ariel-os-stm32/src/usb.rs
@@ -1,7 +1,7 @@
 use embassy_stm32::{Peri, bind_interrupts, peripherals, usb, usb::Driver};
 
 bind_interrupts!(struct Irqs {
-    #[cfg(capability = "hw/stm32-usb-synopsis")]
+    #[cfg(capability = "hw/stm32-usb-synopsys")]
     OTG_FS => usb::InterruptHandler<peripherals::USB_OTG_FS>;
     #[cfg(capability = "hw/stm32-usb")]
     USB => usb::InterruptHandler<peripherals::USB>;
@@ -19,9 +19,9 @@ bind_interrupts!(struct Irqs {
     USB_UCPD1_2 => usb::InterruptHandler<peripherals::USB>;
 });
 
-#[cfg(not(capability = "hw/stm32-usb-synopsis"))]
+#[cfg(not(capability = "hw/stm32-usb-synopsys"))]
 type UsbPeripheral = peripherals::USB;
-#[cfg(capability = "hw/stm32-usb-synopsis")]
+#[cfg(capability = "hw/stm32-usb-synopsys")]
 type UsbPeripheral = peripherals::USB_OTG_FS;
 
 pub type UsbDriver = Driver<'static, UsbPeripheral>;
@@ -36,9 +36,9 @@ impl Peripherals {
     #[must_use]
     pub fn new(peripherals: &mut crate::OptionalPeripherals) -> Self {
         Self {
-            #[cfg(not(capability = "hw/stm32-usb-synopsis"))]
+            #[cfg(not(capability = "hw/stm32-usb-synopsys"))]
             usb: peripherals.USB.take().unwrap(),
-            #[cfg(capability = "hw/stm32-usb-synopsis")]
+            #[cfg(capability = "hw/stm32-usb-synopsys")]
             usb: peripherals.USB_OTG_FS.take().unwrap(),
             dp: peripherals.PA12.take().unwrap(),
             dm: peripherals.PA11.take().unwrap(),
@@ -46,12 +46,12 @@ impl Peripherals {
     }
 }
 
-#[cfg(not(capability = "hw/stm32-usb-synopsis"))]
+#[cfg(not(capability = "hw/stm32-usb-synopsys"))]
 pub fn driver(peripherals: Peripherals) -> UsbDriver {
     Driver::new(peripherals.usb, Irqs, peripherals.dp, peripherals.dm)
 }
 
-#[cfg(capability = "hw/stm32-usb-synopsis")]
+#[cfg(capability = "hw/stm32-usb-synopsys")]
 pub fn driver(peripherals: Peripherals) -> UsbDriver {
     use static_cell::ConstStaticCell;
 


### PR DESCRIPTION
# Description

This fixes the typo where the brand synopsys was spelled synopsis. No external api should be affected.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

I don't have any stm32 board using this flag. Building on `st-steval-mkboxpro` seems to work.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
