### PR TITLE
docs(editor-config): document when to regenerate the config

### DIFF
--- a/book/src/code-editor-configuration.md
+++ b/book/src/code-editor-configuration.md
@@ -2,6 +2,10 @@
 
 This chapter covers how to setup supported code editors to get features in-editor linting, go to definition, documentation on hover, inlay hints.
 
+> [!NOTE]
+> The `editor-config` laze task generates a configuration according to the [laze builder used][laze-builders-book] and the [modules selected][laze-modules-book] (in the cli and in `laze-project.yml`). 
+> If you add/remove a module or want to target another builder, you will need to re-generate the configuration.
+
 ## VSCode
 
 [Visual Studio Code](https://code.visualstudio.com/) is a popular code editor that can easily be configured to work with Ariel OS.
@@ -61,3 +65,4 @@ laze build -b <builder> editor-config rust-analyzer
 At the time of writing (2026-03-30) some features don't work compared to using the Helix or VSCode configuration.
 
 [laze-builders-book]: ./build-system.md#laze-builders
+[laze-modules-book]: ./build-system.md#laze-modules


### PR DESCRIPTION
# Description

This adds a note to the users to indicate that they should re-generate the editor configuration when they change the builder or modules they use.

## Testing

Look at the book preview

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The documentation now explains when to re-generate the editor configuration.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
