### PR TITLE
refactor(debug): move the exit-related items to a dedicated module

### DIFF
--- a/src/ariel-os-debug/src/exit.rs
+++ b/src/ariel-os-debug/src/exit.rs
@@ -1,0 +1,51 @@
+/// Represents the exit code of a debug session.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ExitCode {
+    #[doc(hidden)]
+    Success,
+    #[doc(hidden)]
+    Failure,
+}
+
+impl ExitCode {
+    /// The [`ExitCode`] for success.
+    pub const SUCCESS: Self = Self::Success;
+    /// The [`ExitCode`] for failure.
+    pub const FAILURE: Self = Self::Failure;
+
+    #[allow(dead_code, reason = "not always used due to conditional compilation")]
+    fn to_semihosting_code(self) -> i32 {
+        match self {
+            Self::Success => 0,
+            Self::Failure => 1,
+        }
+    }
+    #[allow(dead_code, reason = "not always used due to conditional compilation")]
+    fn to_std_code(self) -> i32 {
+        match self {
+            Self::Success => 0,
+            Self::Failure => 1,
+        }
+    }
+}
+
+/// Terminates the debug output session.
+///
+/// # Note
+///
+/// This may or may not stop the MCU.
+pub fn exit(code: ExitCode) {
+    #[cfg(feature = "semihosting")]
+    semihosting::process::exit(code.to_semihosting_code());
+
+    #[cfg(feature = "std")]
+    std::process::exit(code.to_std_code());
+
+    #[allow(unreachable_code, reason = "stop nagging")]
+    let _ = code;
+
+    #[allow(unreachable_code, reason = "fallback loop")]
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -11,60 +11,12 @@
 #[featurecomb::comb]
 mod _featurecomb {}
 
+mod exit;
+
 #[doc(inline)]
 pub use ariel_os_debug_log as log;
 
-/// Represents the exit code of a debug session.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ExitCode {
-    #[doc(hidden)]
-    Success,
-    #[doc(hidden)]
-    Failure,
-}
-
-impl ExitCode {
-    /// The [`ExitCode`] for success.
-    pub const SUCCESS: Self = Self::Success;
-    /// The [`ExitCode`] for failure.
-    pub const FAILURE: Self = Self::Failure;
-
-    #[allow(dead_code, reason = "not always used due to conditional compilation")]
-    fn to_semihosting_code(self) -> i32 {
-        match self {
-            Self::Success => 0,
-            Self::Failure => 1,
-        }
-    }
-    #[allow(dead_code, reason = "not always used due to conditional compilation")]
-    fn to_std_code(self) -> i32 {
-        match self {
-            Self::Success => 0,
-            Self::Failure => 1,
-        }
-    }
-}
-
-/// Terminates the debug output session.
-///
-/// # Note
-///
-/// This may or may not stop the MCU.
-pub fn exit(code: ExitCode) {
-    #[cfg(feature = "semihosting")]
-    semihosting::process::exit(code.to_semihosting_code());
-
-    #[cfg(feature = "std")]
-    std::process::exit(code.to_std_code());
-
-    #[allow(unreachable_code, reason = "stop nagging")]
-    let _ = code;
-
-    #[allow(unreachable_code, reason = "fallback loop")]
-    loop {
-        core::hint::spin_loop();
-    }
-}
+pub use exit::*;
 
 /// Prints the panic on the debug output in a consistent manner across loggers.
 #[doc(hidden)]


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This moves the items from `ariel-os-debug` specific to the exit functionality to a dedicated private module, and re-exports them to not change the crate's API. This small refactor prepares for future changes to this crate, including possibly feature-gating the `exit` module itself.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Check that the docs are not modified.

Successfully tested with the following:

```sh
laze -C examples/hello-world build -b native run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Works towards #1008
- Related to #1987

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
