### PR TITLE
fix(boards): fix st-nucleo-h755zi-q red led pin

### DIFF
--- a/boards/st-nucleo-h755zi-q.yaml
+++ b/boards/st-nucleo-h755zi-q.yaml
@@ -21,7 +21,7 @@ targets:
         color: yellow
         active: high
       led2:
-        pin: PE1
+        pin: PB14
         aliases:
           - LD3
         color: red

--- a/src/ariel-os-boards/src/st-nucleo-h755zi-q.rs
+++ b/src/ariel-os-boards/src/st-nucleo-h755zi-q.rs
@@ -3,7 +3,7 @@
 pub mod pins {
     use ariel_os_hal::hal::peripherals;
     ariel_os_hal::define_peripherals!(
-        LedPeripherals { led0 : PB0, led1 : PE1, led2 : PE1, }
+        LedPeripherals { led0 : PB0, led1 : PE1, led2 : PB14, }
     );
     ariel_os_hal::define_peripherals!(ButtonPeripherals { button0 : PC13, });
 }


### PR DESCRIPTION
# Description

The red led pin was wrong (duplicate of the yellow pin), PB14 is correct according to [zephyr docs](https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/st/nucleo_h755zi_q/nucleo_h755zi_q.dtsi?plain=1).

## Testing

did not test

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Found using https://github.com/ariel-os/sbd/pull/140.

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(ST NUCLEO-H755ZI-Q) The pin association of the red LED (LD3) has been fixed.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
