### PR TITLE
feat(thingy91x): add PMIC initialization

### DIFF
--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -150,6 +150,8 @@ compile_error!(r#"must select one of "executor-interrupt", "executor-thread", "e
 pub(crate) fn init() {
     debug!("ariel-os-embassy::init(): using interrupt mode executor");
     let p = hal::init();
+    debug!("hal init done");
+
 
     #[cfg(any(context = "nrf", context = "stm32"))]
     {
@@ -159,7 +161,10 @@ pub(crate) fn init() {
 
     #[cfg(any(context = "nrf", context = "rp", context = "stm32"))]
     {
+        debug!("starting executor");
         hal::EXECUTOR.start(hal::SWI);
+
+        debug!("spawing task");
         hal::EXECUTOR.spawner().must_spawn(init_task(p));
     }
 

--- a/src/ariel-os-nrf/src/boards.rs
+++ b/src/ariel-os-nrf/src/boards.rs
@@ -1,0 +1,197 @@
+//! Board specific initialization.
+
+/// Initialize the power management components necessary for some of the hardware to function properly.
+///
+/// - `i2c_bus` needs to be a mutable reference to an i2c controller with SCL connected to P0_08 and SDA connected to P0_09.
+/// - Set `sensors` to true to power the sensors (VDD_SENS on the schematic).
+/// - Set `npm6001` to power the nPM6001 PMIC used for the wifi chip (nPM60_ENABLE on the schematic)
+#[cfg(all(feature = "i2c", context = "nordic-thingy-91-x-nrf9151"))]
+pub async fn init_thingy91x_board(
+    i2c_bus: &mut crate::i2c::controller::I2c,
+    npm6001: bool,
+    sensors: bool,
+) -> Result<(), ariel_os_embassy_common::i2c::controller::Error> {
+    use embedded_hal_async::i2c::I2c;
+    const NPM1300_ADDR: u8 = 0x6b;
+
+    // Register addresses are on 16 bits, i2c works with 8 bits words so we split them.
+
+    // Load switch 1, set value to 0x01 to power the wifi chip.
+    const TASKLDSW1SET: [u8; 2] = [0x08, 0x00];
+    let taskldsw1set_value: u8 = if npm6001 { 0x01 } else { 0x00 };
+    // Load switch 2, set value to 0x01 to give power to the sensors.
+    const TASKLDSW2SET: [u8; 2] = [0x08, 0x02];
+    let taskldsw2set_value: u8 = if sensors { 0x01 } else { 0x00 };
+
+    // Buck 2 enabled by GPIO2.
+    const BUCKENCTRL: [u8; 2] = [0x04, 0x0c];
+    const BUCKENCTRL_VALUE: u8 = 0x18;
+
+    // Battery spec: https://www.lipobatteries.net/wp-content/uploads/2021/12/LP803448-LPCWES.pdf
+
+    // Set charging rate to 675mA (from battery spec) and enable charging. This is a 10 bit value but we can't set the last bit.
+    const CHARGING_RATE: u16 = 675;
+    const BCHGISETMSB: [u8; 2] = [0x03, 0x08];
+    const BCHGISETMSB_VALUE: u8 = (CHARGING_RATE >> 2) as u8;
+    const BCHGISETLSB: [u8; 2] = [0x03, 0x09];
+    const BCHGISETLSB_VALUE: u8 = (CHARGING_RATE >> 1) as u8 & 0x01;
+    // Charging must be enabled after setting the charge rate.
+    const BCHGENABLESET: [u8; 2] = [0x03, 0x04];
+    const BCHGENABLESET_ENABLE_VALUE: u8 = 0x01;
+    const BCHGENABLESET_DISABLE_VALUE: u8 = 0x00;
+
+    // 1A current discharge limit. Battery limit is 1350mA. IC can either have 200mA or 1A limit, we select 1A.
+    const BCHGISETDISCHARGEMSB: [u8; 2] = [0x03, 0x0a];
+    const BCHGISETDISCHARGEMSB_VALUE: u8 = 0xcf;
+    const BCHGISETDISCHARGELSB: [u8; 2] = [0x03, 0x0b];
+    const BCHGISETDISCHARGELSB_VALUE: u8 = 0x01;
+
+    // 4.2V (Max. Charge Voltage in battery the spec) termination voltage for cool and nominal temperature region.
+    const BCHGVTERM: [u8; 2] = [0x03, 0x0c];
+    const BCHGVTERM_VALUE: u8 = 0x08;
+    // 4.2V (Max. Charge Voltage in the battery spec) termination voltage for warm temperature region.
+    const BCHGVTERMR: [u8; 2] = [0x03, 0x0d];
+    const BCHGVTERMR_VALUE: u8 = 0x08;
+
+    // Thermistor in the battery? (should be the same specs): https://amwei.com/ntc-10k-ohm-beta-3435k-axial-lead-glass-seal
+    // NTC 10 kOhm
+    const ADCNTCRSEL: [u8; 2] = [0x05, 0x0a];
+    const ADCNTCRSEL_VALUE: u8 = 0x01;
+
+    // Using the table in the NTC spec for resistance values.
+    // The default temperature values of the IC should be fine except the COLD threshold, we need to raise it to 10C.
+    const INTERNAL_BIAS_RESISTOR: u32 = 10000; // 10kOhms
+    const RESISTANCE_10C: u32 = 18054; // 18.054kOhms
+    // From section 6.2.4 of the nPM1300 datasheet.
+    const NTCOLD_RAW_VALUE: u32 = 1024 * RESISTANCE_10C / (RESISTANCE_10C + INTERNAL_BIAS_RESISTOR);
+
+    // Battery shouldn't charge under 10ºC, we change the cold threshold to this temperature. The value is 10 bit across 2 registers.
+    const NTCCOLD: [u8; 2] = [0x03, 0x10];
+    const NTCCOLD_VALUE: u8 = (NTCOLD_RAW_VALUE >> 2 & 0xFF) as u8;
+    const NTCCOLDLSB: [u8; 2] = [0x03, 0x11];
+    const NTCCOLDLSB_VALUE: u8 = (NTCOLD_RAW_VALUE & 0x03) as u8; // keep only the 2 least significant bits.
+
+    // Input current limit for startup. Couldn't find exactly why this is needed but the nrf firmware sets it and if it's not set `i2c-scanner` says it finds a device for every address, that doesn's seem right.
+    const VBUSINILIMSTARTUP: [u8; 2] = [0x02, 0x02];
+    const VBUSINILIMSTARTUP_VALUE: u8 = 0x05;
+
+    // Needs to configure the nPM1300 PMIC for the modem to work correctly.
+    // This is based on reading the datasheets and what is set by the firmware "hello.nrfcloud.com" downloadable at https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-91-X/Download in the archive "Precompiled application and modem firmware".
+    {
+        ariel_os_log::debug!("VBUSINILIMSTARTUP");
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[
+                    VBUSINILIMSTARTUP[0],
+                    VBUSINILIMSTARTUP[1],
+                    VBUSINILIMSTARTUP_VALUE,
+                ],
+            )
+            .await?;
+        // Disable charging before modifying the configuration
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[
+                    BCHGENABLESET[0],
+                    BCHGENABLESET[1],
+                    BCHGENABLESET_DISABLE_VALUE,
+                ],
+            )
+            .await?;
+
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[
+                    BCHGISETDISCHARGEMSB[0],
+                    BCHGISETDISCHARGEMSB[1],
+                    BCHGISETDISCHARGEMSB_VALUE,
+                ],
+            )
+            .await?;
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[BUCKENCTRL[0], BUCKENCTRL[1], BUCKENCTRL_VALUE],
+            )
+            .await?;
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[
+                    BCHGISETDISCHARGELSB[0],
+                    BCHGISETDISCHARGELSB[1],
+                    BCHGISETDISCHARGELSB_VALUE,
+                ],
+            )
+            .await?;
+
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[TASKLDSW1SET[0], TASKLDSW1SET[1], taskldsw1set_value],
+            )
+            .await?;
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[TASKLDSW2SET[0], TASKLDSW2SET[1], taskldsw2set_value],
+            )
+            .await?;
+
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[BCHGISETMSB[0], BCHGISETMSB[1], BCHGISETMSB_VALUE],
+            )
+            .await?;
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[BCHGISETLSB[0], BCHGISETLSB[1], BCHGISETLSB_VALUE],
+            )
+            .await?;
+        ariel_os_log::debug!("BCHGVTERM");
+
+        i2c_bus
+            .write(NPM1300_ADDR, &[BCHGVTERM[0], BCHGVTERM[1], BCHGVTERM_VALUE])
+            .await?;
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[BCHGVTERMR[0], BCHGVTERMR[1], BCHGVTERMR_VALUE],
+            )
+            .await?;
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[ADCNTCRSEL[0], ADCNTCRSEL[1], ADCNTCRSEL_VALUE],
+            )
+            .await?;
+        i2c_bus
+            .write(NPM1300_ADDR, &[NTCCOLD[0], NTCCOLD[1], NTCCOLD_VALUE])
+            .await?;
+        ariel_os_log::debug!("NTCCOLDLSB");
+
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[NTCCOLDLSB[0], NTCCOLDLSB[1], NTCCOLDLSB_VALUE],
+            )
+            .await?;
+        // Enable charging once everything is configured.
+        i2c_bus
+            .write(
+                NPM1300_ADDR,
+                &[
+                    BCHGENABLESET[0],
+                    BCHGENABLESET[1],
+                    BCHGENABLESET_ENABLE_VALUE,
+                ],
+            )
+            .await?;
+    }
+    Ok(())
+}

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -17,6 +17,8 @@ pub mod peripheral {
 #[doc(hidden)]
 pub mod ble;
 
+pub mod boards;
+
 #[cfg(feature = "external-interrupts")]
 #[doc(hidden)]
 pub mod extint_registry;


### PR DESCRIPTION
# Description

Configures the nPM1300 PMIC on the Thingy91:X board to support modem operation. This currently needs to be manually called with an i2c bus correctly configured.

Currently there is no way to give back the already initialized i2c controller to the application, so the application has to call the board initialization:

```rust

#[cfg(context = "nordic-thingy-91-x-nrf9151")]
use ariel_os::hal::peripherals;
#[cfg(context = "nordic-thingy-91-x-nrf9151")]
pub type SensorI2c = ariel_os::hal::i2c::controller::SERIAL1;
#[cfg(context = "nordic-thingy-91-x-nrf9151")]
ariel_os::hal::define_peripherals!(Peripherals {
    i2c_sda: P0_09,
    i2c_scl: P0_08,
});

#[cfg(not(context = "nordic-thingy-91-x-nrf9151"))]
ariel_os::hal::define_peripherals!(Peripherals {});

#[cfg(context = "nordic-thingy-91-x-nrf9151")]
#[ariel_os::task(autostart, peripherals)]
async fn board_init(peripherals: Peripherals) {
    use ariel_os::{
        i2c::controller::{Kilohertz, highest_freq_in},
        log::Debug2Format,
    };
    let mut i2c_config = ariel_os::hal::i2c::controller::Config::default();
    i2c_config.frequency = const { highest_freq_in(Kilohertz::kHz(100)..=Kilohertz::kHz(400)) };

    let mut i2c_bus = SensorI2c::new(peripherals.i2c_sda, peripherals.i2c_scl, i2c_config);

    let err = ariel_os::hal::boards::init_thingy91x_board(&mut i2c_bus, true, true).await;
    info!("{:?}", Debug2Format(&err));
}

```

The objective is to have this in the SBD. 

## Testing

- flash an application to drain the battery, disconnect the usb charging cable:

```
laze -C examples/sensors-debug build -b nordic-thingy-91-x-nrf9151 run -- --allow-erase-all        
```

- wait a bit for the battery to discharge
- flash a basic hello world to the nrf9151:

```
laze -C examples/hello-world build -b nordic-thingy-91-x-nrf9151 run -- --allow-erase-all        
```

- disconnect the programming connector, the battery connector and the charging cable, then reconnect everything
- add the above code to `examples/tcp-client/main.rs`
- flash the tcp-client example: 

```
laze -C examples/tcp-client build -b nordic-thingy-91-x-nrf9151 -DLOG=trace run -- --allow-erase-all --no-catch-reset 
```

The charging LED should turn green

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- #1583


## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The nPM1300 PMIC is no configured on the Thingy:91 X
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
