### PR TITLE
refactor(embassy-common): enable `embassy-time` only when needed

### DIFF
--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -12,7 +12,7 @@ ariel-os-utils = { workspace = true }
 const-sha1 = { version = "0.3.0", default-features = false }
 defmt = { workspace = true, optional = true }
 embassy-executor = { workspace = true }
-embassy-time = { workspace = true }
+embassy-time = { workspace = true, optional = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }
 fugit = { workspace = true, optional = true }
@@ -24,7 +24,7 @@ trouble-host = { workspace = true, optional = true }
 external-interrupts = []
 
 ## Enables I2C support.
-i2c = ["dep:fugit"]
+i2c = ["dep:embassy-time", "dep:fugit"]
 
 ## Enables SPI support.
 spi = ["dep:fugit"]

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -31,6 +31,7 @@ pub mod reexports {
     //! Crate re-exports.
 
     // Used by macros provided by this crate.
+    #[cfg(feature = "i2c")]
     pub use embassy_time;
     pub use embedded_hal_async;
 }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
`embassy-time` currently is a non-optional dependency of `ariel-os-embassy-common`, which makes it always part of the build, even though it is only necessary (in that crate) for I2C. In applications that do not enable the `time` Cargo feature, and that do not otherwise transitively rely on `embassy-time`, `embassy-time` was only part of the build because of `ariel-os-embassy-common`, as can be seen with the following:

```sh
laze -C examples/log build -b stm32u083c-dk tree --no-dedupe --invert embassy-time
```

This PR enables `embassy-time` in `ariel-os-embassy-common` only when `i2c` is enabled, as that is the only thing that requires it in that crate.  

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Grepping in `ariel-os-embassy-common` can be useful to check that `i2c` is only the only thing that needs `embassy-time`.

Successfully tested the `log` and `sensors-debug` (which uses I2C) on the stm32u083c-dk.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
`embassy-time` is no longer *always* part of the build of Ariel OS. It was previously compiled even when it was not actually necessary.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
