### PR TITLE
refactor(logging): drop values using the underscore when syntax-checking

### DIFF
--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -79,7 +79,7 @@ mod log_macros {
             if true {
                 defmt::trace!($($arg)*);
             } else {
-                drop(format_args!($($arg)*));
+                let _ = format_args!($($arg)*);
             }
         }};
     }
@@ -92,7 +92,7 @@ mod log_macros {
             if true {
                 defmt::debug!($($arg)*);
             } else {
-                drop(format_args!($($arg)*));
+                let _ = format_args!($($arg)*);
             }
         }};
     }
@@ -105,7 +105,7 @@ mod log_macros {
             if true {
                 defmt::info!($($arg)*);
             } else {
-                drop(format_args!($($arg)*));
+                let _ = format_args!($($arg)*);
             }
         }};
     }
@@ -118,7 +118,7 @@ mod log_macros {
             if true {
                 defmt::warn!($($arg)*);
             } else {
-                drop(format_args!($($arg)*));
+                let _ = format_args!($($arg)*);
             }
         }};
     }
@@ -131,7 +131,7 @@ mod log_macros {
             if true {
                 defmt::error!($($arg)*);
             } else {
-                drop(format_args!($($arg)*));
+                let _ = format_args!($($arg)*);
             }
         }};
     }
@@ -144,7 +144,7 @@ mod log_macros {
             if true {
                 defmt::println!($($arg)*);
             } else {
-                drop(format_args!($($arg)*));
+                let _ = format_args!($($arg)*);
             }
         }};
     }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This replaces the usage of `core::mem::drop()` with the `let _ =` construct in our `defmt` logging macros.

This fixes the following warning that appears in #2013 for some configurations:

```
   --> src/ariel-os-log/src/lib.rs:187:17
    |
 60 |     println!("panicked at {}:\n{}", location, message);
    |     -------------------------------------------------- in this macro invocation
...
187 |                 drop(format_args!($($arg)*));
    |                 ^^^^^----------------------^
    |                      |
    |                      argument has type `core::fmt::Arguments<'_>`
    |
    = note: `-D dropping-copy-types` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dropping_copy_types)]`
    = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
help: use `let _ = ...` to ignore the expression or result
    |
187 -                 drop(format_args!($($arg)*));
187 +                 let _ = format_args!($($arg)*);
```

(This is because [`Location`](https://doc.rust-lang.org/stable/core/panic/struct.Location.html) is `Copy`.)

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
The `if true { /* … */ } else { drop(/* … */) }` construct was used to enforce at compile time that only the common denominator of display hints of [`defmt` macros](https://defmt.ferrous-systems.com/hints) and of [`log`/`std::fmt`](https://doc.rust-lang.org/stable/std/fmt/index.html#formatting-parameters) is used in our logging macros. The following can be done to make sure this still works as expected:

- In the `log` example, add a `{=u8}` display hint and a `42` parameter to:
    - The `println!()` statement
    - Any of the actual logging macros
- This should *still* be failing at compile time with the following error:

    ```sh
    error: invalid format string: expected `}`, found `=`
    ```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
I don't think this was observable in any way, so not adding to the changelog.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
