### PR TITLE
refactor(flash-dfu)!: rename the `flash-dfu` laze task to `flash-dfuse`

### DIFF
--- a/book/src/boards/st-steval-mkboxpro.md
+++ b/book/src/boards/st-steval-mkboxpro.md
@@ -46,7 +46,7 @@ The `st-steval-mkboxpro` can be flashed using USB DFU and using a debug probe.
 
 After connecting a USB-C cable, start the bootloader with DFU by cycling the power of the microcontroller while pressing button 2 on the side of the case.
 The microcontroller enumerates as "STMicroelectronics STM Device in DFU Mode" on the host computer.
-Use the `laze build flash-dfu` task to flash the microcontroller.
+Use the `laze build flash-dfuse` task to flash the microcontroller.
 
 ##### Using a Debug Probe for Flashing
 

--- a/book/src/build-system.md
+++ b/book/src/build-system.md
@@ -24,8 +24,9 @@ Tasks available in Ariel OS include:
 
 - `run`: Compiles, flashes, and runs an application. The [debug output](./debug-console.md) is printed in the terminal.
 - `flash`: Compiles and flashes an application, before rebooting the target.
-- `flash-dfu`: (Currently only available for STM32.) Compiles and flashes an application via USB DFU, before rebooting the target if supported by the target's DFU bootloader.
-  Requires bootloader support for DFU in the board or microcontroller, and [dfu-util][dfu-util-homepage] on the host.
+- `flash-dfuse`: Only available on DfuSe devices, i.e., STM32 devices.
+  Compiles and flashes an application via DfuSe, the non-standard ST protocol based on USB DFU, before rebooting the target.
+  Requires bootloader support for DfuSe in the microcontroller, and [dfu-util][dfu-util-homepage] on the host.
 - `debug`: Starts a GDB debug session for the selected application.
   The application needs to be flashed using the `flash` task beforehand.
 - `flash-erase-all`: Erases the entire flash memory, including user data. Unlocks it if locked.

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -1255,7 +1255,7 @@ builders:
 
       After connecting a USB-C cable, start the bootloader with DFU by cycling the power of the microcontroller while pressing button 2 on the side of the case.
       The microcontroller enumerates as "STMicroelectronics STM Device in DFU Mode" on the host computer.
-      Use the `laze build flash-dfu` task to flash the microcontroller.
+      Use the `laze build flash-dfuse` task to flash the microcontroller.
 
       ##### Using a Debug Probe for Flashing
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -544,7 +544,7 @@ contexts:
     env:
       OPENOCD_ARGS: foo
     tasks:
-      flash-dfu:
+      flash-dfuse:
         cmd:
           - llvm-objcopy -O binary ${out} ${out}.bin
           - 'dfu-util -d 0483:df11 -a 0 -s 0x08000000:leave -D ${out}.bin || echo "... Note: dfu-util sometimes fails despite the upload being correct."'


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This renames the `flash-dfu` laze task to `flash-dfuse` as it is only available on STM32 devices and *is* DfuSe-specific. [DfuSe is based on USB DFU, but is ST's non-standard protocol and is incompatible](https://dfu-util.sourceforge.net/dfuse.html) with [standard USB DFU](https://www.usb.org/sites/default/files/DFU_1.1.pdf). 

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested with:

```sh
laze -C examples/blinky/ build -b st-steval-mkboxpro flash-dfuse
```

There is no remaining occurrences of `flash-dfu\b` in the codebase.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The `flash-dfu` laze task has been renamed to `flash-dfuse` for clarity, as it is only available on DfuSe devices, i.e., STM32 devices.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
