### PR TITLE
docs(storage): impl `defmt::Format` if and only if needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,6 +3225,7 @@ dependencies = [
  "ariel-os",
  "ariel-os-boards",
  "arrayvec",
+ "defmt 1.0.1",
  "heapless 0.9.1",
  "serde",
 ]

--- a/examples/storage/Cargo.toml
+++ b/examples/storage/Cargo.toml
@@ -8,8 +8,12 @@ publish = false
 ariel-os = { path = "../../src/ariel-os", features = ["storage"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 arrayvec = { version = "0.7.4", default-features = false, features = ["serde"] }
-heapless = { workspace = true, features = ["defmt", "serde"] }
+defmt = { workspace = true, optional = true }
+heapless = { workspace = true, features = ["serde"] }
 serde = { workspace = true, default-features = false, features = ["derive"] }
+
+[features]
+defmt = ["dep:defmt", "heapless/defmt"]
 
 [lints]
 workspace = true

--- a/examples/storage/laze.yml
+++ b/examples/storage/laze.yml
@@ -1,4 +1,14 @@
 apps:
   - name: example-storage
     selects:
+      - ?example-storage-defmt
       - sw/storage
+
+modules:
+  - name: example-storage-defmt
+    selects:
+      - defmt
+    env:
+      global:
+        FEATURES:
+          - defmt

--- a/examples/storage/src/main.rs
+++ b/examples/storage/src/main.rs
@@ -3,7 +3,7 @@
 
 use ariel_os::debug::{
     ExitCode, exit,
-    log::{Hex, defmt, info},
+    log::{Hex, info},
 };
 
 // Imports for using [`ariel_os::storage`]
@@ -13,7 +13,8 @@ use serde::{Deserialize, Serialize};
 /// Example object.
 ///
 /// The serde Serialize / Deserialize traits are required for storage.
-#[derive(Serialize, Deserialize, Debug, defmt::Format)]
+#[derive(Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 struct MyConfig {
     val_one: heapless::String<64>,
     val_two: u64,
@@ -69,7 +70,6 @@ async fn main() {
         .await
         .unwrap()
     {
-        // no `defmt::Format` for arrayvec, so just print length
         info!(
             "Attempting to retrieve string value as ArrayString: {}",
             Hex(string.as_bytes())


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This introduces a laze module in the `storage` example to enable `defmt` *in the application* if and only if needed. This makes this example now properly usable with both `defmt` and `log`.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested in hardware with:

```sh
laze -C examples/storage/ build -b stm32u083c-dk -v run
```

and

```sh
laze -C examples/storage/ build -s log -b stm32u083c-dk -v run
```

Printing the `size` allows to check that `defmt` is appropriately enabled only when needed:

```sh
$ laze -C examples/storage/ build -b stm32u083c-dk -v size
   text    data     bss     dec     hex filename
  53244      88   13544   66876   1053c build/bin/stm32u083c-dk/cargo/thumbv6m-none-eabi/release/example-storage
```

and

```sh
$ laze -C examples/storage/ build -s log -b stm32u083c-dk -v size
   text    data     bss     dec     hex filename
  64748      40   13612   78400   13240 build/bin/stm32u083c-dk/cargo/thumbv6m-none-eabi/release/example-storage
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Related to #1022 (and maybe completely addresses it)

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The `storage` example can now be used with both `defmt` or `log`.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
