### PR TITLE
fix(nrf)!: re-enable the default protection on NFC pins

### DIFF
--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -39,26 +39,19 @@ trouble-host = { workspace = true, optional = true }
 embassy-nrf = { workspace = true, features = ["nrf51"] }
 
 [target.'cfg(context = "nrf52832")'.dependencies]
-# Disable NFC support for now, as we do not support it yet.
-embassy-nrf = { workspace = true, features = ["nfc-pins-as-gpio", "nrf52832"] }
+embassy-nrf = { workspace = true, features = ["nrf52832"] }
 nrf-sdc = { workspace = true, features = ["nrf52832"], optional = true }
 
 [target.'cfg(context = "nrf52833")'.dependencies]
-# Disable NFC support for now, as we do not support it yet.
-embassy-nrf = { workspace = true, features = ["nfc-pins-as-gpio", "nrf52833"] }
+embassy-nrf = { workspace = true, features = ["nrf52833"] }
 nrf-sdc = { workspace = true, features = ["nrf52833"], optional = true }
 
 [target.'cfg(context = "nrf52840")'.dependencies]
-# Disable NFC support for now, as we do not support it yet.
-embassy-nrf = { workspace = true, features = ["nfc-pins-as-gpio", "nrf52840"] }
+embassy-nrf = { workspace = true, features = ["nrf52840"] }
 nrf-sdc = { workspace = true, features = ["nrf52840"], optional = true }
 
 [target.'cfg(context = "nrf5340-app")'.dependencies]
-# Disable NFC support for now, as we do not support it yet.
-embassy-nrf = { workspace = true, features = [
-  "nfc-pins-as-gpio",
-  "nrf5340-app-s",
-] }
+embassy-nrf = { workspace = true, features = ["nrf5340-app-s"] }
 
 [target.'cfg(context = "nrf5340-net")'.dependencies]
 embassy-nrf = { workspace = true, features = ["nrf5340-net"] }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This undoes #523 as I've since realized that this disables the protection circuit on these pins, aimed at preventing damage from the current induced by an NFC field if an antenna is connected to those (and an NFC reader generating a field), see section 6.14.3 of [nRF52840's datasheet](https://docs-be.nordicsemi.com/bundle/ps_nrf52840/attach/nRF52840_PS_v1.11.pdf?_LANG=enus). This sets the pins back into NFC mode (and therefore prevents from using them as GPIOs). Users that would want to use these pins as GPIOs could always rely on feature unification to enable that Cargo feature back (even though that's not something we really document currently). This is of course a breaking change.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Flashing the `hello-world` example on an nRF52840-DK still shows the following warning (which was the reason for #523 in the first place):

```
WARN  You have requested to use P0.09 and P0.10 pins for NFC, by not enabling the Cargo feature `nfc-pins-as-gpio`.
However, UICR is already programmed to some other setting, and can't be changed without erasing it.
To fix this, erase UICR manually, for example using `probe-rs erase` or `nrfjprog --eraseuicr`.
```

I suppose having that warning show up is still better than putting the MCU in a state that can more easily get some of its pins damaged?

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(nRF) The protection circuit on NFC pins has been re-enabled, disabling the GPIO functionality on them. If needed, GPIO functionality can be re-enabled out of tree by enabling `embassy-nrf`'s `nfc-pins-as-gpio` Cargo feature.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
