### PR TITLE
docs(log): use `debug::log::println!()` in applications when relevant

### DIFF
--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{log::*, println};
+use ariel_os::debug::log::*;
 
 #[ariel_os::task(autostart)]
 async fn main() {

--- a/tests/benchmarks/bench_sched_yield/src/main.rs
+++ b/tests/benchmarks/bench_sched_yield/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::{debug::println, thread};
+use ariel_os::{debug::log::println, thread};
 
 #[ariel_os::thread(autostart)]
 fn thread0() {


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This uses `ariel_os::debug::log::println!()` instead of `ariel_os::debug::println!()` for the two relevant occurrences in the codebase. `ariel_os::debug::log::println!()` is not *always* the right choice (especially as the future of `ariel_os::debug::println!()` is simply unclear), but it is in these cases.

On top of being semantically the right choice, this helps reduce the size of the binary in some cases, as it enables using `defmt` (which may or may not be used with `ariel_os::debug::println!()`), and especially on ESP32.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Comparing the binary size of the `log` example on ESP32-C6, this saves 116 bytes of `.text`. Additionally, it can be seen that the `println!()` message is now `defmt`-encoded, for instance by using a regular serial monitor on the UART output of an ESP32-C6 running the `log` example.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
I don't think this has to go into the changelog, this is just alignment with the upcoming documentation of debug logging transports. 

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
