### PR TITLE
fix(eth-stm32)!: randomize the Ethernet MAC address on every boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
  "embedded-io-async 0.6.1",
  "paste",
  "portable-atomic",
+ "rand_core 0.9.3",
  "static_cell",
  "stm32-metapac",
 ]

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1353,6 +1353,7 @@ modules:
   - name: eth-stm32
     selects:
       - has_eth_stm32
+      - hwrng
       - network
     provides_unique:
       - network_device

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -27,6 +27,7 @@ embedded-hal-async = { workspace = true }
 embedded-io-async = { workspace = true, optional = true }
 paste = { workspace = true }
 portable-atomic = { workspace = true }
+rand_core = { workspace = true, optional = true }
 static_cell = { workspace = true }
 
 [target.'cfg(use_stm32_single_bank)'.dependencies]
@@ -79,7 +80,14 @@ storage = ["dep:embassy-embedded-hal"]
 usb = []
 
 eth = []
-eth-stm32 = ["dep:embassy-embedded-hal", "eth"]
+# The `hwrng` Cargo feature is enabled through the laze module of the same name.
+eth-stm32 = [
+  "dep:ariel-os-random",
+  "dep:embassy-embedded-hal",
+  "dep:rand_core",
+  "ariel-os-random?/csprng",
+  "eth",
+]
 
 ## Enables defmt support.
 defmt = ["dep:defmt", "embassy-stm32/defmt"]

--- a/src/ariel-os-stm32/src/eth.rs
+++ b/src/ariel-os-stm32/src/eth.rs
@@ -7,12 +7,14 @@ bind_interrupts!(struct Irqs {
     ETH => eth::InterruptHandler;
 });
 
+type MacAddress = [u8; 6];
+
 pub type NetworkDevice = Ethernet<'static, ETH, GenericPhy>;
 
 pub fn device(peripherals: &mut crate::OptionalPeripherals) -> NetworkDevice {
     static PKTS: StaticCell<eth::PacketQueue<4, 4>> = StaticCell::new();
 
-    let mac_addr = [0xCA, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC];
+    let mac_addr = generate_random_aai_mac_addr();
 
     Ethernet::new(
         PKTS.init(eth::PacketQueue::<4, 4>::new()),
@@ -30,4 +32,17 @@ pub fn device(peripherals: &mut crate::OptionalPeripherals) -> NetworkDevice {
         GenericPhy::new(0),
         mac_addr,
     )
+}
+
+fn generate_random_aai_mac_addr() -> MacAddress {
+    use rand_core::RngCore as _;
+
+    let mut eui48 = [0u8; _];
+    ariel_os_random::crypto_rng().fill_bytes(&mut eui48);
+
+    // Enforce the `?2-??-??-??-??-??` pattern of an AAI (Administratively Assigned Identifier).
+    eui48[0] &= 0xf0;
+    eui48[0] |= 0x02;
+
+    eui48
 }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Support for Ethernet on STM32 boards was introduced in #993 (but is currently undocumented, see #1925), with a hard-coded MAC address. This replaces this fixed address, with a randomized address in the AAI format.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested the `udp-echo` example using:

```sh
laze -C examples/udp-echo/ build -s eth-stm32 -b st-nucleo-h755zi-q
```

A log statement can manually be added to print the generated MAC address and check it complies to the expected format.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Needed before #1926

## Open Questions

<!-- Unresolved questions, if any. -->
- Should we rely on the device identity instead? It's unclear to me how to make sure that only one interface gets each MAC address from [`interface_eui48()`](https://ariel-os.github.io/ariel-os/0.4.0/docs/api/ariel_os/identity/fn.interface_eui48.html).

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(STM32) Ethernet support on STM32 MCUs is now using a MAC address randomized on every boot instead of a fixed one.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
