### PR TITLE
refactor(logging)!: rename "debug logging" to "logging"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "ariel-os-embassy",
  "ariel-os-hal",
  "ariel-os-identity",
+ "ariel-os-log",
  "ariel-os-macros",
  "ariel-os-nrf",
  "ariel-os-power",

--- a/book/src/debug-console.md
+++ b/book/src/debug-console.md
@@ -21,17 +21,17 @@ The laze configuration automatically enables semihosting on the target when the 
 When the flashing tool does not, support for semihosting can still be enabled in the firmware by selecting the `semihosting` [laze module][laze-modules-book].
 This is needed to later be able to attach a semihosting-enabled host tool to the target.
 
-## Debug Logging
+## Logging
 
-Ariel OS supports debug logging on all platforms and it is enabled by default with the `debug-logging-facade` [laze module][laze-modules-book].
-Debug logging offers a set of macros that print on the debug console with helpful logging formatting.
+Ariel OS supports logging on all platforms and it is enabled by default with the `debug-logging-facade` [laze module][laze-modules-book].
+Logging offers a set of macros that print on the debug console with helpful logging formatting.
 
 ### Logging
 
-Within Rust code, import `ariel_os::debug::log` items, then use Ariel OS logging macros:
+Within Rust code, import `ariel_os::log` items, then use Ariel OS logging macros:
 
 ```rust
-use ariel_os::debug::log::info;
+use ariel_os::log::info;
 
 #[ariel_os::task(autostart)]
 async fn main() {
@@ -68,14 +68,14 @@ defmt should be preferred when possible as it results in smaller binaries.
 
 The precise set of formatting operations and traits required on formatted data
 depends on the selected backend.
-There are some wrapper structs available in the [`ariel_os::debug::log`] module
+There are some wrapper structs available in the [`ariel_os::log`] module
 that help represent some types in a portable way;
 in particular, this includes [`Debug2Format`] and [`Display2Format`],
 which (while defeating some of `defmt`'s optimizations) come in handy when debugging third party types.
 
-[`ariel_os::debug::log`]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/debug/log/
-[`Debug2Format`]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/debug/log/struct.Debug2Format.html
-[`Display2Format`]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/debug/log/struct.Display2Format.html
+[`ariel_os::log`]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/log/
+[`Debug2Format`]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/log/struct.Debug2Format.html
+[`Display2Format`]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/log/struct.Display2Format.html
 
 #### [defmt]
 

--- a/book/src/debug-console.md
+++ b/book/src/debug-console.md
@@ -23,7 +23,7 @@ This is needed to later be able to attach a semihosting-enabled host tool to the
 
 ## Logging
 
-Ariel OS supports logging on all platforms and it is enabled by default with the `debug-logging-facade` [laze module][laze-modules-book].
+Ariel OS supports logging on all platforms and it is enabled by default with the `logging-facade` [laze module][laze-modules-book].
 Logging offers a set of macros that print on the debug console with helpful logging formatting.
 
 ### Logging

--- a/examples/alloc/src/main.rs
+++ b/examples/alloc/src/main.rs
@@ -3,7 +3,10 @@
 
 extern crate alloc;
 
-use ariel_os::debug::{ExitCode, exit, log::*};
+use ariel_os::{
+    debug::{ExitCode, exit},
+    log::*,
+};
 
 #[ariel_os::task(autostart)]
 async fn main() {

--- a/examples/benchmark/src/main.rs
+++ b/examples/benchmark/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::log::*;
+use ariel_os::log::*;
 
 #[ariel_os::thread(autostart)]
 fn main() {

--- a/examples/ble-advertiser/src/main.rs
+++ b/examples/ble-advertiser/src/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::{debug::log::info, reexports::embassy_time, time::Timer};
+use ariel_os::{log::info, reexports::embassy_time, time::Timer};
 use embassy_futures::join::join;
 use embassy_time::Duration;
 use trouble_host::advertise::{

--- a/examples/ble-scanner/src/main.rs
+++ b/examples/ble-scanner/src/main.rs
@@ -4,7 +4,7 @@
 
 use core::cell::RefCell;
 
-use ariel_os::{debug::log::info, reexports::embassy_time, time::Timer};
+use ariel_os::{log::info, reexports::embassy_time, time::Timer};
 use embassy_futures::join::join;
 use embassy_time::Duration;
 use heapless::Deque;

--- a/examples/coap-client/src/main.rs
+++ b/examples/coap-client/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::log::info;
+use ariel_os::log::info;
 
 #[ariel_os::task(autostart)]
 async fn run_client_operations() {

--- a/examples/device-metadata/src/main.rs
+++ b/examples/device-metadata/src/main.rs
@@ -1,7 +1,10 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{ExitCode, exit, log::*};
+use ariel_os::{
+    debug::{ExitCode, exit},
+    log::*,
+};
 
 #[ariel_os::task(autostart)]
 async fn main() {

--- a/examples/hello-world-threading/src/main.rs
+++ b/examples/hello-world-threading/src/main.rs
@@ -1,7 +1,10 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{ExitCode, exit, log::*};
+use ariel_os::{
+    debug::{ExitCode, exit},
+    log::*,
+};
 
 #[ariel_os::thread(autostart)]
 fn main() {

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,7 +1,10 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{ExitCode, exit, log::*};
+use ariel_os::{
+    debug::{ExitCode, exit},
+    log::*,
+};
 
 #[ariel_os::task(autostart)]
 async fn main() {

--- a/examples/http-client/src/main.rs
+++ b/examples/http-client/src/main.rs
@@ -3,7 +3,8 @@
 
 use ariel_os::{
     config,
-    debug::{ExitCode, exit, log::*},
+    debug::{ExitCode, exit},
+    log::*,
     net,
     reexports::embassy_net,
 };

--- a/examples/i2c-scanner/src/main.rs
+++ b/examples/i2c-scanner/src/main.rs
@@ -4,9 +4,9 @@
 mod pins;
 
 use ariel_os::{
-    debug::log::info,
     hal,
     i2c::controller::{Kilohertz, highest_freq_in},
+    log::info,
 };
 
 use embedded_hal_async::i2c::I2c;

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{log::*, println};
+use ariel_os::{debug::println, log::*};
 
 #[ariel_os::task(autostart)]
 async fn main() {

--- a/examples/power/src/main.rs
+++ b/examples/power/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::{debug::log::info, power, time::Timer};
+use ariel_os::{log::info, power, time::Timer};
 
 #[ariel_os::task(autostart)]
 async fn main() {

--- a/examples/random/src/main.rs
+++ b/examples/random/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::log::*;
+use ariel_os::log::*;
 use rand::Rng as _;
 
 #[ariel_os::task(autostart)]

--- a/examples/sensors-debug/src/i2c_bus.rs
+++ b/examples/sensors-debug/src/i2c_bus.rs
@@ -1,7 +1,7 @@
 //! This module is intended to be @generated.
 
 use ariel_os::{
-    debug::log::debug,
+    log::debug,
     hal,
     i2c::controller::{Kilohertz, highest_freq_in},
 };

--- a/examples/sensors-debug/src/main.rs
+++ b/examples/sensors-debug/src/main.rs
@@ -6,7 +6,7 @@ mod pins;
 mod sensors;
 
 use ariel_os::{
-    debug::log::{debug, error, info},
+    log::{debug, error, info},
     sensors::{
         Label, REGISTRY, Reading as _, Sensor,
         sensor::{ReadingChannel, Sample, SampleError, SampleMetadata},

--- a/examples/storage/src/main.rs
+++ b/examples/storage/src/main.rs
@@ -1,8 +1,8 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{
-    ExitCode, exit,
+use ariel_os::{
+    debug::{ExitCode, exit},
     log::{Hex, info},
 };
 

--- a/examples/tcp-client/src/main.rs
+++ b/examples/tcp-client/src/main.rs
@@ -9,7 +9,7 @@ use embedded_io_async::Write as _;
 
 use ariel_os::time::Timer;
 use ariel_os::{
-    debug::log::{info, warn},
+    log::{info, warn},
     net,
     reexports::embassy_net,
     time::Duration,

--- a/examples/tcp-echo/src/main.rs
+++ b/examples/tcp-echo/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::{debug::log::*, net, reexports::embassy_net, reexports::embassy_time};
+use ariel_os::{log::*, net, reexports::embassy_net, reexports::embassy_time};
 use embassy_net::tcp::TcpSocket;
 use embassy_time::Duration;
 use embedded_io_async::Write;

--- a/examples/thermometer/src/i2c_bus.rs
+++ b/examples/thermometer/src/i2c_bus.rs
@@ -1,6 +1,6 @@
 //! This module is intended to be @generated.
 use ariel_os::{
-    debug::log::debug,
+    log::debug,
     hal,
     i2c::controller::{Kilohertz, highest_freq_in},
 };

--- a/examples/thermometer/src/main.rs
+++ b/examples/thermometer/src/main.rs
@@ -6,7 +6,7 @@ mod pins;
 mod sensors;
 
 use ariel_os::{
-    debug::log::{error, info},
+    log::{error, info},
     sensors::{
         Category, Label, MeasurementUnit, REGISTRY, Reading as _,
         sensor::{ReadingChannel, Sample},

--- a/examples/thread-async-interop/src/main.rs
+++ b/examples/thread-async-interop/src/main.rs
@@ -5,7 +5,8 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal}
 
 use ariel_os::{
     asynch::spawner,
-    debug::{ExitCode, exit, log::*},
+    debug::{ExitCode, exit},
+    log::*,
     thread::block_on,
     time::{Instant, Timer},
 };

--- a/examples/threading-channel/src/main.rs
+++ b/examples/threading-channel/src/main.rs
@@ -1,8 +1,8 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{ExitCode, log::*};
 use ariel_os::thread::sync::Channel;
+use ariel_os::{debug::ExitCode, log::*};
 
 static CHANNEL: Channel<u8> = Channel::new();
 

--- a/examples/threading-event/src/main.rs
+++ b/examples/threading-event/src/main.rs
@@ -1,8 +1,8 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{ExitCode, log::*};
 use ariel_os::thread::{ThreadId, sync::Event};
+use ariel_os::{debug::ExitCode, log::*};
 
 static EVENT: Event = Event::new();
 

--- a/examples/threading-multicore/src/main.rs
+++ b/examples/threading-multicore/src/main.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 use ariel_os::{
-    debug::log::*,
+    log::*,
     thread::{CoreAffinity, CoreId},
 };
 

--- a/examples/threading-timers/src/main.rs
+++ b/examples/threading-timers/src/main.rs
@@ -2,7 +2,8 @@
 #![no_std]
 
 use ariel_os::{
-    debug::{ExitCode, exit, log::info},
+    debug::{ExitCode, exit},
+    log::info,
     thread::block_on,
     time::Timer,
 };

--- a/examples/threading/src/main.rs
+++ b/examples/threading/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::log::*;
+use ariel_os::log::*;
 
 #[ariel_os::thread(autostart)]
 fn thread0() {

--- a/examples/udp-echo/src/main.rs
+++ b/examples/udp-echo/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::{debug::log::*, net, reexports::embassy_net};
+use ariel_os::{log::*, net, reexports::embassy_net};
 use embassy_net::udp::{PacketMetadata, UdpSocket};
 
 // UDP datagrams with payloads larger than this will be dropped and ignored, both when receiving

--- a/examples/usb-keyboard/src/main.rs
+++ b/examples/usb-keyboard/src/main.rs
@@ -5,7 +5,7 @@ mod pins;
 
 use ariel_os::{
     cell::StaticCell,
-    debug::log::*,
+    log::*,
     reexports::{embassy_usb, usbd_hid},
     time::Timer,
     usb::UsbDriver,

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -3,7 +3,7 @@
 
 use ariel_os::{
     cell::StaticCell,
-    debug::log::{Hex, info},
+    log::{Hex, info},
     reexports::embassy_usb,
     usb::UsbDriver,
 };

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1063,7 +1063,7 @@ modules:
         FEATURES:
           - ariel-os/log
         CARGO_ENV:
-          - DEBUG_LOG_LEVEL=${LOG}
+          - LOG_LEVEL=${LOG}
 
   - name: panic-printing
     context: ariel-os

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -973,7 +973,7 @@ modules:
   - name: debug-console
     context: ariel-os
     selects:
-      - ?debug-logging-facade-default
+      - ?logging-facade-default
       - ?panic-printing
     env:
       global:
@@ -1033,18 +1033,17 @@ modules:
         RUSTFLAGS:
           - --cfg nightly
 
-  # This module should be hard-selected when an application *requires* debug
-  # logging.
-  - name: debug-logging-facade-default
+  # This module should be hard-selected when an application *requires* logging.
+  - name: logging-facade-default
     selects:
       - ?defmt
       - ?log
-      - debug-logging-facade
+      - logging-facade
 
   - name: defmt
-    help: Use the `defmt` crate as the debug logging facade
+    help: Use the `defmt` crate as the logging facade
     provides_unique:
-      - debug-logging-facade
+      - logging-facade
     env:
       global:
         FEATURES:
@@ -1056,9 +1055,9 @@ modules:
           - DEFMT_LOG=info,${LOG}
 
   - name: log
-    help: Use the `log` crate as the debug logging facade
+    help: Use the `log` crate as the logging facade
     provides_unique:
-      - debug-logging-facade
+      - logging-facade
     env:
       global:
         FEATURES:

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -13,9 +13,6 @@ mod _featurecomb {}
 
 mod exit;
 
-#[doc(inline)]
-pub use ariel_os_log as log;
-
 pub use exit::*;
 
 /// Prints the panic on the debug output in a consistent manner across loggers.
@@ -244,7 +241,7 @@ mod logger {
             });
         }
 
-        log::debug!("debug logging enabled at level {MAX_LEVEL}");
+        log::debug!("logging enabled at level {MAX_LEVEL}");
     }
 
     struct DebugLogger;

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -185,7 +185,7 @@ mod logger {
 
     const MAX_LEVEL: LevelFilter = {
         let max_level =
-            ariel_os_utils::str_from_env_or!("DEBUG_LOG_LEVEL", "info", "maximum level to log");
+            ariel_os_utils::str_from_env_or!("LOG_LEVEL", "info", "maximum level to log");
 
         // NOTE: these magic strings could likely be replaced with calls to
         // `LevelFilter::*::as_str()` if that method was const.

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -1,4 +1,4 @@
-//! Provides debug logging facilities.
+//! Provides logging facilities.
 //!
 //! # Syntax of formatting strings
 //!

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -26,6 +26,7 @@ ariel-os-debug = { workspace = true }
 ariel-os-embassy = { path = "../ariel-os-embassy" }
 ariel-os-hal = { workspace = true }
 ariel-os-identity = { workspace = true }
+ariel-os-log = { workspace = true }
 ariel-os-macros = { path = "../ariel-os-macros" }
 ariel-os-nrf = { path = "../ariel-os-nrf", optional = true }
 ariel-os-power = { path = "../ariel-os-power" }
@@ -198,7 +199,7 @@ timer-generic-queue-128 = ["ariel-os-embassy/timer-generic-queue-128"]
 # Enables the debug console, required to use
 # [`println!`](ariel_os_debug::println).
 debug-console = ["ariel-os-rt/debug-console"]
-# Enables logging support through `defmt`, see [`debug::log`].
+# Enables logging support through `defmt`, see [`log`].
 defmt = [
   "ariel-os-bench?/defmt",
   "ariel-os-coap?/defmt",
@@ -207,7 +208,7 @@ defmt = [
   "ariel-os-sensors?/defmt",
   "ariel-os-threads?/defmt",
 ]
-# Enables logging support through `log`, see [`debug::log`].
+# Enables logging support through `log`, see [`log`].
 log = ["ariel-os-debug/log", "ariel-os-embassy/log"]
 ## Enables benchmarking facilities.
 bench = ["dep:ariel-os-bench"]

--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -38,6 +38,8 @@ pub use ariel_os_hal::api::*;
 #[doc(inline)]
 pub use ariel_os_identity as identity;
 #[doc(inline)]
+pub use ariel_os_log as log;
+#[doc(inline)]
 pub use ariel_os_power as power;
 #[cfg(feature = "random")]
 #[doc(inline)]

--- a/src/sensors/ariel-os-sensor-nrf91-gnss/src/config.rs
+++ b/src/sensors/ariel-os-sensor-nrf91-gnss/src/config.rs
@@ -18,7 +18,7 @@ pub enum GnssOperationMode {
 pub struct Config {
     /// The GNSS operating mode to use.
     pub operation_mode: GnssOperationMode,
-    /// Whether NMEA messages should be logged as debug logs (adds extra processing).
+    /// Whether NMEA messages should be logged as logs (adds extra processing).
     pub log_nmea: bool,
 }
 

--- a/tests/benchmarks/bench_sched_flags/src/main.rs
+++ b/tests/benchmarks/bench_sched_flags/src/main.rs
@@ -2,7 +2,7 @@
 #![no_std]
 
 use ariel_os::{
-    debug::log::*,
+    log::*,
     thread::{ThreadId, current_tid, sync::Channel, thread_flags},
 };
 

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -2,9 +2,10 @@
 #![no_std]
 
 use ariel_os::{
-    debug::{ExitCode, exit, log::info},
+    debug::{ExitCode, exit},
     gpio::{self, Input, Pull},
     hal::peripherals,
+    log::info,
 };
 
 #[cfg(context = "nrf51")]

--- a/tests/gpio-interrupt-stm32/src/main.rs
+++ b/tests/gpio-interrupt-stm32/src/main.rs
@@ -2,9 +2,10 @@
 #![no_std]
 
 use ariel_os::{
-    debug::{ExitCode, exit, log::info},
+    debug::{ExitCode, exit},
     gpio::{self, Input, Pull},
     hal::peripherals,
+    log::info,
 };
 
 // These pins should be available on all STM32 chips.

--- a/tests/i2c-controller/src/main.rs
+++ b/tests/i2c-controller/src/main.rs
@@ -11,12 +11,10 @@
 mod pins;
 
 use ariel_os::{
-    debug::{
-        ExitCode, exit,
-        log::{debug, info},
-    },
+    debug::{ExitCode, exit},
     hal,
     i2c::controller::{I2cDevice, Kilohertz, highest_freq_in},
+    log::{debug, info},
 };
 use embassy_sync::mutex::Mutex;
 use embedded_hal_async::i2c::I2c as _;

--- a/tests/random-getrandom/src/main.rs
+++ b/tests/random-getrandom/src/main.rs
@@ -1,7 +1,10 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{ExitCode, exit, log::*};
+use ariel_os::{
+    debug::{ExitCode, exit},
+    log::*,
+};
 
 #[ariel_os::task(autostart)]
 async fn main() {

--- a/tests/spi-loopback/src/main.rs
+++ b/tests/spi-loopback/src/main.rs
@@ -8,11 +8,9 @@
 mod pins;
 
 use ariel_os::{
-    debug::{
-        ExitCode, exit,
-        log::{Hex, debug, info},
-    },
+    debug::{ExitCode, exit},
     gpio, hal,
+    log::{Hex, debug, info},
     spi::{
         Mode,
         main::{Kilohertz, SpiDevice, highest_freq_in},

--- a/tests/spi-main/src/main.rs
+++ b/tests/spi-main/src/main.rs
@@ -10,11 +10,9 @@
 mod pins;
 
 use ariel_os::{
-    debug::{
-        ExitCode, exit,
-        log::{debug, info},
-    },
+    debug::{ExitCode, exit},
     gpio, hal,
+    log::{debug, info},
     spi::{
         Mode,
         main::{Kilohertz, SpiDevice, highest_freq_in},

--- a/tests/stack-painting/src/main.rs
+++ b/tests/stack-painting/src/main.rs
@@ -1,7 +1,10 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::{ExitCode, exit, log::info};
+use ariel_os::{
+    debug::{ExitCode, exit},
+    log::info,
+};
 
 #[ariel_os::task(autostart)]
 async fn main() {

--- a/tests/threading-dynamic-prios/src/main.rs
+++ b/tests/threading-dynamic-prios/src/main.rs
@@ -32,7 +32,7 @@ fn thread0() {
     // thread1 runs now.
 
     assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 2);
-    ariel_os::debug::log::info!("Test passed!");
+    ariel_os::log::info!("Test passed!");
     exit(ExitCode::Success);
 }
 

--- a/tests/threading-fpu/src/main.rs
+++ b/tests/threading-fpu/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::{debug::log::info, thread};
+use ariel_os::{log::info, thread};
 
 #[ariel_os::thread(autostart)]
 fn thread0() {

--- a/tests/threading-lock/src/main.rs
+++ b/tests/threading-lock/src/main.rs
@@ -33,7 +33,7 @@ fn thread0() {
 
     // Wait for other threads to complete.
     thread_flags::wait_all(0b111);
-    ariel_os::debug::log::info!("Test passed!");
+    ariel_os::log::info!("Test passed!");
     exit(ExitCode::Success);
 }
 

--- a/tests/threading-mutex/src/main.rs
+++ b/tests/threading-mutex/src/main.rs
@@ -52,7 +52,7 @@ fn thread0() {
     thread_flags::wait_all(0b111);
 
     assert_eq!(*MUTEX.lock(), 4);
-    ariel_os::debug::log::info!("Test passed!");
+    ariel_os::log::info!("Test passed!");
 }
 
 #[ariel_os::thread(autostart, priority = 2)]

--- a/tests/uart-loopback/src/main.rs
+++ b/tests/uart-loopback/src/main.rs
@@ -6,11 +6,9 @@
 mod pins;
 
 use ariel_os::{
-    debug::{
-        ExitCode, exit,
-        log::{Hex, info},
-    },
+    debug::{ExitCode, exit},
     hal,
+    log::{Hex, info},
     time::{Duration, with_timeout},
     uart::Baudrate,
 };


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
As mentioned in https://github.com/ariel-os/ariel-os/pull/1987#issuecomment-4242681143, this renames "debug logging" to "logging", and replaces `ariel_os::debug::log` with the top-level `ariel_os::log`.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
I've tested the `log` example in hardware, and searched for leftovers with the following case-insensitive regexes: `debug.log`, `debug$`.

Also tested `laze -C examples/log build -DLOG=warn -s log -b stm32u083c-dk -v run` to make sure log level filtering still works when use the `log` logger.

This PR only takes care of this, and in particular does not address `ariel_os::debug::println!()`, or the distinction between "debug output" vs "logging" introduced by #1987 (including moving items from `ariel-os-debug` that actually belong in `ariel-os-log`).

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #2007

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
"Debug logging" has been renamed to "logging": `ariel_os::log` should be used instead of `ariel_os::debug::log`. In addition, the `ariel_os::debug::log::defmt` module has been removed entirely. The portable items from `ariel_os::log` should be used instead, or the `defmt` crate should be used directly instead if actually needed.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
