### PR TITLE
fix: don't use semihosting with espflash

### DIFF
--- a/book/src/debug-console.md
+++ b/book/src/debug-console.md
@@ -21,6 +21,14 @@ The laze configuration automatically enables semihosting on the target when the 
 When the flashing tool does not, support for semihosting can still be enabled in the firmware by selecting the `semihosting` [laze module][laze-modules-book].
 This is needed to later be able to attach a semihosting-enabled host tool to the target.
 
+> [!NOTE]
+> When semihosting is enabled on the target and no host tool supporting semihosting (or a debugger) is connected, calling [`ariel_os::debug::exit()`][debug-exit-fn-rustdoc] may result in a panic.
+> For example on ESP using `espflash` you would get:
+>
+> ```
+> [ERROR] panicked at 'Unhandled interrupt on ProCpu' (esp_hal src/interrupt/mod.rs:90)
+> ```
+
 ## Logging
 
 Ariel OS supports logging on all platforms and it is enabled by default with the `logging-facade` [laze module][laze-modules-book].

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -24,7 +24,6 @@ contexts:
       - ?critical-section
       - ?hw/device-identity
       - ?lto
-      - ?semihosting
 
       # Selecting default toolchain here. try xtensa, stable, nightly.
       - ?xtensa
@@ -1160,6 +1159,7 @@ modules:
     help: use probe-rs as runner
     selects:
       - ?debug-console
+      - ?semihosting
       - defmt:
           - defmt-rtt
       - log:
@@ -1202,6 +1202,8 @@ modules:
           - probe-rs reset --chip ${PROBE_RS_CHIP} $@
 
   - name: openocd
+    selects:
+      - ?semihosting
     tasks:
       flash:
         cmd:


### PR DESCRIPTION
# Description

I searched the espflash codebase and found no mention of semihosting. I got confirmation in the esp-rs matrix chat espflash wasn't meant to be a debugger and handle semihosting calls.

## Testing

Shouldn't panic :

```
laze -C examples/hello-world build -b espressif-esp32-s3-devkitc-1 run 
```

Should still print "Firmware exited successfully": 

```
laze -C examples/hello-world build -b espressif-esp32-s3-devkitc-1 -s probe-rs run
```

## Issues/PRs References

- Depends on #1988
- Fixes #1756 

## Open Questions

There's no specific `espflash` laze module where `probe-rs` has one, should we make one ?

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Semihosting is now only enabled by default when probe-rs is selected as host tool during compilation. This fixes the "Unhandled interrupt" panic on Xtensa when calling `ariel_os::debug::exit()` when using `espflash`. Semihosting can be manually enabled using the `semihosting` laze module if needed.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
