### PR TITLE
feat(power): expose the reset reason on nRF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "ariel-os-stm32",
  "bt-hci",
  "const_panic",
+ "defmt 1.0.1",
  "embassy-embedded-hal",
  "embassy-executor",
  "embassy-hal-internal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,9 @@ version = "0.4.0"
 dependencies = [
  "cortex-m",
  "defmt 1.0.1",
+ "embassy-nrf",
  "esp-hal",
+ "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
 name = "ariel-os-power"
 version = "0.4.0"
 dependencies = [
+ "ariel-os-hal",
  "cortex-m",
  "defmt 1.0.1",
  "embassy-nrf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "ariel-os-identity",
  "ariel-os-log",
  "ariel-os-macros",
+ "ariel-os-power",
  "ariel-os-random",
  "ariel-os-rt",
  "ariel-os-storage",
@@ -460,6 +461,7 @@ name = "ariel-os-power"
 version = "0.4.0"
 dependencies = [
  "cortex-m",
+ "defmt 1.0.1",
  "esp-hal",
 ]
 

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -36,6 +36,7 @@ ariel-os-hal = { path = "../ariel-os-hal" }
 ariel-os-identity = { path = "../ariel-os-identity" }
 ariel-os-log = { workspace = true }
 ariel-os-macros = { path = "../ariel-os-macros" }
+ariel-os-power = { workspace = true }
 ariel-os-random = { path = "../ariel-os-random", optional = true }
 ariel-os-rt = { path = "../ariel-os-rt" }
 ariel-os-storage = { workspace = true, optional = true }
@@ -200,6 +201,7 @@ no-boards = []
 defmt = [
   "ariel-os-embassy-common/defmt",
   "ariel-os-hal/defmt",
+  "ariel-os-power/defmt",
   "embassy-net?/defmt",
   "embassy-time?/defmt",
   "embassy-usb?/defmt",

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -201,6 +201,9 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     let spawner = unsafe { asynch::Spawner::for_current_executor().await };
     asynch::set_spawner(spawner.make_send());
 
+    // This should be called as early as possible in the boot sequence.
+    ariel_os_power::init();
+
     #[cfg(feature = "debug-uart")]
     debug_uart::init(&mut peripherals);
 

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -201,9 +201,6 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     let spawner = unsafe { asynch::Spawner::for_current_executor().await };
     asynch::set_spawner(spawner.make_send());
 
-    // This should be called as early as possible in the boot sequence.
-    ariel_os_power::init();
-
     #[cfg(feature = "debug-uart")]
     debug_uart::init(&mut peripherals);
 

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 ariel-os-embassy-common = { workspace = true }
 
 const_panic = { workspace = true }
+defmt = { workspace = true, optional = true }
 
 embassy-embedded-hal = { workspace = true, optional = true }
 embassy-sync = { workspace = true, optional = true }
@@ -158,6 +159,7 @@ executor-interrupt = [
 ]
 
 defmt = [
+  "dep:defmt",
   "ariel-os-embassy-common/defmt",
   "ariel-os-esp/defmt",
   "ariel-os-nrf/defmt",

--- a/src/ariel-os-hal/src/hal/dummy/mod.rs
+++ b/src/ariel-os-hal/src/hal/dummy/mod.rs
@@ -22,6 +22,12 @@ pub mod gpio;
 #[doc(hidden)]
 pub mod peripheral;
 
+pub mod power {
+    //! Provides facilities related to the MCU reset.
+
+    pub mod reset;
+}
+
 #[doc(hidden)]
 #[cfg(feature = "ble")]
 pub mod ble;

--- a/src/ariel-os-hal/src/hal/dummy/power/reset.rs
+++ b/src/ariel-os-hal/src/hal/dummy/power/reset.rs
@@ -1,8 +1,12 @@
 //! Provides facilities related to the MCU reset.
 
 /// Indicates why the microcontroller has reset.
+///
+/// # Note
+///
+/// This is a dummy type, HALs provide additional variants specific to their microcontrollers.
 // NOTE: Marking this as `non_exhaustive` allows to make introducing *new* variants not a breaking
-// change, especially on unaffected MCU families. However, returning the newly introduced variant
+// change, especially on unaffected MCUs. However, returning the newly introduced variant
 // instead of an already existing one is still likely to be one.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -15,18 +19,4 @@ pub enum ResetReason {
     /// power-on resets.
     #[default]
     PowerOnReset,
-    /// HAL-specific reset reason.
-    Hal(ariel_os_hal::hal::power::reset::ResetReason),
-}
-
-/// Returns the reason why the microcontroller has reset.
-#[cfg(context = "nrf")]
-#[must_use]
-pub fn reason() -> ResetReason {
-    let reason = ariel_os_hal::hal::power::reset::reason();
-
-    match reason {
-        ariel_os_hal::hal::power::reset::ResetReason::PowerOnReset => ResetReason::PowerOnReset,
-        _ => ResetReason::Hal(reason),
-    }
 }

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -13,6 +13,12 @@ pub mod peripheral {
     pub use embassy_nrf::Peri;
 }
 
+pub mod power {
+    //! Provides power management functionality.
+
+    pub mod reset;
+}
+
 #[cfg(feature = "ble")]
 #[doc(hidden)]
 pub mod ble;
@@ -101,6 +107,8 @@ mod private {
 #[doc(hidden)]
 #[must_use]
 pub fn init() -> OptionalPeripherals {
+    power::reset::save_reason();
+
     enable_flash_cache();
 
     let peripherals = embassy_nrf::init(Config::default());

--- a/src/ariel-os-nrf/src/power/reset.rs
+++ b/src/ariel-os-nrf/src/power/reset.rs
@@ -1,0 +1,189 @@
+//! Provides facilities related to the MCU reset.
+
+use portable_atomic::{AtomicU8, Ordering};
+
+static RESET_REASON: AtomicU8 = AtomicU8::new(ResetReason::PowerOnReset as u8);
+
+/// Indicates why the microcontroller has reset.
+///
+/// # Note
+///
+/// Not all microcontrollers allow distinguishing between all variants, and
+/// [`ResetReason::PowerOnReset`] acts as the default variant.
+/// When a variant other than [`ResetReason::PowerOnReset`] is returned, it does however reflect
+/// the actual reset reason.
+// NOTE: Marking this as `non_exhaustive` allows to make introducing *new* variants not a breaking
+// change, especially on unaffected MCUs. However, returning the newly introduced variant
+// instead of an already existing one is still likely to be one.
+// NOTE: `cfg` predicates are written differently than in the implementation for documentation clarity.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum ResetReason {
+    /// The reset has been triggered by a power cycle.
+    /// This variant also acts as a default when the reset reason cannot be determined or
+    /// distinguished from a power-on reset.
+    /// In particular, many microcontrollers do not allow distinguishing brownout resets from
+    /// power-on resets.
+    #[default]
+    PowerOnReset,
+    /// The reset has been triggered through the dedicated reset pin.
+    ResetPin,
+    /// The reset has been triggered by software, e.g., with `reboot()`.
+    /// Using `reboot()` however does not guarantee that this variant will be returned, as this
+    /// depends on the microcontroller's ability to distinguish this.
+    SoftwareReset,
+    /// The reset has been triggered by an external-interrupt wake-up event.
+    ExternalInterrupt,
+    /// The reset has been triggered by a real-time clock (RTC) wake-up event.
+    Rtc,
+    /// The reset has been triggered by a wake-up event as the USB power became available.
+    #[cfg(any(all(context = "nrf52", not(context = "nrf52832")), context = "nrf53"))]
+    Usb,
+    /// The reset has been triggered by a wake-up event from an analog comparator.
+    #[cfg(any(context = "nrf51", context = "nrf52", context = "nrf53"))]
+    Comparator,
+    /// The reset has been triggered by entering an RF field (e.g., an NFC/RFID field) able to
+    /// power the microcontroller.
+    #[cfg(any(context = "nrf52", context = "nrf53"))]
+    Field,
+    /// The reset has been triggered due to a processor lockup.
+    CpuLockup,
+    /// The reset has been triggered by the watchdog.
+    WatchdogReset,
+    /// The reset has been triggered by a wake-up event from the debug interface.
+    DebugInterface,
+}
+
+impl ResetReason {
+    #[must_use]
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::PowerOnReset => 0,
+            Self::ResetPin => 1,
+            Self::SoftwareReset => 2,
+            Self::ExternalInterrupt => 3,
+            Self::Rtc => 4,
+            #[cfg(not(any(context = "nrf51", context = "nrf52832", context = "nrf91")))]
+            Self::Usb => 5,
+            #[cfg(not(context = "nrf91"))]
+            Self::Comparator => 6,
+            #[cfg(not(any(context = "nrf51", context = "nrf91")))]
+            Self::Field => 7,
+            Self::WatchdogReset => 8,
+            Self::CpuLockup => 9,
+            Self::DebugInterface => 10,
+        }
+    }
+
+    fn try_from_u8(int: u8) -> Result<Self, ()> {
+        match int {
+            0 => Ok(Self::PowerOnReset),
+            1 => Ok(Self::ResetPin),
+            2 => Ok(Self::SoftwareReset),
+            3 => Ok(Self::ExternalInterrupt),
+            4 => Ok(Self::Rtc),
+            #[cfg(not(any(context = "nrf51", context = "nrf52832", context = "nrf91")))]
+            5 => Ok(Self::Usb),
+            #[cfg(not(context = "nrf91"))]
+            6 => Ok(Self::Comparator),
+            #[cfg(not(any(context = "nrf51", context = "nrf91")))]
+            7 => Ok(Self::Field),
+            8 => Ok(Self::WatchdogReset),
+            9 => Ok(Self::CpuLockup),
+            10 => Ok(Self::DebugInterface),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Saves the reset reason.
+///
+/// *Important*: this needs to be called as early as possible in the boot sequence.
+/// In particular, on microcontrollers whose reset reason needs to be cleared manually on each
+/// reset, this needs to be called before anything else has the change to clear it.
+/// This function may clear these bits.
+pub(crate) fn save_reason() {
+    // NOTE: this avoids forgetting to update this when adding support for other families.
+    #[cfg(not(any(
+        context = "nrf51",
+        context = "nrf52",
+        context = "nrf53",
+        context = "nrf91",
+        not(context = "ariel-os"),
+    )))]
+    compile_error!("unsupported nRF MCU");
+
+    let resetreas;
+
+    cfg_select! {
+        context = "nrf53" => {
+            resetreas = embassy_nrf::pac::RESET.resetreas().read();
+        }
+        _ => {
+            resetreas = embassy_nrf::pac::POWER.resetreas().read();
+        }
+    }
+
+    let mut reset_reason = ResetReason::default();
+
+    // NOTE: `cfg` predicates is written differently than on `ResetReason` to avoid forgetting to
+    // update the list of reasons when adding support for new families.
+
+    #[cfg(not(any(context = "nrf51", context = "nrf91")))]
+    if resetreas.nfc() {
+        reset_reason = ResetReason::Field;
+    }
+
+    #[cfg(not(any(context = "nrf51", context = "nrf52832", context = "nrf91")))]
+    if resetreas.vbus() {
+        reset_reason = ResetReason::Usb;
+    }
+
+    #[cfg(not(context = "nrf53"))]
+    if resetreas.dog() {
+        reset_reason = ResetReason::WatchdogReset;
+    }
+
+    // TODO: it is unclear whether each watchdog timer should be attributed to one of the
+    // cores specifically.
+    #[cfg(context = "nrf53")]
+    if resetreas.dog0() || resetreas.dog1() {
+        reset_reason = ResetReason::WatchdogReset;
+    }
+
+    #[cfg(not(context = "nrf91"))]
+    if resetreas.lpcomp() {
+        reset_reason = ResetReason::Comparator;
+    }
+
+    if resetreas.resetpin() {
+        reset_reason = ResetReason::ResetPin;
+    } else if resetreas.sreq() {
+        reset_reason = ResetReason::SoftwareReset;
+    } else if resetreas.off() {
+        reset_reason = ResetReason::ExternalInterrupt;
+    } else if resetreas.lockup() {
+        reset_reason = ResetReason::CpuLockup;
+    } else if resetreas.dif() {
+        reset_reason = ResetReason::DebugInterface;
+    };
+
+    RESET_REASON.store(reset_reason.as_u8(), Ordering::Release);
+
+    cfg_select! {
+        context = "nrf53" => {
+            let clear_value = embassy_nrf::pac::reset::regs::Resetreas(u32::MAX);
+            embassy_nrf::pac::RESET.resetreas().write_value(clear_value);
+        }
+        _ => {
+            let clear_value = embassy_nrf::pac::power::regs::Resetreas(u32::MAX);
+            embassy_nrf::pac::POWER.resetreas().write_value(clear_value);
+        }
+    }
+}
+
+#[doc(hidden)]
+pub fn reason() -> ResetReason {
+    ResetReason::try_from_u8(RESET_REASON.load(Ordering::Acquire)).unwrap()
+}

--- a/src/ariel-os-power/Cargo.toml
+++ b/src/ariel-os-power/Cargo.toml
@@ -7,12 +7,16 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+defmt = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 cortex-m = { workspace = true }
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-hal = { workspace = true }
+
+[features]
+defmt = ["dep:defmt"]
 
 [lints]
 workspace = true

--- a/src/ariel-os-power/Cargo.toml
+++ b/src/ariel-os-power/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+ariel-os-hal = { workspace = true }
 defmt = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]

--- a/src/ariel-os-power/Cargo.toml
+++ b/src/ariel-os-power/Cargo.toml
@@ -15,6 +15,10 @@ cortex-m = { workspace = true }
 [target.'cfg(context = "esp")'.dependencies]
 esp-hal = { workspace = true }
 
+[target.'cfg(context = "nrf")'.dependencies]
+embassy-nrf = { workspace = true }
+portable-atomic = { workspace = true }
+
 [features]
 defmt = ["dep:defmt"]
 

--- a/src/ariel-os-power/src/lib.rs
+++ b/src/ariel-os-power/src/lib.rs
@@ -6,3 +6,14 @@
 mod reset;
 
 pub use reset::*;
+
+/// Initializes power management.
+///
+/// *Important*: this needs to be called as early as possible in the boot sequence.
+/// In particular, on microcontrollers whose reset reason needs to be cleared manually on each
+/// reset, this needs to be called before anything else has the change to clear it.
+/// This function may clear these bits.
+#[doc(hidden)]
+pub fn init() {
+    reset::save_reset_reason();
+}

--- a/src/ariel-os-power/src/lib.rs
+++ b/src/ariel-os-power/src/lib.rs
@@ -1,7 +1,8 @@
 //! Provides power management functionality.
 
-#![deny(missing_docs)]
 #![cfg_attr(not(context = "native"), no_std)]
+#![cfg_attr(nightly, feature(doc_cfg))]
+#![deny(missing_docs)]
 
 mod reset;
 

--- a/src/ariel-os-power/src/lib.rs
+++ b/src/ariel-os-power/src/lib.rs
@@ -4,17 +4,28 @@
 #![cfg_attr(nightly, feature(doc_cfg))]
 #![deny(missing_docs)]
 
-mod reset;
+pub mod reset;
 
-pub use reset::*;
-
-/// Initializes power management.
+/// Reboots the MCU.
 ///
-/// *Important*: this needs to be called as early as possible in the boot sequence.
-/// In particular, on microcontrollers whose reset reason needs to be cleared manually on each
-/// reset, this needs to be called before anything else has the change to clear it.
-/// This function may clear these bits.
-#[doc(hidden)]
-pub fn init() {
-    reset::save_reset_reason();
+/// This function initiates a software reset of the microcontroller and never returns.
+pub fn reboot() -> ! {
+    cfg_select! {
+        context = "cortex-m" => {
+            cortex_m::peripheral::SCB::sys_reset()
+        }
+        context = "esp" => {
+            esp_hal::system::software_reset()
+        }
+        context = "native" => {
+            std::process::exit(0)
+        }
+        context = "ariel-os" => {
+            compile_error!("reboot is not yet implemented for this platform")
+        }
+        _ => {
+            #[expect(clippy::empty_loop, reason = "for platform-independent tooling only")]
+            loop {}
+        }
+    }
 }

--- a/src/ariel-os-power/src/reset.rs
+++ b/src/ariel-os-power/src/reset.rs
@@ -1,3 +1,9 @@
+#[cfg(context = "nrf")]
+use portable_atomic::{AtomicU8, Ordering};
+
+#[cfg(context = "nrf")]
+static RESET_REASON: AtomicU8 = AtomicU8::new(ResetReason::PowerOnReset as u8);
+
 /// Indicates why the microcontroller has reset.
 ///
 /// # Note
@@ -38,6 +44,120 @@ pub enum ResetReason {
     /// The reset has been triggered by a source for which there is no other suitable variant, but
     /// the microcontroller does allow to distinguish it from a power-on reset.
     Other,
+}
+
+#[cfg(context = "nrf")]
+impl ResetReason {
+    #[must_use]
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::PowerOnReset => 0,
+            Self::ResetPin => 1,
+            Self::SoftwareReset => 2,
+            Self::StandbyWakeup => 3,
+            Self::PowerFailure => 4,
+            Self::WatchdogReset => 5,
+            Self::Other => 6,
+        }
+    }
+
+    fn try_from_u8(int: u8) -> Result<Self, ()> {
+        match int {
+            0 => Ok(Self::PowerOnReset),
+            1 => Ok(Self::ResetPin),
+            2 => Ok(Self::SoftwareReset),
+            3 => Ok(Self::StandbyWakeup),
+            4 => Ok(Self::PowerFailure),
+            5 => Ok(Self::WatchdogReset),
+            6 => Ok(Self::Other),
+            _ => Err(()),
+        }
+    }
+}
+
+pub(crate) fn save_reset_reason() {
+    cfg_if::cfg_if! {
+        if #[cfg(context = "nrf")] {
+            // NOTE: this avoids forgetting to update this when adding support for other families.
+            #[cfg(not(any(
+                context = "nrf51",
+                context = "nrf52",
+                context = "nrf53",
+                context = "nrf91",
+            )))]
+            compile_error!("unsupported nRF MCU");
+
+            let resetreas;
+
+            cfg_if::cfg_if! {
+                if #[cfg(context = "nrf53")] {
+                    resetreas = embassy_nrf::pac::RESET.resetreas().read();
+                } else {
+                    resetreas = embassy_nrf::pac::POWER.resetreas().read();
+                }
+            }
+
+            let mut reset_reason = ResetReason::default();
+
+            #[cfg(not(any(context = "nrf51", context = "nrf91")))]
+            if resetreas.nfc() {
+                reset_reason = ResetReason::Other;
+            }
+
+            #[cfg(not(context = "nrf53"))]
+            if resetreas.dog() {
+                reset_reason = ResetReason::WatchdogReset;
+            }
+
+            // TODO: it is unclear whether each watchdog timer should be attributed to one of the
+            // cores specifically.
+            #[cfg(context = "nrf53")]
+            if resetreas.dog0() || resetreas.dog1() {
+                reset_reason = ResetReason::WatchdogReset;
+            }
+
+            #[cfg(not(context = "nrf91"))]
+            if resetreas.lpcomp() {
+                reset_reason = ResetReason::Other;
+            }
+
+            if resetreas.resetpin() {
+                reset_reason = ResetReason::ResetPin;
+            } else if resetreas.sreq() {
+                reset_reason = ResetReason::SoftwareReset;
+            } else if resetreas.off() {
+                reset_reason = ResetReason::StandbyWakeup;
+            } else if resetreas.lockup() | resetreas.dif() {
+                reset_reason = ResetReason::Other;
+            };
+
+            RESET_REASON.store(reset_reason.as_u8(), Ordering::Release);
+
+            cfg_if::cfg_if! {
+                if #[cfg(context = "nrf53")] {
+                    let clear_value = embassy_nrf::pac::reset::regs::Resetreas(u32::MAX);
+                    embassy_nrf::pac::RESET.resetreas().write_value(clear_value);
+                } else {
+                    let clear_value = embassy_nrf::pac::power::regs::Resetreas(u32::MAX);
+                    embassy_nrf::pac::POWER.resetreas().write_value(clear_value);
+                }
+            }
+
+        }
+    }
+}
+
+/// Returns the reason why the microcontroller has reset.
+#[cfg(context = "nrf")]
+#[must_use]
+pub fn reset_reason() -> ResetReason {
+    cfg_if::cfg_if! {
+        if #[cfg(any(context = "nrf"))] {
+            ResetReason::try_from_u8(RESET_REASON.load(Ordering::Acquire)).unwrap()
+        } else {
+            compile_error!("obtaining the reseat reason is not yet supported on this MCU family");
+        }
+    }
 }
 
 /// Reboots the MCU.

--- a/src/ariel-os-power/src/reset.rs
+++ b/src/ariel-os-power/src/reset.rs
@@ -1,3 +1,45 @@
+/// Indicates why the microcontroller has reset.
+///
+/// # Note
+///
+/// Not all microcontrollers allow distinguishing between all variants, and
+/// [`ResetReason::PowerOnReset`] acts as the default variant.
+/// When a variant other than [`ResetReason::PowerOnReset`] is returned, it does however reflect
+/// the actual reset reason.
+/// The [`ResetReason::Other`] variant is used when the reset reason can be determined not to be a
+/// power-on reset but there is no other suitable variant.
+// NOTE: Marking this as `non_exhaustive` allows to make introducing *new* variants not a breaking
+// change, especially on unaffected MCU families. However, returning the newly introduced variant
+// instead of an already existing one is still likely to be one.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum ResetReason {
+    /// The reset has been triggered by a power cycle.
+    /// This variant also acts as a default when the reset reason cannot be determined or
+    /// distinguished from a power-on reset.
+    /// In particular, many microcontrollers do not allow distinguishing brownout resets from
+    /// power-on resets.
+    #[default]
+    PowerOnReset,
+    /// The reset has been triggered through the dedicated reset pin.
+    ResetPin,
+    /// The reset has been triggered by software, e.g., with [`reboot()`].
+    /// Using [`reboot()`] however does not guarantee that this variant will be returned, as this
+    /// depends on the microcontroller's ability to distinguish this.
+    SoftwareReset,
+    /// The reset has been triggered through a wake-up event which woke up the microcontroller from a
+    /// low-power standby state.
+    StandbyWakeup,
+    /// The reset has been triggered by hardware following a power failure, e.g., a brownout.
+    PowerFailure,
+    /// The reset has been triggered by the watchdog.
+    WatchdogReset,
+    /// The reset has been triggered by a source for which there is no other suitable variant, but
+    /// the microcontroller does allow to distinguish it from a power-on reset.
+    Other,
+}
+
 /// Reboots the MCU.
 ///
 /// This function initiates a software reset of the microcontroller and never returns.

--- a/src/ariel-os-power/src/reset.rs
+++ b/src/ariel-os-power/src/reset.rs
@@ -41,6 +41,8 @@ pub enum ResetReason {
     /// The reset has been triggered by entering an RF field (e.g., an NFC/RFID field) able to
     /// power the microcontroller.
     Field,
+    /// The reset has been triggered by a tamper-detection mechanism.
+    Tamper,
     /// The reset has been triggered by hardware following a power failure, e.g., a brownout.
     PowerFailure,
     /// The reset has been triggered by the watchdog.

--- a/src/ariel-os-power/src/reset.rs
+++ b/src/ariel-os-power/src/reset.rs
@@ -37,6 +37,9 @@ pub enum ResetReason {
     /// The reset has been triggered through a wake-up event which woke up the microcontroller from a
     /// low-power standby state.
     StandbyWakeup,
+    /// The reset has been triggered by entering an RF field (e.g., an NFC/RFID field) able to
+    /// power the microcontroller.
+    Field,
     /// The reset has been triggered by hardware following a power failure, e.g., a brownout.
     PowerFailure,
     /// The reset has been triggered by the watchdog.
@@ -55,9 +58,10 @@ impl ResetReason {
             Self::ResetPin => 1,
             Self::SoftwareReset => 2,
             Self::StandbyWakeup => 3,
-            Self::PowerFailure => 4,
-            Self::WatchdogReset => 5,
-            Self::Other => 6,
+            Self::Field => 4,
+            Self::PowerFailure => 5,
+            Self::WatchdogReset => 6,
+            Self::Other => 7,
         }
     }
 
@@ -67,9 +71,10 @@ impl ResetReason {
             1 => Ok(Self::ResetPin),
             2 => Ok(Self::SoftwareReset),
             3 => Ok(Self::StandbyWakeup),
-            4 => Ok(Self::PowerFailure),
-            5 => Ok(Self::WatchdogReset),
-            6 => Ok(Self::Other),
+            4 => Ok(Self::Field),
+            5 => Ok(Self::PowerFailure),
+            6 => Ok(Self::WatchdogReset),
+            7 => Ok(Self::Other),
             _ => Err(()),
         }
     }
@@ -101,7 +106,7 @@ pub(crate) fn save_reset_reason() {
 
             #[cfg(not(any(context = "nrf51", context = "nrf91")))]
             if resetreas.nfc() {
-                reset_reason = ResetReason::Other;
+                reset_reason = ResetReason::Field;
             }
 
             #[cfg(not(context = "nrf53"))]

--- a/src/ariel-os-power/src/reset.rs
+++ b/src/ariel-os-power/src/reset.rs
@@ -34,9 +34,10 @@ pub enum ResetReason {
     /// Using [`reboot()`] however does not guarantee that this variant will be returned, as this
     /// depends on the microcontroller's ability to distinguish this.
     SoftwareReset,
-    /// The reset has been triggered through a wake-up event which woke up the microcontroller from a
-    /// low-power standby state.
-    StandbyWakeup,
+    /// The reset has been triggered by an external-interrupt wake-up event.
+    ExternalInterrupt,
+    /// The reset has been triggered by a real-time clock (RTC) wake-up event.
+    Rtc,
     /// The reset has been triggered by entering an RF field (e.g., an NFC/RFID field) able to
     /// power the microcontroller.
     Field,

--- a/src/ariel-os-power/src/reset.rs
+++ b/src/ariel-os-power/src/reset.rs
@@ -134,7 +134,7 @@ pub(crate) fn save_reset_reason() {
             } else if resetreas.sreq() {
                 reset_reason = ResetReason::SoftwareReset;
             } else if resetreas.off() {
-                reset_reason = ResetReason::StandbyWakeup;
+                reset_reason = ResetReason::ExternalInterrupt;
             } else if resetreas.lockup() | resetreas.dif() {
                 reset_reason = ResetReason::Other;
             };

--- a/src/ariel-os-power/src/reset.rs
+++ b/src/ariel-os-power/src/reset.rs
@@ -58,11 +58,12 @@ impl ResetReason {
             Self::PowerOnReset => 0,
             Self::ResetPin => 1,
             Self::SoftwareReset => 2,
-            Self::StandbyWakeup => 3,
-            Self::Field => 4,
-            Self::PowerFailure => 5,
-            Self::WatchdogReset => 6,
-            Self::Other => 7,
+            Self::ExternalInterrupt => 3,
+            Self::Rtc => 4,
+            Self::Field => 5,
+            Self::PowerFailure => 6,
+            Self::WatchdogReset => 7,
+            Self::Other => 8,
         }
     }
 
@@ -71,11 +72,12 @@ impl ResetReason {
             0 => Ok(Self::PowerOnReset),
             1 => Ok(Self::ResetPin),
             2 => Ok(Self::SoftwareReset),
-            3 => Ok(Self::StandbyWakeup),
-            4 => Ok(Self::Field),
-            5 => Ok(Self::PowerFailure),
-            6 => Ok(Self::WatchdogReset),
-            7 => Ok(Self::Other),
+            3 => Ok(Self::ExternalInterrupt),
+            4 => Ok(Self::Rtc),
+            5 => Ok(Self::Field),
+            6 => Ok(Self::PowerFailure),
+            7 => Ok(Self::WatchdogReset),
+            8 => Ok(Self::Other),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This exposes the reason why the microcontroller has reset inside `ariel_os::power`, see https://github.com/ariel-os/ariel-os/issues/1855 for details. This is limited to nRF MCUs only for now, but I'll expand support to other families in follow-ups.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
- The `SoftwareReset` and `ResetPin` reasons can be tested using the following snippet in the `blinky` example (replacing `ResetPin` with `SoftwareReset`):

  ```rust
  let mut led0 = if ariel_os::power::reset_reason() == ariel_os::power::ResetReason::ResetPin {
      Output::new(peripherals.led0, Level::Low)
  } else {
      Output::new(peripherals.led1, Level::Low)
  };
  ```

  Running the example using probe-rs (which seemingly resets the MCU through software) will make one of the LED blink, while pressing the RESET button on the DK will make the other LED blink instead.
- The combination with `ariel_os::power::reboot();` can also be tested.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Split out from #1863

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
