### PR TITLE
docs(contributing): require attribution of AI tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,3 +87,13 @@ We are happy to hear from you and help you. The best way to reach us is to ask o
 
 [text of the DCO]: https://developercertificate.org/
 [adding-board-support]: https://ariel-os.github.io/ariel-os/dev/docs/book/adding-board-support.html
+
+
+## AI contributions
+
+When contributors use AI tools to generate any contribution (code, PR, issue),
+that tool must be acknowledged in the contribution (e.g. through a `Co-authored-by:` trailer).
+
+We define a tool as an AI tool if, when it makes a bad suggestion, no member of the project can find where to report and fix the false positive.
+
+It is the duty of the contributor to ensure that the requirements of the DCO are upheld when using those (or any other) tools.


### PR DESCRIPTION
# Description

Recent events such as the Git Workflow incident ([article with images](https://www.pcgamer.com/software/ai/microsoft-uses-plagiarized-ai-slop-flowchart-to-explain-how-github-works-removes-it-after-original-creator-calls-it-out-careless-blatantly-amateuristic-and-lacking-any-ambition-to-put-it-gently/), [original author's blog post](https://nvie.com/posts/15-years-later/)) indicate that contributions involving large AI models might easily violate copyright in ways that are not trivial for the operator to recognize.

Note that this is not ruling out contributions with AI assistance (or, really, completely AI-automated PRs for that matter), it merely requires transparency about them.

So far, we have a good grasp of our code's provenance. Let's keep it that way.

## Issues / References

We discussed some of this in today's weekly meeting; the text in the PR is adapted from the text there.

## Open questions

* (How) should we maintain a list of tools/uses that do not need per-item declaration?

## Changelog Entry

<!-- changelog:begin -->
Contributing guidelines now require that AI tools used in contributions are declared.
<!-- changelog:end -->

## Change Checklist

- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- n/a I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
