### PR TITLE
docs(esp32): correct debug output support on esp32 

### DIFF
--- a/book/src/boards/ulanzi-tc001.md
+++ b/book/src/boards/ulanzi-tc001.md
@@ -24,7 +24,7 @@ laze build -b ulanzi-tc001
 
 |Functionality|Support Status|
 |---|:---:|
-|Debug Output|<span title="supported">✅</span>|
+|Debug Output|<span title="not available on this piece of hardware">–</span>[^jtag-pins-are-not-accessible-through-the-case]|
 |Logging|<span title="supported">✅</span>|
 |GPIO|<span title="supported">✅</span>|
 |I2C Controller Mode|<span title="supported">✅</span>|
@@ -65,5 +65,6 @@ dt, dd {
 
 
   
+[^jtag-pins-are-not-accessible-through-the-case]: JTAG pins are not accessible through the case.
 [^no-generic-usb-peripheral]: No generic USB peripheral.
 [^requires-partitioning-support]: Requires partitioning support.

--- a/book/src/chips/esp32-d0wd.md
+++ b/book/src/chips/esp32-d0wd.md
@@ -8,7 +8,7 @@
 
 |Functionality|Support Status|
 |---|:---:|
-|Debug Output|<span title="supported">✅</span>|
+|Debug Output|<span title="needs testing">🚦</span>|
 |Logging|<span title="supported">✅</span>|
 |GPIO|<span title="supported">✅</span>|
 |I2C Controller Mode|<span title="supported">✅</span>|
@@ -87,7 +87,7 @@ Boards using this chip.
 	  <tr>
 	    <td><code>ulanzi-tc001</code></td>
 		<td style="text-align: center;">2</td>
-		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -677,7 +677,7 @@
 	  <tr>
 	    <td><code>ulanzi-tc001</code></td>
 		<td style="text-align: center;">2</td>
-		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>
 		  <td class="support-cell" title="supported">✅</td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -289,7 +289,7 @@ chips:
     manufacturer: Espressif
     support:
       gpio: supported
-      debug_output: supported
+      debug_output: needs_testing
       hwrng: supported
       i2c_controller: supported
       spi_main: needs_testing
@@ -1274,6 +1274,10 @@ builders:
     chip: esp32-d0wd
     tier: "2"
     support:
+      debug_output:
+        status: not_available
+        comments:
+          - JTAG pins are not accessible through the case
 
   unihiker-k10:
     chip: esp32s3


### PR DESCRIPTION
# Description

This PR marks `debug output` as `needs_testing`  on the ESP32-D0WD (the only documented plain ESP32 variant currently documented) and as `not_available` on the Ulanzi TC001.
<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
