### PR TITLE
build: remove the use of `--config` in laze

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -189,7 +189,7 @@ contexts:
       vscode-config:
         help: Generate a VSCode configuration for selected board (select a board with -b)
         build: false
-        # The --config arg in CARGO_ARGS is pointing to a file relative to the appdir, it makes more sense to generate the config in the appdir
+        # Place the config in the application directory as it's the configuration for this application.
         workdir: ${appdir}
         export:
           - FEATURES


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This PR removes the use of `--config` now that config includes have been stabilized in 1.94

## Testing

In tree: `laze build ... cargo tree` fails. Now it doesn't
 O-O-T: the same 
<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References
Enabled by #1865 
<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions
Should the laze `cargo` task exist ? Seems like it is doomed to always be fairly limited because not everything that follows will expect its arguments in the same places. 

Also OOT doing `laze build -b ... run/clippy/tree` will work on the OOT application by default (as expected) whereas `laze build -b ... cargo tree` will work on the default member of Ariel OS's workspace *i.e.* the `hello-world` example. 

I'm open to my second commit being too opinionated and thus needing to be removed. I will say though that without it, you can't `laze build cargo run` or `laze build cargo clippy` (but then again OOT if you don't remember to do `--apps my-app` you'll actually run those against the `hello-world` example and not your application plus there are already laze tasks for that).

Could be a release blocker I guess.
<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
