### PR TITLE
fix: make usb port available on nordic-thingy-91-x-nrf5340-app 

### DIFF
--- a/boards/nordic-thingy-91-x.yaml
+++ b/boards/nordic-thingy-91-x.yaml
@@ -18,6 +18,8 @@ boards:
 
   nordic-thingy-91-x-nrf5340-app:
     chip: nrf5340-app
+    flags:
+      - has_usb_device_port
     leds:
       led0:
         pin: P0_14

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -82,6 +82,7 @@ builders:
   provides:
   - has_buttons
   - has_leds
+  - has_usb_device_port
 - name: nordic-thingy-91-x-nrf5340-net
   parent: nrf5340-net
   provides:


### PR DESCRIPTION
# Description

USB for `nordic-thingy-91-x-nrf5340-app` is marked as supported in the documentation but wasn't enabled in the board description. This PR enables USB for it in the board description.

## Testing

Tested with: 

```
laze -C examples/http-server/ build -d network-config-dhcp -b nordic-thingy-91-x-nrf5340-app run
```

and 

```
laze -C examples/usb-serial/ build -b nordic-thingy-91-x-nrf5340-app run
```


## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->


## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(Nordic Thingy:91 X) USB is now usable on the `nordic-thingy-91-x-nrf5340-app` laze builder. This fixes the discrepancy between the docs and the build system. 
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
