### PR TITLE
fix(net): use Default initializer for heapless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,6 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io 0.6.1",
  "embedded-io-async 0.6.1",
- "heapless 0.9.1",
  "linkme",
  "portable-atomic",
  "rand_core 0.9.3",

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -42,7 +42,6 @@ ariel-os-storage = { workspace = true, optional = true }
 ariel-os-threads = { path = "../ariel-os-threads", optional = true }
 ariel-os-utils = { workspace = true }
 
-heapless = "0.9.1"
 trouble-host = { workspace = true, optional = true }
 usbd-hid = { version = "0.8.2", optional = true }
 

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -212,7 +212,11 @@ fn __ariel_os_network_config() -> embassy_net::Config {
 
             config.ipv4 = embassy_net::ConfigV4::Static(embassy_net::StaticConfigV4 {
                 address: embassy_net::Ipv4Cidr::new(ipaddr, PREFIX_LEN),
-                dns_servers: heapless::Vec::new(),
+                #[expect(
+                    clippy::default_trait_access,
+                    reason = "This allows us to not import heapless (and not worry about its version)."
+                )]
+                dns_servers: Default::default(),
                 gateway: Some(gw_addr),
             });
         } else if #[cfg(feature = "dhcpv4")] {
@@ -246,7 +250,11 @@ fn __ariel_os_network_config() -> embassy_net::Config {
 
         config.ipv6 = embassy_net::ConfigV6::Static(embassy_net::StaticConfigV6 {
             address: embassy_net::Ipv6Cidr::new(ipaddr, PREFIX_LEN),
-            dns_servers: heapless::Vec::new(),
+            #[expect(
+                clippy::default_trait_access,
+                reason = "This allows us to not import heapless (and not worry about its version)."
+            )]
+            dns_servers: Default::default(),
             gateway: Some(gw_addr),
         });
     }


### PR DESCRIPTION
# Description

This changes the `embassy-net` initialization to use `Default::default()` and thus removes the dependency on `heapless` in `ariel-os-embassy`.

## Testing

Tested with: 

```
CONFIG_NET_IPV6_STATIC_GATEWAY_ADDRESS=fd00::1 CONFIG_NET_IPV6_STATIC_ADDRESS=fd00::2 laze -C examples/tcp-echo/ build -d network-config-dhcp -b stm32u083c-dk  -s ipv6 run
```


## Issues/PRs References

- Fixes #1827 

## Open Questions

<!-- Unresolved questions, if any. -->


## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
