### PR TITLE
feat: bump `embassy-time` to 0.5.1 and `embassy-time-driver` to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,8 +2340,8 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.5.0"
-source = "git+https://github.com/ariel-os/embassy?rev=32919cd38e4a5ad5fc21dfb339abd45a74bd1dc9#32919cd38e4a5ad5fc21dfb339abd45a74bd1dc9"
+version = "0.5.1"
+source = "git+https://github.com/ariel-os/embassy?rev=3c1b5fbf28237ea7144ae970c3aec11c38023c3f#3c1b5fbf28237ea7144ae970c3aec11c38023c3f"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -2357,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-driver"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a244c7dc22c8d0289379c8d8830cae06bb93d8f990194d0de5efb3b5ae7ba6"
+checksum = "6ee71af1b3a0deaa53eaf2d39252f83504c853646e472400b763060389b9fcc9"
 dependencies = [
  "document-features",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,8 @@ embassy-nrf = { version = "0.8.0", default-features = false }
 embassy-rp = { version = "0.8", default-features = false }
 embassy-stm32 = { version = "0.4", default-features = false }
 embassy-sync = { version = "0.7.2", default-features = false }
-embassy-time = { version = "0.5.0", default-features = false }
-embassy-time-driver = { version = "0.2.1", default-features = false }
+embassy-time = { version = "0.5.1", default-features = false }
+embassy-time-driver = { version = "0.2.2", default-features = false }
 embassy-time-queue-utils = { version = "0.3.0", default-features = false }
 embassy-usb = { version = "0.5.1", default-features = false }
 

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -31,8 +31,8 @@ embassy-net = { git = "https://github.com/ariel-os/embassy", rev = "3b185bf1b385
 embassy-rp = { git = "https://github.com/ariel-os/embassy", rev = "0314802282e112a47b4ccb303c0e7f09cf33df53" }
 # branch = "embassy-stm32-v0.4.0+ariel-os"
 embassy-stm32 = { git = "https://github.com/ariel-os/embassy", rev = "1b75c3d6e61a99a312e2d12f039fa6e76e9c3a9c" }
-# branch = "embassy-time-v0.5.0+ariel-os"
-embassy-time = { git = "https://github.com/ariel-os/embassy", rev = "32919cd38e4a5ad5fc21dfb339abd45a74bd1dc9" }
+# branch = "embassy-time-v0.5.1+ariel-os"
+embassy-time = { git = "https://github.com/ariel-os/embassy", rev = "3c1b5fbf28237ea7144ae970c3aec11c38023c3f" }
 # branch = "embassy-usb-synopsys-otg-v0.3.1+ariel-os
 embassy-usb-synopsys-otg = { git = "https://github.com/ariel-os/embassy", rev = "478df29985c8e0d0ff2e915440c8ca15e36f4403" }
 # ariel-os esp-hal fork, using branch = "esp-hal-v1.0.0+20251203+ariel-os"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -43,11 +43,24 @@ who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"
 version = "0.1.0"
 
+[[audits.embassy-time]]
+who = "ROMemories <152802150+ROMemories@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.0@git:32919cd38e4a5ad5fc21dfb339abd45a74bd1dc9 -> 0.5.1@git:3c1b5fbf28237ea7144ae970c3aec11c38023c3f"
+importable = false
+notes = "Nanosecond-related methods have been introduced, along with a new tick rate and dependency updates."
+
 [[audits.embassy-time-driver]]
 who = "ROMemories <152802150+ROMemories@users.noreply.github.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.0 -> 0.2.1"
 notes = "A very minor update: only an extra tick setting is added, a few methods inlined, and the Cargo.lock is now distributed."
+
+[[audits.embassy-time-driver]]
+who = "ROMemories <152802150+ROMemories@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
+notes = "Edition 2024 is now used, which requires a few extra `unsafe` keywords that do not affect the behavior in any way, and a new tick rate has been introduced."
 
 [[audits.embedded-io]]
 who = "chrysn <chrysn@fsfe.org>"


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This updates `embassy-time` and `embassy-time-driver` to the latest versions, which are compatible with the current ones. Even though we re-export `embassy-time` as a whole in `ariel_os::reexports`, this is therefore not a breaking change.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested the `gpio` example using the following:

```sh
laze -C examples/gpio/ build -b nrf52840dk run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The `embassy-time` crate re-exported as `ariel_os::reexports::embassy_time` has been updated from v0.5.0 to v0.5.1.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
