### PR TITLE
refactor(ariel-os-embassy)!: make `net` only enable the time driver

### DIFF
--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -89,8 +89,8 @@ uart = ["ariel-os-embassy-common/uart", "ariel-os-hal/uart"]
 usb = ["dep:embassy-usb", "ariel-os-hal/usb"]
 usb-hid = ["dep:usbd-hid", "embassy-usb?/usbd-hid", "usb"]
 
-# embassy-net requires embassy-time and support for timeouts in the executor
-net = ["dep:embassy-net", "time"]
+# `embassy-net` requires a time driver, which HALs provide.
+net = ["dep:embassy-net", "ariel-os-hal/time"]
 usb-ethernet = ["net", "usb"]
 ## Selects the network backend that goes through tun/tap (native only)
 tuntap = ["net"]


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
[The docs of `embassy-net`](https://docs.embassy.dev/embassy-net/git/default/index.html#interoperability) only mention that it needs a time driver, not the entirety of `embassy-time` enabled in the build. This PR makes the `net` Cargo feature of `ariel-os-embassy` only enable `ariel-os-hal/time` which, as now documented in #1808, enables the HAL-specific time driver.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Tested the `http-client` example on espressif-esp32-c6-devkitc-1 and rpi-pico-w, and the `udp-echo` example (with DHCP disabled) on nrf52840dk and stm32u083c-dk.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #1899

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Timing functionality is now not indirectly enabled by enabling networking anymore. Applications that were relying on this simply need to enable the `time` Cargo feature.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
