### PR TITLE
fix(stm32u083c-dk)!: add support for the remaining user LEDs

### DIFF
--- a/boards/stm32u083c-dk.yaml
+++ b/boards/stm32u083c-dk.yaml
@@ -7,7 +7,14 @@ boards:
       swi: USART4_LPUART3
     leds:
       led0:
+        pin: PC13
+        color: green
+      led1:
         pin: PA5
+        color: blue
+      led2:
+        pin: PB2
+        color: red
     buttons:
       button0:
         pin: PC2

--- a/src/ariel-os-boards/src/stm32u083c-dk.rs
+++ b/src/ariel-os-boards/src/stm32u083c-dk.rs
@@ -2,7 +2,9 @@
 
 pub mod pins {
     use ariel_os_hal::hal::peripherals;
-    ariel_os_hal::define_peripherals!(LedPeripherals { led0 : PA5, });
+    ariel_os_hal::define_peripherals!(
+        LedPeripherals { led0 : PC13, led1 : PA5, led2 : PB2, }
+    );
     ariel_os_hal::define_peripherals!(ButtonPeripherals { button0 : PC2, });
 }
 #[allow(unused_variables)]


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This PR add the two user LEDs LD3 and LD5 in `boards/stm32u083c-dk.yaml` and orders them according the labeling on the board 

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
`laze build -C examples/blinky -b stm32u083c-dk run` will now blink the green LD3 instead of the blue LD4. Changing the blinky code to use led2 will blink the red LD5. 

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(STM32U083C-DK) All three LEDs are now supported and ordered according to the on-board labeling. Notably, `led0` changed from the blue LD4 LED to the green LD3 LED.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
