### PR TITLE
docs(http-client): make the app not enable `time` as that is unnecessary

### DIFF
--- a/examples/http-client/Cargo.toml
+++ b/examples/http-client/Cargo.toml
@@ -10,7 +10,6 @@ ariel-os = { path = "../../src/ariel-os", features = [
   "dns",
   "mdns",
   "tcp",
-  "time",
 ] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This makes the `http-client` example not enable the `time` Cargo feature as it is simply not needed: neither `ariel_os::time` `ariel_os::reexports::embassy_time` are used, and `embassy-time` is not separately imported by the example either, so it doesn't directly need an `embassy-time` time driver. This would have made it easier to find #1949.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Currently this makes the `http-client` panic at startup on ESP due to #1949.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #1949

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The `http-client` example no longer needlessly enables the `time` Cargo feature.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
