### PR TITLE
docs(examples): add the anonymous lifetime on `I2cDevice` types

### DIFF
--- a/examples/sensors-debug/src/sensors.rs
+++ b/examples/sensors-debug/src/sensors.rs
@@ -16,7 +16,7 @@ pub async fn init() {
 mod lis2du12 {
     use ariel_os::i2c::controller::I2cDevice;
 
-    pub static LIS2DU12_I2C: ariel_os_sensor_lis2du12::i2c::Lis2du12<I2cDevice> =
+    pub static LIS2DU12_I2C: ariel_os_sensor_lis2du12::i2c::Lis2du12<I2cDevice<'_>> =
         const { ariel_os_sensor_lis2du12::i2c::Lis2du12::new(Some("onboard")) };
     #[ariel_os::reexports::linkme::distributed_slice(ariel_os::sensors::SENSOR_REFS)]
     #[linkme(crate = ariel_os::reexports::linkme)]
@@ -53,7 +53,7 @@ pub use lis2du12::LIS2DU12_I2C;
 mod lps22df {
     use ariel_os::i2c::controller::I2cDevice;
 
-    pub static LPS22DF_I2C: ariel_os_sensor_lps22df::i2c::Lps22df<I2cDevice> =
+    pub static LPS22DF_I2C: ariel_os_sensor_lps22df::i2c::Lps22df<I2cDevice<'_>> =
         const { ariel_os_sensor_lps22df::i2c::Lps22df::new(Some("onboard")) };
     #[ariel_os::reexports::linkme::distributed_slice(ariel_os::sensors::SENSOR_REFS)]
     #[linkme(crate = ariel_os::reexports::linkme)]
@@ -90,7 +90,7 @@ pub use lps22df::LPS22DF_I2C;
 mod stts22h {
     use ariel_os::i2c::controller::I2cDevice;
 
-    pub static STTS22H_I2C: ariel_os_sensor_stts22h::i2c::Stts22h<I2cDevice> =
+    pub static STTS22H_I2C: ariel_os_sensor_stts22h::i2c::Stts22h<I2cDevice<'_>> =
         const { ariel_os_sensor_stts22h::i2c::Stts22h::new(Some("onboard")) };
     #[ariel_os::reexports::linkme::distributed_slice(ariel_os::sensors::SENSOR_REFS)]
     #[linkme(crate = ariel_os::reexports::linkme)]

--- a/examples/thermometer/src/sensors.rs
+++ b/examples/thermometer/src/sensors.rs
@@ -10,7 +10,7 @@ pub async fn init() {
 mod stts22h {
     use ariel_os::i2c::controller::I2cDevice;
 
-    pub static STTS22H_I2C: ariel_os_sensor_stts22h::i2c::Stts22h<I2cDevice> =
+    pub static STTS22H_I2C: ariel_os_sensor_stts22h::i2c::Stts22h<I2cDevice<'_>> =
         const { ariel_os_sensor_stts22h::i2c::Stts22h::new(Some("onboard")) };
     #[ariel_os::reexports::linkme::distributed_slice(ariel_os::sensors::SENSOR_REFS)]
     #[linkme(crate = ariel_os::reexports::linkme)]


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This adds the missing anonymous lifetime on `I2cDevice` types on sensor-related examples, required since #1793. Fixes the following kind of warnings:

```sh
warning: hidden lifetime parameters in types are deprecated
  --> examples/thermometer/src/sensors.rs:13:67
   |
13 |     pub static STTS22H_I2C: ariel_os_sensor_stts22h::i2c::Stts22h<I2cDevice> =
   |                                                                   ^^^^^^^^^ expected lifetime parameter
   |
   = note: `-W elided-lifetimes-in-paths` implied by `-W rust-2018-idioms`
   = help: to override `-W rust-2018-idioms` add `#[allow(elided_lifetimes_in_paths)]`
help: indicate the anonymous lifetime
   |
13 |     pub static STTS22H_I2C: ariel_os_sensor_stts22h::i2c::Stts22h<I2cDevice<'_>> =
   |
```

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #1913

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
