### PR TITLE
fix(eth-stm32)!: generate the MAC address based on the device identity

### DIFF
--- a/src/ariel-os-stm32/src/ethernet.rs
+++ b/src/ariel-os-stm32/src/ethernet.rs
@@ -3,6 +3,9 @@ use embassy_stm32::peripherals::ETH;
 use embassy_stm32::{bind_interrupts, eth};
 use static_cell::StaticCell;
 
+// Index of the builtin Ethernet MAC, used for generating the MAC address.
+const IF_INDEX: u32 = 0;
+
 bind_interrupts!(struct Irqs {
     ETH => eth::InterruptHandler;
 });
@@ -12,7 +15,7 @@ pub type NetworkDevice = Ethernet<'static, ETH, GenericPhy>;
 pub fn device(peripherals: &mut crate::OptionalPeripherals) -> NetworkDevice {
     static PKTS: StaticCell<eth::PacketQueue<4, 4>> = StaticCell::new();
 
-    let mac_addr = [0xCA, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC];
+    let mac_addr = get_mac_address();
 
     Ethernet::new(
         PKTS.init(eth::PacketQueue::<4, 4>::new()),
@@ -30,4 +33,15 @@ pub fn device(peripherals: &mut crate::OptionalPeripherals) -> NetworkDevice {
         GenericPhy::new(0),
         mac_addr,
     )
+}
+
+/// Returns a stable MAC address based on the device identity.
+fn get_mac_address() -> [u8; 6] {
+    use ariel_os_embassy_common::identity::DeviceId;
+
+    // NOTE(no-panic): infallible on STM32.
+    match crate::identity::DeviceId::get() {
+        Ok(device_id) => device_id.interface_eui48(IF_INDEX).0,
+        Err(_) => unreachable!(),
+    }
 }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Support for Ethernet on STM32 boards was introduced in #993 (but is currently undocumented, see #1925), with a hard-coded MAC address. This replaces this fixed address with a stable MAC address derived from the device identity.

Documentation for the interface index will be added in #1926.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested the `udp-echo` example using:

```sh
laze -C examples/udp-echo/ build -s ethernet-stm32 -b st-nucleo-h755zi-q
```

I've added a log statement to print the generated MAC address and checked it complies to the expected format and is stable across reboots.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Supersedes #1927
- Needed before #1926

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(STM32) Ethernet support on STM32 MCUs is now using a stable MAC address (derived from the device identity) instead of a fixed one.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
