### PR TITLE
fix(hal)!: seal the doc-only `IntoPeripheral` trait

### DIFF
--- a/src/ariel-os-hal/src/hal/dummy/peripheral.rs
+++ b/src/ariel-os-hal/src/hal/dummy/peripheral.rs
@@ -5,13 +5,17 @@
 pub struct OptionalPeripherals;
 
 /// Helper trait to support both `Peri` style and singleton style peripherals.
-pub trait IntoPeripheral<'a, P> {
+// NOTE: the trait is sealed as it is only used for documentation, and should never be implemented
+// by users on anything.
+pub trait IntoPeripheral<'a, P>: private::Sealed {
     #[must_use]
     fn into_hal_peripheral(self) -> Self;
 }
 
 #[doc(hidden)]
 pub struct Peripheral;
+
+impl private::Sealed for Peripheral {}
 
 impl<T> IntoPeripheral<'_, T> for Peripheral {
     fn into_hal_peripheral(self) -> Peripheral {
@@ -27,4 +31,8 @@ impl From<Peripherals> for OptionalPeripherals {
     fn from(_peripherals: Peripherals) -> Self {
         Self {}
     }
+}
+
+mod private {
+    pub trait Sealed {}
 }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This seals the dummy/doc-only variant of `IntoPeripheral` to make sure users never implement it.

BREAKING CHANGE: invalidates inappropriate user implementations of the trait.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The variant of the `IntoPeripheral` trait that is used only for documentation is now sealed. It should never be implemented on anything outside of Ariel OS.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
