### PR TITLE
fix(logging)!: provide `println!()` when using the `log` facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,15 +244,8 @@ dependencies = [
 name = "ariel-os-debug"
 version = "0.4.0"
 dependencies = [
- "ariel-os-log",
- "ariel-os-utils",
- "const-str",
- "critical-section",
  "defmt-rtt",
- "embassy-sync 0.7.2",
- "esp-println",
  "featurecomb",
- "log",
  "rtt-target",
  "semihosting",
 ]
@@ -394,7 +387,13 @@ dependencies = [
 name = "ariel-os-log"
 version = "0.4.0"
 dependencies = [
+ "ariel-os-debug",
+ "ariel-os-utils",
+ "const-str",
+ "critical-section",
  "defmt 1.0.1",
+ "embassy-sync 0.7.2",
+ "esp-println",
  "featurecomb",
  "log",
 ]
@@ -5485,7 +5484,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4235cd78091930e907d2a510adb0db1369e82668eafa338f109742fa0c83059d"
 dependencies = [
  "critical-section",
- "defmt 0.3.100",
  "portable-atomic",
  "ufmt-write",
 ]

--- a/book/src/debug-console.md
+++ b/book/src/debug-console.md
@@ -6,7 +6,7 @@ The debug console is enabled by default and the corresponding [laze module][laze
 
 ## Printing on the Debug Console
 
-The [`ariel_os::debug::println!()`][println-macro-rustdoc] macro is used to print on the debug console.
+The [`ariel_os::log::println!()`][println-macro-rustdoc] macro is used to print on the debug console.
 
 When the debug console is enabled, panic messages are automatically printed to it.
 If this is unwanted, the `panic-printing` [laze module][laze-modules-book] can be disabled.
@@ -95,7 +95,7 @@ The defmt logger supports configuring the log level per crate and per module, as
 $ laze build -C examples/log --builders nrf52840dk -DLOG=info,ariel_os_rt=trace run
 ```
 
-Note: On Cortex-M devices, the order of `ariel_os::debug::println!()` output and
+Note: On Cortex-M devices, the order of `ariel_os::log::println!()` output and
       `defmt` log output is not deterministic.
 
 #### [log]
@@ -106,5 +106,5 @@ Ariel OS's logger for `log` supports configuring the log level globally, but do
 [defmt documentation]: https://defmt.ferrous-systems.com/
 [log]: https://github.com/rust-lang/log
 [laze-modules-book]: ./build-system.md#laze-modules
-[println-macro-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/debug/macro.println.html
+[println-macro-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/log/macro.println.html
 [debug-exit-fn-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/debug/fn.exit.html

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::{debug::println, log::*};
+use ariel_os::log::*;
 
 #[ariel_os::task(autostart)]
 async fn main() {

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -6,71 +6,32 @@ rust-version.workspace = true
 repository.workspace = true
 license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-ariel-os-log = { workspace = true }
-ariel-os-utils = { workspace = true }
-const-str = { workspace = true }
-critical-section = { workspace = true, optional = true }
-defmt-rtt = { workspace = true, optional = true }
-embassy-sync = { workspace = true }
-featurecomb = { workspace = true }
-log = { workspace = true, optional = true }
-rtt-target = { workspace = true, optional = true }
-semihosting = { workspace = true, optional = true }
-
 [package.metadata.feature-groups]
-debug-backend.xor = { features = ["esp-println", "rtt-target", "uart"] }
+debug-output.xor = { features = ["defmt-rtt", "rtt-target", "std"] }
 
 [package.metadata.features]
-debug-console = { groups = ["debug-backend"] }
+debug-console = { groups = ["debug-output"] }
+
+[dependencies]
+defmt-rtt = { workspace = true, optional = true }
+featurecomb = { workspace = true }
+rtt-target = { workspace = true, optional = true }
+semihosting = { workspace = true, optional = true }
 
 [target.'cfg(context = "xtensa")'.dependencies]
 semihosting = { workspace = true, optional = true, features = [
   "openocd-semihosting",
 ] }
 
-[target.'cfg(context = "esp")'.dependencies]
-esp-println = { workspace = true, optional = true, features = [
-  "auto",
-  "colors",
-  "critical-section",
-] }
-
-[target.'cfg(context = "esp32")'.dependencies]
-esp-println = { workspace = true, optional = true, features = ["esp32"] }
-
-[target.'cfg(context = "esp32c3")'.dependencies]
-esp-println = { workspace = true, optional = true, features = ["esp32c3"] }
-
-[target.'cfg(context = "esp32c6")'.dependencies]
-esp-println = { workspace = true, optional = true, features = ["esp32c6"] }
-
-[target.'cfg(context = "esp32s2")'.dependencies]
-esp-println = { workspace = true, optional = true, features = ["esp32s2"] }
-
-[target.'cfg(context = "esp32s3")'.dependencies]
-esp-println = { workspace = true, optional = true, features = ["esp32s3"] }
-
 [features]
 debug-console = []
 
-defmt = [
-  "ariel-os-log/defmt",
-  "esp-println?/defmt-espflash",
-  "rtt-target?/defmt",
-]
-log = ["dep:critical-section", "dep:log", "ariel-os-log/log"]
-
 semihosting = ["dep:semihosting"]
-
-# Debug output backends
-defmt-rtt = ["dep:defmt-rtt"]
-esp-println = ["dep:esp-println"]
-rtt-target = ["dep:rtt-target"]
 std = []
-uart = []
+
+# Debug output transports.
+defmt-rtt = ["dep:defmt-rtt"]
+rtt-target = ["dep:rtt-target"]
 
 [lints]
 workspace = true

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -2,10 +2,6 @@
 
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 #![cfg_attr(test, no_main)]
-#![cfg_attr(
-    all(feature = "log", not(target_has_atomic = "ptr")),
-    expect(unsafe_code)
-)]
 #![deny(missing_docs)]
 
 #[featurecomb::comb]
@@ -15,28 +11,8 @@ mod exit;
 
 pub use exit::*;
 
-/// Prints the panic on the debug output in a consistent manner across loggers.
-#[doc(hidden)]
-pub fn print_panic(info: &core::panic::PanicInfo<'_>) {
-    // `location()`'s documentation currently states that it always returns `Some(_)`.
-    // It is unclear what the panic formatting would be otherwise, because the std does not
-    // currently handle the case where the location cannot be obtained.
-    let location = info.location().unwrap();
-    let message = info.message();
-
-    // `PanicMessage` does not currently implement `defmt::Format`.
-    // We *need* to use the `Display` implementation and cannot use `PanicMessage::as_str()` as
-    // that would not work for dynamically formatted messages.
-    #[cfg(feature = "defmt")]
-    let message = ariel_os_log::Display2Format(&message);
-
-    // Mimics the `Display` implementation of `core::panic::PanicInfo`.
-    println!("panicked at {}:\n{}", location, message);
-}
-
 #[cfg(all(feature = "debug-console", feature = "defmt-rtt"))]
 mod backend {
-    pub use ariel_os_log::println;
     use defmt_rtt as _;
 
     #[doc(hidden)]
@@ -45,11 +21,11 @@ mod backend {
 
 #[cfg(all(feature = "debug-console", feature = "rtt-target"))]
 mod backend {
+    #[cfg(feature = "defmt")]
+    pub use defmt::println;
+
     #[cfg(not(feature = "defmt"))]
     pub use rtt_target::rprintln as println;
-
-    #[cfg(feature = "defmt")]
-    pub use ariel_os_log::println;
 
     #[doc(hidden)]
     pub fn init() {
@@ -83,70 +59,6 @@ mod backend {
     }
 }
 
-#[cfg(all(feature = "debug-console", feature = "esp-println"))]
-mod backend {
-    pub use esp_println::println;
-
-    #[doc(hidden)]
-    pub fn init() {
-        #[cfg(feature = "log")]
-        crate::logger::init();
-    }
-}
-
-#[cfg(all(feature = "debug-console", feature = "uart"))]
-#[doc(hidden)]
-pub mod backend {
-    use embassy_sync::once_lock::OnceLock;
-
-    #[doc(hidden)]
-    pub enum Error {
-        Writing,
-    }
-
-    // Populated by a downstream crate.
-    // The function must print to a UART output.
-    #[doc(hidden)]
-    pub static DEBUG_UART_WRITE_FN: OnceLock<fn(&[u8]) -> Result<(), Error>> = OnceLock::new();
-
-    struct DebugUart;
-
-    impl core::fmt::Write for DebugUart {
-        fn write_str(&mut self, s: &str) -> core::fmt::Result {
-            let bytes = s.as_bytes();
-
-            if let Some(debug_uart_write_fn) = DEBUG_UART_WRITE_FN.try_get() {
-                // Panicking in this case would not be useful as (a) it is recoverable, we would
-                // just be dropping some debug output and (b) there would not be a output to print
-                // the panic on, as there can currently only be one backend at once.
-                let _ = debug_uart_write_fn(bytes);
-            }
-
-            Ok(())
-        }
-    }
-
-    pub fn init() {
-        crate::logger::init();
-    }
-
-    // Based on <https://blog.m-ou.se/format-args/>.
-    #[doc(hidden)]
-    pub fn _print(args: core::fmt::Arguments<'_>) {
-        use core::fmt::Write;
-
-        DebugUart.write_fmt(args).unwrap();
-    }
-
-    #[macro_export]
-    macro_rules! println {
-        ($($arg:tt)*) => {{
-            #[expect(clippy::used_underscore_items, reason = "consistency with std::println")]
-            $crate::backend::_print(format_args!("{}\n", format_args!($($arg)*)));
-        }};
-    }
-}
-
 #[cfg(all(feature = "debug-console", feature = "std"))]
 mod backend {
     pub use std::println;
@@ -158,105 +70,13 @@ mod backend {
     }
 }
 
-#[cfg(not(feature = "debug-console"))]
+#[cfg(not(all(
+    feature = "debug-console",
+    any(feature = "defmt-rtt", feature = "rtt-target", feature = "std")
+)))]
 mod backend {
     #[doc(hidden)]
     pub fn init() {}
-
-    /// Prints to the debug output, with a newline.
-    #[macro_export]
-    macro_rules! println {
-        ($($arg:tt)*) => {{
-            let _ = ($($arg)*);
-            // Do nothing
-        }};
-    }
 }
 
 pub use backend::*;
-
-#[allow(unused, reason = "conditional compilation")]
-#[doc(hidden)]
-#[cfg(feature = "log")]
-mod logger {
-    use log::{LevelFilter, Metadata, Record};
-
-    static LOGGER: DebugLogger = DebugLogger;
-
-    const MAX_LEVEL: LevelFilter = {
-        let max_level =
-            ariel_os_utils::str_from_env_or!("LOG_LEVEL", "info", "maximum level to log");
-
-        // NOTE: these magic strings could likely be replaced with calls to
-        // `LevelFilter::*::as_str()` if that method was const.
-        if const_str::compare!(==, max_level, "trace") {
-            LevelFilter::Trace
-        } else if const_str::compare!(==, max_level, "debug") {
-            LevelFilter::Debug
-        } else if const_str::compare!(==, max_level, "info") {
-            LevelFilter::Info
-        } else if const_str::compare!(==, max_level, "warn") {
-            LevelFilter::Warn
-        } else if const_str::compare!(==, max_level, "error") {
-            LevelFilter::Error
-        } else if const_str::compare!(==, max_level, "off") {
-            LevelFilter::Off
-        } else if const_str::compare!(==, max_level, "") {
-            // Default level
-            LevelFilter::Info
-        } else {
-            panic!("invalid log level");
-        }
-    };
-
-    /// Initializes the `log` logger.
-    ///
-    /// # Panics
-    ///
-    /// When a logger has already been set.
-    pub fn init() {
-        #[cfg(target_has_atomic = "ptr")]
-        {
-            log::set_logger(&LOGGER).unwrap();
-            log::set_max_level(MAX_LEVEL);
-        }
-
-        // The non-racy functions are not available on architectures with no pointer-wide atomics.
-        #[cfg(not(target_has_atomic = "ptr"))]
-        {
-            critical_section::with(|_| {
-                // NOTE: these calls do not need to be made atomically but this still uses a single
-                // critical section.
-
-                // SAFETY: the critical section prevents concurrent calls of `set_logger_racy()` or
-                // `logger()`.
-                unsafe {
-                    log::set_logger_racy(&LOGGER).unwrap();
-                }
-                // SAFETY: the critical section prevents concurrent calls of `set_max_level_racy()`
-                // or `max_level()`.
-                unsafe {
-                    log::set_max_level_racy(MAX_LEVEL);
-                }
-            });
-        }
-
-        log::debug!("logging enabled at level {MAX_LEVEL}");
-    }
-
-    struct DebugLogger;
-
-    impl log::Log for DebugLogger {
-        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
-            metadata.level() <= MAX_LEVEL
-        }
-
-        fn log(&self, record: &Record<'_>) {
-            if self.enabled(record.metadata()) {
-                crate::println!("[{}] {}", record.level(), record.args());
-            }
-        }
-
-        fn flush(&self) {}
-    }
-}

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -22,10 +22,10 @@ mod backend {
 #[cfg(all(feature = "debug-console", feature = "rtt-target"))]
 mod backend {
     #[cfg(feature = "defmt")]
-    pub use defmt::println;
+    pub use defmt::println as debug_output_println;
 
     #[cfg(not(feature = "defmt"))]
-    pub use rtt_target::rprintln as println;
+    pub use rtt_target::rprintln as debug_output_println;
 
     #[doc(hidden)]
     pub fn init() {
@@ -61,7 +61,7 @@ mod backend {
 
 #[cfg(all(feature = "debug-console", feature = "std"))]
 mod backend {
-    pub use std::println;
+    pub use std::println as debug_output_println;
 
     #[doc(hidden)]
     pub fn init() {

--- a/src/ariel-os-embassy/src/debug_uart.rs
+++ b/src/ariel-os-embassy/src/debug_uart.rs
@@ -19,11 +19,11 @@ pub fn init(peripherals: &mut crate::hal::OptionalPeripherals) {
 
     let _ = DEBUG_UART.init(embassy_sync::mutex::Mutex::new(uart));
 
-    let _ = ariel_os_debug::DEBUG_UART_WRITE_FN.init(write_debug_uart);
+    let _ = ariel_os_log::backend::DEBUG_UART_WRITE_FN.init(write_debug_uart);
 }
 
-fn write_debug_uart(buffer: &[u8]) -> Result<(), ariel_os_debug::Error> {
-    use ariel_os_debug::Error;
+fn write_debug_uart(buffer: &[u8]) -> Result<(), ariel_os_log::backend::Error> {
+    use ariel_os_log::backend::Error;
 
     #[cfg(context = "stm32")]
     use embedded_io::Write as _;

--- a/src/ariel-os-log/Cargo.toml
+++ b/src/ariel-os-log/Cargo.toml
@@ -8,17 +8,52 @@ license.workspace = true
 
 [package.metadata.feature-groups]
 logging-facade.xor = { features = ["defmt", "log"] }
+logging-tranport.xor = { features = ["defmt-rtt", "esp-println", "uart"] }
 
 [dependencies]
+ariel-os-debug = { workspace = true }
+ariel-os-utils = { workspace = true, optional = true }
+const-str = { workspace = true, optional = true }
+critical-section = { workspace = true, optional = true }
 defmt = { workspace = true, optional = true }
+embassy-sync = { workspace = true, optional = true }
 featurecomb = { workspace = true }
 log = { workspace = true, optional = true }
 
+[target.'cfg(context = "esp")'.dependencies]
+esp-println = { workspace = true, optional = true, features = [
+  "auto",
+  "colors",
+  "critical-section",
+] }
+
+[target.'cfg(context = "esp32")'.dependencies]
+esp-println = { workspace = true, optional = true, features = ["esp32"] }
+
+[target.'cfg(context = "esp32c3")'.dependencies]
+esp-println = { workspace = true, optional = true, features = ["esp32c3"] }
+
+[target.'cfg(context = "esp32c6")'.dependencies]
+esp-println = { workspace = true, optional = true, features = ["esp32c6"] }
+
+[target.'cfg(context = "esp32s2")'.dependencies]
+esp-println = { workspace = true, optional = true, features = ["esp32s2"] }
+
+[target.'cfg(context = "esp32s3")'.dependencies]
+esp-println = { workspace = true, optional = true, features = ["esp32s3"] }
+
 [features]
 ## Enables `defmt` as logging facade.
-defmt = ["dep:defmt"]
+defmt = ["dep:defmt", "esp-println?/defmt-espflash"]
 ## Enables `log` as logging facade.
-log = ["dep:log"]
+log = ["dep:ariel-os-utils", "dep:const-str", "dep:critical-section", "dep:log"]
+
+# Logging transports.
+# `defmt-rtt` forces the logging transport to be the debug output, so it has to
+# go through this crate.
+defmt-rtt = ["ariel-os-debug/defmt-rtt"]
+esp-println = ["dep:esp-println"]
+uart = ["dep:embassy-sync"]
 
 _test = []
 

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -97,7 +97,7 @@ pub mod log {
         context = "ariel-os",
         not(any(feature = "esp-println", feature = "uart"))
     ))]
-    pub use ariel_os_debug::println;
+    pub use ariel_os_debug::debug_output_println as println;
 
     #[cfg(feature = "esp-println")]
     pub use esp_println::println;

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -12,10 +12,19 @@
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(nightly, feature(doc_cfg))]
+#![cfg_attr(
+    all(feature = "log", not(target_has_atomic = "ptr")),
+    expect(unsafe_code)
+)]
 #![deny(missing_docs)]
 
 #[featurecomb::comb]
 mod _featurecomb {}
+
+#[allow(unused, reason = "conditional compilation")]
+#[doc(hidden)]
+#[cfg(feature = "log")]
+mod log_logger;
 
 // This module is hidden in the docs, but would still be imported by a wildcard import of this
 // crate's items.
@@ -26,8 +35,34 @@ pub mod hidden_for_logging_macros {
     pub use defmt;
 }
 
+// Make sure the `defmt` logger gets linked.
+#[cfg(feature = "esp-println")]
+use esp_println as _;
+
 #[cfg(feature = "defmt")]
 pub use defmt::{Debug2Format, Display2Format};
+
+/// Prints the panic on the logging output in a consistent manner across loggers.
+#[doc(hidden)]
+pub fn print_panic(info: &core::panic::PanicInfo<'_>) {
+    // `location()`'s documentation currently states that it always returns `Some(_)`.
+    // It is unclear what the panic formatting would be otherwise, because the std does not
+    // currently handle the case where the location cannot be obtained.
+    #[allow(
+        unused_variables,
+        reason = "FP due to macro usage and conditional compilation"
+    )]
+    let (location, message) = (info.location().unwrap(), info.message());
+
+    // `PanicMessage` does not currently implement `defmt::Format`.
+    // We *need* to use the `Display` implementation and cannot use `PanicMessage::as_str()` as
+    // that would not work for dynamically formatted messages.
+    #[cfg(feature = "defmt")]
+    let message = Display2Format(&message);
+
+    // Mimics the `Display` implementation of `core::panic::PanicInfo`.
+    println!("panicked at {}:\n{}", location, message);
+}
 
 #[cfg(feature = "log")]
 #[doc(hidden)]
@@ -57,6 +92,27 @@ pub mod log {
             self.0.fmt(f)
         }
     }
+
+    #[cfg(all(
+        context = "ariel-os",
+        not(any(feature = "esp-println", feature = "uart"))
+    ))]
+    pub use ariel_os_debug::println;
+
+    #[cfg(feature = "esp-println")]
+    pub use esp_println::println;
+
+    #[cfg(feature = "uart")]
+    pub use crate::uart_println as println;
+
+    /// Prints to the logging output, with a newline.
+    #[cfg(not(context = "ariel-os"))]
+    #[macro_export]
+    macro_rules! noop_println {
+        ($($arg:tt)*) => {};
+    }
+    #[cfg(not(context = "ariel-os"))]
+    pub use crate::noop_println as println;
 }
 
 #[cfg(feature = "log")]
@@ -136,7 +192,7 @@ mod log_macros {
         }};
     }
 
-    /// Prints to the debug output, with a newline.
+    /// Prints to the logging output, with a newline.
     #[macro_export]
     macro_rules! println {
         ($($arg:tt)*) => {{
@@ -191,6 +247,14 @@ mod log_macros {
             $crate::log::error!($($arg)*);
         }};
     }
+
+    /// Prints to the logging output, with a newline.
+    #[macro_export]
+    macro_rules! println {
+        ($($arg:tt)*) => {{
+            $crate::log::println!($($arg)*);
+        }};
+    }
 }
 
 // Define no-op macros in case no facade is enabled.
@@ -223,6 +287,12 @@ mod log_macros {
     /// Logs a message at the error level.
     #[macro_export]
     macro_rules! error {
+        ($($arg:tt)*) => {};
+    }
+
+    /// Prints to the logging output, with a newline.
+    #[macro_export]
+    macro_rules! println {
         ($($arg:tt)*) => {};
     }
 }
@@ -274,4 +344,61 @@ impl<T: AsRef<[u8]>> defmt::Format for Cbor<T> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f, "{=[u8]:cbor}", self.0.as_ref());
     }
+}
+
+#[cfg(feature = "uart")]
+#[doc(hidden)]
+pub mod backend {
+    use embassy_sync::once_lock::OnceLock;
+
+    #[doc(hidden)]
+    pub enum Error {
+        Writing,
+    }
+
+    // Populated by a downstream crate.
+    // The function must print to a UART output.
+    #[expect(clippy::type_complexity, reason = "not worth it")]
+    #[doc(hidden)]
+    pub static DEBUG_UART_WRITE_FN: OnceLock<fn(&[u8]) -> Result<(), Error>> = OnceLock::new();
+
+    struct DebugUart;
+
+    impl core::fmt::Write for DebugUart {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            let bytes = s.as_bytes();
+
+            if let Some(debug_uart_write_fn) = DEBUG_UART_WRITE_FN.try_get() {
+                // Panicking in this case would not be useful as (a) it is recoverable, we would
+                // just be dropping some debug output and (b) there would not be a output to print
+                // the panic on, as there can currently only be one backend at once.
+                let _ = debug_uart_write_fn(bytes);
+            }
+
+            Ok(())
+        }
+    }
+
+    // Based on <https://blog.m-ou.se/format-args/>.
+    #[doc(hidden)]
+    pub fn _print(args: core::fmt::Arguments<'_>) {
+        use core::fmt::Write as _;
+
+        DebugUart.write_fmt(args).unwrap();
+    }
+
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! uart_println {
+        ($($arg:tt)*) => {{
+            #[expect(clippy::used_underscore_items, reason = "consistency with std::println")]
+            $crate::backend::_print(format_args!("{}\n", format_args!($($arg)*)));
+        }};
+    }
+}
+
+#[doc(hidden)]
+pub fn init() {
+    #[cfg(feature = "log")]
+    log_logger::init();
 }

--- a/src/ariel-os-log/src/log_logger.rs
+++ b/src/ariel-os-log/src/log_logger.rs
@@ -1,0 +1,79 @@
+use log::{LevelFilter, Metadata, Record};
+
+static LOGGER: DebugLogger = DebugLogger;
+
+const MAX_LEVEL: LevelFilter = {
+    let max_level = ariel_os_utils::str_from_env_or!("LOG_LEVEL", "info", "maximum level to log");
+
+    // NOTE: these magic strings could likely be replaced with calls to
+    // `LevelFilter::*::as_str()` if that method was const.
+    if const_str::compare!(==, max_level, "trace") {
+        LevelFilter::Trace
+    } else if const_str::compare!(==, max_level, "debug") {
+        LevelFilter::Debug
+    } else if const_str::compare!(==, max_level, "info") {
+        LevelFilter::Info
+    } else if const_str::compare!(==, max_level, "warn") {
+        LevelFilter::Warn
+    } else if const_str::compare!(==, max_level, "error") {
+        LevelFilter::Error
+    } else if const_str::compare!(==, max_level, "off") {
+        LevelFilter::Off
+    } else if const_str::compare!(==, max_level, "") {
+        // Default level
+        LevelFilter::Info
+    } else {
+        panic!("invalid log level");
+    }
+};
+
+/// Initializes the `log` logger.
+///
+/// # Panics
+///
+/// When a logger has already been set.
+pub fn init() {
+    #[cfg(target_has_atomic = "ptr")]
+    {
+        log::set_logger(&LOGGER).unwrap();
+        log::set_max_level(MAX_LEVEL);
+    }
+
+    // The non-racy functions are not available on architectures with no pointer-wide atomics.
+    #[cfg(not(target_has_atomic = "ptr"))]
+    {
+        critical_section::with(|_| {
+            // NOTE: these calls do not need to be made atomically but this still uses a single
+            // critical section.
+
+            // SAFETY: the critical section prevents concurrent calls of `set_logger_racy()` or
+            // `logger()`.
+            unsafe {
+                log::set_logger_racy(&LOGGER).unwrap();
+            }
+            // SAFETY: the critical section prevents concurrent calls of `set_max_level_racy()`
+            // or `max_level()`.
+            unsafe {
+                log::set_max_level_racy(MAX_LEVEL);
+            }
+        });
+    }
+
+    log::debug!("logging enabled at level {MAX_LEVEL}");
+}
+
+struct DebugLogger;
+
+impl log::Log for DebugLogger {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.level() <= MAX_LEVEL
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if self.enabled(record.metadata()) {
+            crate::println!("[{}] {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -138,7 +138,7 @@ mod isr_stack {
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo<'_>) -> ! {
     #[cfg(feature = "panic-printing")]
-    ariel_os_debug::print_panic(_info);
+    ariel_os_log::print_panic(_info);
 
     ariel_os_debug::exit(ariel_os_debug::ExitCode::FAILURE);
 
@@ -159,6 +159,8 @@ fn startup() -> ! {
 
     #[cfg(feature = "debug-console")]
     ariel_os_debug::init();
+
+    ariel_os_log::init();
 
     debug!("ariel_os_rt::startup()");
 

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -197,19 +197,19 @@ timer-generic-queue-128 = ["ariel-os-embassy/timer-generic-queue-128"]
 
 #! ## Development and debugging
 # Enables the debug console, required to use
-# [`println!`](ariel_os_debug::println).
+# [`println!`](ariel_os_log::println).
 debug-console = ["ariel-os-rt/debug-console"]
 # Enables logging support through `defmt`, see [`log`].
 defmt = [
   "ariel-os-bench?/defmt",
   "ariel-os-coap?/defmt",
-  "ariel-os-debug/defmt",
   "ariel-os-embassy/defmt",
+  "ariel-os-log/defmt",
   "ariel-os-sensors?/defmt",
   "ariel-os-threads?/defmt",
 ]
 # Enables logging support through `log`, see [`log`].
-log = ["ariel-os-debug/log", "ariel-os-embassy/log"]
+log = ["ariel-os-embassy/log", "ariel-os-log/log"]
 ## Enables benchmarking facilities.
 bench = ["dep:ariel-os-bench"]
 # Prints panic messages on the debug console.
@@ -218,10 +218,10 @@ panic-printing = ["ariel-os-rt/panic-printing"]
 no-boards = ["ariel-os-boards/no-boards", "executor-none"]
 
 # These are selected by laze
-debug-uart = ["ariel-os-debug/uart", "ariel-os-embassy/debug-uart"]
+debug-uart = ["ariel-os-embassy/debug-uart", "ariel-os-log/uart"]
 rtt-target = ["ariel-os-debug/rtt-target"]
-defmt-rtt = ["ariel-os-debug/defmt-rtt"]
-esp-println = ["ariel-os-debug/esp-println"]
+defmt-rtt = ["ariel-os-log/defmt-rtt"]
+esp-println = ["ariel-os-log/esp-println"]
 semihosting = ["ariel-os-debug/semihosting"]
 
 net = ["ariel-os-embassy/net"]

--- a/tests/benchmarks/bench_sched_yield/src/main.rs
+++ b/tests/benchmarks/bench_sched_yield/src/main.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::{debug::println, thread};
+use ariel_os::{log::println, thread};
 
 #[ariel_os::thread(autostart)]
 fn thread0() {


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This heavily revisits the relationship between the `ariel-os-log` and `ariel-os-debug` crates. The motivation is mostly twofold: aligning the contents of the crates with their responsibility as mentioned in https://github.com/ariel-os/ariel-os/pull/1987#issuecomment-4242681143 and defined in the documentation of #1987, and providing the missing `println!()` macro from `ariel_os::log` when using the `log` facade (see https://github.com/ariel-os/ariel-os/pull/1989#issuecomment-4183480958).

Unfortunately I haven't found a way to split this PR in smaller chunks, as I couldn't find intermediate states where the various `println!()` macros were not more broken than on main. Instead, here is a list of semantic changes this PR does:

- Move the `log` logger from `ariel-os-debug` to `ariel-os-log`
- **Add a `println!()` macro to `ariel-os-log` when the `log` facade is used**
- **Remove `ariel-os-debug`'s `println!()` macro from the API** (as discussed out of band)
- Expose the debug output from `ariel-os-debug` to `ariel-os-log` when using `rtt-target`, by exposing a `println!()` macro to it (hidden from the public API)
- Make `ariel-os-log` depend on `ariel-os-debug` instead of the opposite
- Move the `panic-printing` logic into `ariel-os-log`, and **make it use the logging output** instead of the debug output directly (which means for instance panics could get printed on UART)
- Move the `debug-uart` logic into `ariel-os-log`
- Move the `esp-println` logic into `ariel-os-log`

(Changes that are visible in the API are in bold.)

Renaming `debug-uart` and revisiting the laze configuration to allow for more combinations (including an explicit `logging-over-debug-output`) is out of scope of this PR and will be done in another one.

## Future work

Introducing the following laze modules:

- `logging-over-debug-output`
- `logging-over-uart`
- `logging-over-usb`

and likely slightly realigning the set of Cargo features on `ariel-os`/`ariel-os-log`/`ariel-os-debug` when doing so.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

### Testing the debug output and logging

The testing matrix of this is quite large, as we need `defmt-rtt`, `rtt-target` with `log` (and maybe `defmt` as well?), `esp-println` with both `defmt` and `log`, and `debug-uart` (soon to be renamed; always uses `log`) to still be working.

Here are the cases I've checked (they should have have one `println!()` and three log lines):

- `laze -C examples/log build -b stm32u083c-dk -v run`
- `laze -C examples/log build -s log -b stm32u083c-dk -v run`
- `laze -C examples/log build -s rtt-target -s log -b stm32u083c-dk -v run`
- `laze -C examples/log build -b espressif-esp32-c6-devkitc-1 -v run`
- `laze -C examples/log build -s log -b espressif-esp32-c6-devkitc-1 -v run`
- `laze -C examples/log build -s debug-uart -b stm32u083c-dk -v run`
- `laze -C examples/log build -s probe-rs -b espressif-esp32-c6-devkitc-1 -v run`
- `laze -C examples/log build -s rtt-target -s log -s probe-rs -b espressif-esp32-c6-devkitc-1 -v run`
- `laze -C examples/log build -b native run`

The nrf52840dk can be used instead of the stm32u083c-dk.
Observing command parameters printed by `-v`, the style of the output, and the binary size (using the `size` laze task) can be useful to make sure whether `defmt` or `log` is effectively used in each case.

When using `debug-uart`, the following can be used as serial monitor (the serial device may need to be adjusted):

```sh
picocom /dev/ttyACM0 --baud 115200
```

### Testing panics

Additionally, panics also need to be tested, especially as they are now printed on the logging output instead of only the debug output. To test this, a `panic!("test panic");` can be added at the end of the `log` example (for instance) before going the above list of commands again.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #2008
- Closes #1989

## Open Questions

<!-- Unresolved questions, if any. -->
- Should `defmt` be usable with `rtt-target`? I think the laze config doesn't currently allow for that, but there are remnants of implementation from before `defmt-rtt` was added in #1603.

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The logging facilities have been revisited: `ariel_os::debug::println!()` has been removed, `ariel_os::log::println!()` must be used instead; `ariel_os::log::println!()` now also exists when using the `log` logging facade. Panics are always printed to the logging output. 
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
