### PR TITLE
ci(cache): don't skip the build when clearing the cache

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -67,16 +67,24 @@ jobs:
           path: .tree-hash
           key: build-cache-success-${{ steps.get-tree-hash.outputs.hash }}-${{ matrix.node }}
 
+      - name: Whether we should clear the cache
+        id: clear-cache
+        run: |
+          day=$(date +'%u')
+          # Clear the cache on Sundays and when manually selected.
+          if [ "$day" = "7" ] || [ "${{ inputs.clear_cache }}" = "true" ];
+          then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Whether to skip next steps
         id: should-skip
         run: |
-          result="result=${{ steps.result-cache.outputs.cache-hit == 'true' }}"
+          result="result=${{ steps.result-cache.outputs.cache-hit == 'true' && steps.clear-cache.outputs.result != 'true' }}"
           echo "${result}"
           echo "${result}" >> $GITHUB_OUTPUT
-      - name: Get day of week
-        if: steps.should-skip.outputs.result != 'true'
-        id: day
-        run: echo "day=$(date +'%u')" >> $GITHUB_OUTPUT
 
       - name: Set nightly fallback key
         run: echo "FALLBACK_KEY=nightly" >> "$GITHUB_ENV"
@@ -84,7 +92,7 @@ jobs:
       # Instead of deleting the existing cache, we just don't use it and replace it after the build
       # succeeds, this avoids being left with no cache when the cache build fails.
       - name: Don't use cache on Sunday
-        if: steps.should-skip.outputs.result != 'true' && ( steps.day.outputs.day == '7' || inputs.clear_cache )
+        if: steps.clear-cache.outputs.result == 'true'
         run: echo "FALLBACK_KEY=none" >> "$GITHUB_ENV"
 
       # Allows to reuse more cache


### PR DESCRIPTION
# Description

There is a possibility where the `build-cache` job can be skipped if there was no file change since the last job run. This would also skip the cleaning of the cache, something we want to happen regularly.

This disables the skipping mechanism when the option to clean the cache is selected.  

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->


## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
