### PR TITLE
 fix: resolve smoltcp build failure when specifying only a link layer 

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1353,6 +1353,7 @@ modules:
   - name: eth-stm32
     selects:
       - has_eth_stm32
+      - network
     provides_unique:
       - network_device
     env:


### PR DESCRIPTION
# Description

When building an application with a specific network link in the laze.yml, but without specifying the `network` module, the build fails on smoltcp:

```
error: You must enable at least one of the following features: proto-ipv4, proto-ipv6, proto-sixlowpan
  --> /home/koen/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/smoltcp-0.12.0/src/lib.rs:99:1
   |
99 | compile_error!("You must enable at least one of the following features: proto-ipv4, proto-ipv6, proto-sixlowpan");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-udp, socket-tcp, socket-icmp, socket-dhcpv4, socket-dns
   --> /home/koen/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/smoltcp-0.12.0/src/lib.rs:112:1
    |
112 | compile_error!("If you enable the socket feature, you must enable at least one of the following features: socket-raw, socket-udp, socket-tcp, socket-icmp, socket-dhcpv4, socket-dns");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This can of course be resolved by also adding the `network` module, but this PR adds the network module as `selects` to the specific link layers. 

## Testing

Issue can be reproduced by adding `wifi-esp` to the hello-world example:

```diff
diff --git i/examples/hello-world/laze.yml w/examples/hello-world/laze.yml
index 8643593a..63826e1e 100644
--- i/examples/hello-world/laze.yml
+++ w/examples/hello-world/laze.yml
@@ -1,2 +1,4 @@
 apps:
   - name: hello-world
+    selects:
+      - wifi-esp
```

and building for any espressif board.

This PR resolves the build failure.

## Issues/PRs References

None

## Open Questions

None

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The `network` laze module is now automatically enabled by network-link laze modules (e.g., `usb-ethernet`, `wifi-esp`). 
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
