### PR TITLE
ci: check for "ci-host:github" label

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -43,12 +43,6 @@ jobs:
       # newest standard library. It may also need to be aligned with the clang
       # version which Xtensa provides.
       CLANG_PATH: /usr/bin/clang-18
-      CACHE_THING_LOCATION: /cache/cache-thing
-      RUSTC_WRAPPER: sccache
-      SCCACHE_DIR: /cache/sccache
-      SCCACHE_CACHE_SIZE: 128G
-
-      CARGO_NET_GIT_FETCH_WITH_CLI: true
 
     steps:
       - name: reset git-cache update barrier

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,11 +121,6 @@ jobs:
       # newest standard library. It may also need to be aligned with the clang
       # version which Xtensa provides.
       CLANG_PATH: /usr/bin/clang-18
-      CACHE_THING_LOCATION: /cache/cache-thing
-      RUSTC_WRAPPER: sccache
-      CARGO_NET_GIT_FETCH_WITH_CLI: true
-      SCCACHE_DIR: /cache/sccache
-      SCCACHE_CACHE_SIZE: 128G
 
     strategy:
       fail-fast: true


### PR DESCRIPTION
# Description

Allows to override where the Build CI is run for a PR.
The default runner label selected is "self-hosted-ubuntu", it can be overriden by the repository level variable BUILD_RUNNER, that can be overridden by the PR label "ci-host:github" (sets the runner label to "ubuntu-24.04").

This would allow us to test the GitHub-hosted build ci and test toolchain upgrades without having an effect on the rest of the Build CI runs (in self-hosted, we can only have one esp toolchain preinstalled).

## Testing

Toggle on and off the label, see if it correctly changes the runners used.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->


## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
