### PR TITLE
fix(esp): make timers compatible with internally-enabled threading

### DIFF
--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -148,7 +148,12 @@ nrf91-modem = ["ariel-os-hal/nrf91-modem"]
 threading = [
   "dep:ariel-os-threads",
   "ariel-os-hal/threading",
-  # this sets the default timer queue size, which is currently 64. See `generic-queue-*` features.
+  # This enables the timer queue implementation provided by
+  # `embassy-time-queue-utils` that is independent of `embassy-executor` (i.e.,
+  # the generic queue implementation), allowing `embassy_timer::Timer`s to be
+  # used in threads and/or when our custom executor is used.
+  # The default queue size is 64 (see the `generic-queue-*` features of
+  # `embassy-time-queue-utils`).
   "embassy-time-queue-utils?/_generic-queue",
 ]
 

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -120,11 +120,11 @@ threading = [
   "embassy-time-queue-utils?/_generic-queue",
 ]
 
-## Enables timers
+## Enables a time driver.
 time = [
-  "dep:embassy-time",
   "dep:embassy-time-driver",
   "dep:embassy-time-queue-utils",
+  # `esp-sync` is used for the time driver.
   "dep:esp-sync",
 ]
 
@@ -160,7 +160,14 @@ ble-peripheral = ["ble-esp"]
 wifi = []
 
 ## Enables built-in Wi-Fi hardware.
-wifi-esp = ["dep:allocator-api2", "_radio-esp", "esp-radio?/wifi", "wifi"]
+wifi-esp = [
+  "dep:allocator-api2",
+  # `embassy-time` is used for Wi-Fi-specific functionality.
+  "dep:embassy-time",
+  "_radio-esp",
+  "esp-radio?/wifi",
+  "wifi",
+]
 
 ## Enables facilities required by the built-in Wi-Fi and/or BLE radio.
 _radio-esp = [
@@ -169,8 +176,10 @@ _radio-esp = [
   "dep:esp-alloc",
   "dep:esp-radio",
   "dep:esp-radio-rtos-driver",
+  # `esp-sync` is used in scheduler-related facilities.
   "dep:esp-sync",
   "esp-radio?/esp-alloc",
+  "time",
 ]
 
 #! ## Executor type selection for the (autostarted) main executor

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -111,7 +111,14 @@ spi = ["dep:embassy-embedded-hal", "dep:fugit", "ariel-os-embassy-common/spi"]
 uart = ["dep:embedded-io-async", "ariel-os-embassy-common/uart"]
 
 ## Enables threading support.
-threading = ["dep:ariel-os-threads"]
+threading = [
+  "dep:ariel-os-threads",
+  # See `ariel-os-embassy` for an explanation of what this enables.
+  # This needs to be duplicated here because this HAL depends on
+  # `embassy-time-queue-utils` directly, and `_generic-queue` would otherwise
+  # not be enabled when `time` is enabled from this crate alone.
+  "embassy-time-queue-utils?/_generic-queue",
+]
 
 ## Enables timers
 time = [


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This fixes #1949: `embassy-time-queue-utils?/_generic-queue` was not enabled (in `ariel-os-esp`) by enabling `threading` because `embassy-time-queue-utils` was only enabled *inside*  `ariel-os-esp` and not from inside `ariel-os-embassy` where the `embassy-time-queue-utils` + `embassy-time-queue-utils?/_generic-queue` logic is.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
The `udp-echo` example (which does not enable `time` at application-level) now works on ESPs.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #1964
- Fixes #1949

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(ESP32) It is now possible to use the built-in Wi-Fi and BLE radio without enabling the `time` Cargo feature at the same time. 
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
