### PR TITLE
docs(boards): provide dfu instructions for the `st-steval-mkboxpro`

### DIFF
--- a/book/src/boards/st-steval-mkboxpro.md
+++ b/book/src/boards/st-steval-mkboxpro.md
@@ -39,6 +39,14 @@ laze build -b st-steval-mkboxpro
 
 #### Additional Notes
 
+The `st-steval-mkboxpro` can be flashed using USB DFU and using a debug probe.
+
+##### Using USB DFU for Flashing
+
+After connecting a USB-C cable, start the bootloader with DFU by cycling the power of the microcontroller while pressing button 2 on the side of the case.
+The microcontroller enumerates as "STMicroelectronics STM Device in DFU Mode" on the host computer.
+Use the `laze build flash-dfu` task to flash the microcontroller.
+
 ##### Using a Debug Probe for Flashing
 
 After opening the case, use the JP2/SWD connector (marked "MCU SWD") with an SWD debug probe (e.g., the STLINK-V3MINIE):

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -1114,6 +1114,14 @@ builders:
         comments:
           - "[USB does not enumerate](https://github.com/embassy-rs/embassy/issues/2376), [workaround](https://github.com/ariel-os/ariel-os/pull/1126)"
     notes: |-
+      The `st-steval-mkboxpro` can be flashed using USB DFU and using a debug probe.
+
+      ##### Using USB DFU for Flashing
+
+      After connecting a USB-C cable, start the bootloader with DFU by cycling the power of the microcontroller while pressing button 2 on the side of the case.
+      The microcontroller enumerates as "STMicroelectronics STM Device in DFU Mode" on the host computer.
+      Use the `laze build flash-dfu` task to flash the microcontroller.
+
       ##### Using a Debug Probe for Flashing
 
       After opening the case, use the JP2/SWD connector (marked "MCU SWD") with an SWD debug probe (e.g., the STLINK-V3MINIE):


### PR DESCRIPTION
# Description

This extends the initial instructions for the `st-steval-mkboxpro` with instructions how to use dfu-flash to make the flashing instructions complete.

## Testing

Follow the documented steps from this PR.

## Issues/PRs References

Follow-up to #1853 

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
