### PR TITLE
fix(debug-logging): add dummy `x2Format` struct

### DIFF
--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -67,31 +67,10 @@ pub fn print_panic(info: &core::panic::PanicInfo<'_>) {
 #[cfg(feature = "log")]
 #[doc(hidden)]
 pub mod log {
-    use core::fmt::{Debug, Display, Formatter};
 
     // Re-export only the minimum set of items to minimize breaking changes in case `log`
     // adds/removes any items.
     pub use log::{debug, error, info, trace, warn};
-
-    /// No-op wrapper that formats the Debug trait (drop-in replacement for the equivalent `defmt`
-    /// type).
-    pub struct Debug2Format<T: Debug>(pub T);
-
-    impl<T: Debug> Debug for Debug2Format<T> {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
-            self.0.fmt(f)
-        }
-    }
-
-    /// No-op wrapper that formats the Display trait (drop-in replacement for the equivalent
-    /// `defmt` type).
-    pub struct Display2Format<T: Display>(pub T);
-
-    impl<T: Display> Display for Display2Format<T> {
-        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
-            self.0.fmt(f)
-        }
-    }
 
     #[cfg(all(
         context = "ariel-os",
@@ -122,8 +101,34 @@ pub mod log {
     pub use crate::noop_println as println;
 }
 
-#[cfg(feature = "log")]
-pub use log::{Debug2Format, Display2Format};
+// NOTE: this module is used both for `log` and when no logging facades are enabled.
+#[cfg(not(feature = "defmt"))]
+#[doc(hidden)]
+mod format_wrappers {
+    use core::fmt::{Debug, Display, Formatter};
+
+    /// No-op wrapper that formats the Debug trait (drop-in replacement for the equivalent `defmt`
+    /// type).
+    pub struct Debug2Format<T: Debug>(pub T);
+
+    impl<T: Debug> Debug for Debug2Format<T> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
+            self.0.fmt(f)
+        }
+    }
+
+    /// No-op wrapper that formats the Display trait (drop-in replacement for the equivalent `defmt`
+    /// type).
+    pub struct Display2Format<T: Display>(pub T);
+
+    impl<T: Display> Display for Display2Format<T> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
+            self.0.fmt(f)
+        }
+    }
+}
+#[cfg(not(feature = "defmt"))]
+pub use format_wrappers::{Debug2Format, Display2Format};
 
 // NOTE: log macros are defined within private modules so that `doc_cfg` does not produce
 // "feature flairs" on them.


### PR DESCRIPTION
# Description

This PR adds dummy `Debug/Display2Format` structs when no logging facades are used. 

This is done to:
- stay consistent with other items like `Hex`, `Cbor` or the log macros that also have dummy versions 
- allow dependents on `ariel-debug-log` that don't want to opt-in to a facade and use `Debug2Format` to run `clippy` on their crates which would otherwise fail on failed imports. 
<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Import `ariel_os_debug_log::Debug2Format` in a crate that only has `ariel-os-debug-log` as a dependency without any feature enabled. Running `clippy`  should succeed with this PR when it woud previously fail. 

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #2013

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [n/a] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
