### PR TITLE
feat(editor-config): add support for Zed and Gram

### DIFF
--- a/book/src/code-editor-configuration.md
+++ b/book/src/code-editor-configuration.md
@@ -20,7 +20,7 @@ It is also recommended to use the the `Even Better TOML` extension to have TOML 
 
 ### Configuration for developing Ariel OS apps (vscode)
 
-This is meant to be used on projects created using the `cargo-generate` command in the getting-started guide. The configuration works by targeting one [laze builder][laze-builders-book], avoiding the linter to be confused about double declarations.
+This is meant to be used on projects created using the `cargo-generate` command in the getting-started guide. The configuration works by targeting one [laze builder][laze-builders-book], avoiding complaints from the linter about double declarations.
 
 To generate/update your vscode configuration in `.vscode/settings.json`, run in the root of your project:
 
@@ -44,12 +44,44 @@ rustup component add rust-analyzer
 
 ### Configuration for developing Ariel OS apps (helix)
 
-This is meant to be used on projects created using the `cargo-generate` command in the getting-started guide. The configuration works by targeting one [laze builder][laze-builders-book], avoiding the linter to be confused about double declarations.
+This is meant to be used on projects created using the `cargo-generate` command in the getting-started guide. The configuration works by targeting one [laze builder][laze-builders-book], avoiding complaints from the linter about double declarations.
 
 To generate/update your helix configuration in `.helix/languages.json`, run in the root of your project:
 
 ```sh
 laze build -b <builder> editor-config helix
+```
+
+## Zed
+
+[Zed](https://zed.dev/) is a code editor built in Rust with a fast and lightweight user interface. The Rust extension and language server is automatically installed when opening a `.rs` file.
+
+### Configuration for developing Ariel OS apps (Zed)
+
+This is meant to be used on projects created using the `cargo-generate` command in the getting-started guide. The configuration works by targeting one [laze builder][laze-builders-book], avoiding complaints from the linter about double declarations.
+
+To generate/update your Zed configuration in `.zed/settings.json`, run in the root of your project:
+
+```sh
+laze build -b <builder> editor-config zed
+```
+
+## Gram
+
+[Gram](https://gram.liten.app/) is a hard fork of Zed disabling AI features and focusing on stability.
+
+### Enabling Rust support on Gram
+
+User action is needed to authorize Gram to download rust-analyzer. Open a Rust source file, then open the language server configuration by clicking the fifth icon on the bottom left of the editor (should have a red notification dot) or typing `lsp::OpenLanguageServerConfig` in the command palette and finally enable "Allow download" for `rust-analyzer`.
+
+### Configuration for developing Ariel OS apps (Gram)
+
+This is meant to be used on projects created using the `cargo-generate` command in the getting-started guide. The configuration works by targeting one [laze builder][laze-builders-book], avoiding complaints from the linter about double declarations.
+
+To generate/update your Gram configuration in `.gram/settings.jsonc`, run in the root of your project:
+
+```sh
+laze build -b <builder> editor-config gram
 ```
 
 ## Generic rust-analyzer

--- a/scripts/editor-config.rs
+++ b/scripts/editor-config.rs
@@ -39,6 +39,8 @@ enum SubCommand {
     VsCode(VsCode),
     RustAnalyzer(RustAnalyzer),
     Helix(Helix),
+    Zed(Zed),
+    Gram(Gram),
 }
 
 impl SubCommand {
@@ -47,6 +49,8 @@ impl SubCommand {
             Self::RustAnalyzer(command) => command.run(),
             Self::VsCode(command) => command.run(),
             Self::Helix(command) => command.run(),
+            Self::Zed(command) => command.run(),
+            Self::Gram(command) => command.run(),
         }
     }
 }
@@ -123,6 +127,91 @@ impl VsCode {
 }
 
 #[derive(argh::FromArgs)]
+#[argh(subcommand, name = "zed")]
+/// Generate configuration for Zed.
+struct Zed {}
+
+impl Zed {
+    fn run(&self) -> miette::Result<()> {
+        zed_and_forks(ZedFlavor::Zed)
+    }
+}
+
+#[derive(argh::FromArgs)]
+#[argh(subcommand, name = "gram")]
+/// Generate configuration for Gram.
+struct Gram {}
+
+impl Gram {
+    fn run(&self) -> miette::Result<()> {
+        zed_and_forks(ZedFlavor::Gram)
+    }
+}
+
+enum ZedFlavor {
+    Zed,
+    Gram,
+}
+
+fn zed_and_forks(flavor: ZedFlavor) -> miette::Result<()> {
+    let directory_path = match flavor {
+        ZedFlavor::Zed => PathBuf::from(".zed"),
+        ZedFlavor::Gram => PathBuf::from(".gram"),
+    };
+
+    // create directory if it doesn't exist
+    if !directory_path.exists() {
+        fs::create_dir_all(&directory_path).map_err(Error::from)?;
+    }
+
+    let settings_path = match flavor {
+        ZedFlavor::Zed => directory_path.join("settings.json"),
+        ZedFlavor::Gram => directory_path.join("settings.jsonc"),
+    };
+    // create settings.json file if it doesn't exist
+    if !settings_path.exists() {
+        fs::write(&settings_path, "{}").map_err(Error::from)?;
+    }
+
+    let settings_file = fs::File::open(&settings_path).map_err(Error::from)?;
+
+    // FIXME: properly parse jsonc files, this will throw an error if there's a comment.
+    let mut settings_json: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_reader(settings_file).map_err(Error::from)?;
+
+    let settings = settings_from_env()?;
+
+    // rust-analyzer config in Zed is in object `lsp.rust-analyzer.initialization_options`
+
+    let mut wrapped_settings_rust_analyzer = HashMap::new();
+    wrapped_settings_rust_analyzer
+        .insert("initialization_options".to_string(), Value::Map(settings));
+
+    let mut wrapped_settings_lsp = HashMap::new();
+    wrapped_settings_lsp.insert(
+        "rust-analyzer".to_string(),
+        Value::Map(wrapped_settings_rust_analyzer),
+    );
+
+    let mut wrapped_settings = HashMap::new();
+    wrapped_settings.insert("lsp".to_string(), Value::Map(wrapped_settings_lsp));
+
+    for (key, value) in wrapped_settings {
+        settings_json.insert(key, value.into());
+    }
+
+    let settings_json_string = serde_json::to_string_pretty(&settings_json).map_err(Error::from)?;
+    fs::write(&settings_path, settings_json_string).map_err(Error::from)?;
+    println!(
+        "Updated settings in {}",
+        std::path::absolute(settings_path)
+            .map_err(Error::from)?
+            .to_string_lossy()
+    );
+    Ok(())
+}
+
+#[derive(argh::FromArgs)]
 #[argh(subcommand, name = "rust-analyzer")]
 /// Generate configuration for generi rust-analyzer (rust-analyzer.toml).
 struct RustAnalyzer {}
@@ -164,7 +253,6 @@ struct Helix {}
 
 impl Helix {
     fn run(&self) -> miette::Result<()> {
-
         // create directory if it doesn't exist
         let directory_path = PathBuf::from(".helix");
         if !directory_path.exists() {
@@ -184,16 +272,20 @@ impl Helix {
 
         let settings = settings_from_env()?;
 
-        // rust-analyzer config in Helix is in struct `language-server.rust-analyzer.config`
+        // rust-analyzer config in Helix is in object `language-server.rust-analyzer.config`
 
         let mut wrapped_settings_rust_analyzer = HashMap::new();
         wrapped_settings_rust_analyzer.insert("config".to_string(), settings);
 
         let mut wrapped_settings_language_server = HashMap::new();
-        wrapped_settings_language_server.insert("rust-analyzer".to_string(), wrapped_settings_rust_analyzer);
+        wrapped_settings_language_server
+            .insert("rust-analyzer".to_string(), wrapped_settings_rust_analyzer);
 
         let mut wrapped_settings = HashMap::new();
-        wrapped_settings.insert("language-server".to_string(), wrapped_settings_language_server);
+        wrapped_settings.insert(
+            "language-server".to_string(),
+            wrapped_settings_language_server,
+        );
 
         for (key, value) in wrapped_settings {
             settings_toml.insert(key, value.into());
@@ -305,9 +397,7 @@ fn settings_from_env() -> miette::Result<HashMap<String, Value>> {
         override_command.extend(extra_args);
         override_command.push(Value::String("--message-format=json".to_string()));
 
-
         let mut build_script = HashMap::new();
-
 
         build_script.insert(
             "overrideCommand".to_string(),
@@ -318,8 +408,6 @@ fn settings_from_env() -> miette::Result<HashMap<String, Value>> {
     }
 
     settings.insert("check".to_string(), Value::Map(check));
-
-
 
     let features_str = features_args.replace("--features=", "");
     let features_list = features_str


### PR DESCRIPTION
# Description

Adds support for generating configuration for Zed and Gram (Zed fork).

## Testing

Use this branch in an Ariel OS app, run 

```
laze build -b nrf52840dk editor-config gram
laze build -b nrf52840dk editor-config zed
```

Open a source file in Gram and Zed check if go to definition works, add an error to the code and check if linting works.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The editor configuration generation task has been renamed from `vscode-config` to `editor-config vscode`. It now also supports Helix, Zed, Gram, and bare rust-analyzer.
<!-- changelog:end -->
This entry also incorporates the changes from #1974, and the changelog label is set to breaking, even though this PR itself is only additive.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
