### PR TITLE
feat(vscode-config): only set toolchain when needed

### DIFF
--- a/book/src/vscode-configuration.md
+++ b/book/src/vscode-configuration.md
@@ -14,18 +14,6 @@ It is also recommended to use the the `Even Better TOML` exentsion to have TOML 
 
 This is meant to be used on projects created using the `cargo-generate` command in the getting-started guide. The configuration works by targeting one [laze builder][laze-builders-book], avoiding the linter to be confused about double declarations.
 
-You will need to have a nightly version of Rust installed, you can install the latest one using:
-
-```sh
-rustup toolchain install nightly
-```
-
-Then install configure the toolchain by running this at the root of your project:
-
-```sh
-laze build -D CARGO_TOOLCHAIN=+nightly install-toolchain
-```
-
 To generate/update your vscode configuration in `.vscode/settings.json`, run in the root of your project:
 
 ```sh

--- a/scripts/vscode.rs
+++ b/scripts/vscode.rs
@@ -123,15 +123,12 @@ fn main() -> miette::Result<()> {
         Value::String("test-password".to_string()),
     );
 
-    // Default to nightly so cargo-metadata can correctly read the config
-    let mut toolchain = "+nightly".to_string();
     if let Ok(toolchain_env) = std::env::var("_CARGO_TOOLCHAIN") {
-        if !toolchain_env.is_empty() {
-            toolchain = toolchain_env
+        if toolchain_env.len() > 1 {
+            let toolchain = toolchain_env[1..].to_string(); // Remove the leading '+' character
+            extra_env.insert("RUSTUP_TOOLCHAIN".to_string(), Value::String(toolchain));
         }
     }
-    let toolchain = toolchain[1..].to_string(); // Remove the leading '+' character
-    extra_env.insert("RUSTUP_TOOLCHAIN".to_string(), Value::String(toolchain));
 
     // Copy the RUSTFLAGS environment variable, without the target prefix
     if let Ok(rustflags_env) = std::env::var("_RUSTFLAGS") {


### PR DESCRIPTION
# Description

Nightly isn't needed anymore for rust-analyzer to read the `include` configuration in `.cargo/config.toml`. This removes the `RUSTUP_TOOLCHAIN` environment when laze doesn't specify a toolchain.

## Testing

- Create an Ariel OS app and cd into it. 
- Run `laze build -b nrf52840dk vscode-config`
- Open VSCode, check if linter works by trying to trigger an error

Example code: 

```
    let a = 0u8;
    let b = a + 5u32;
```

If VSCode shows that there is an error, that means the configuration works.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
