### PR TITLE
fix(espflash): allow using `espflash` when `esp-println` is not used

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -358,6 +358,7 @@ contexts:
     parent: ariel-os
     selects:
       - ?debug-console
+      - ?espflash
       - ?esp-println
     provides:
       - has_hwrng
@@ -1138,6 +1139,14 @@ modules:
           - "-Clink-arg=-v"
         LINK_ARG_PREFIX: -Wl,
 
+  - name: espflash
+    help: use `espflash` as runner
+    provides_unique:
+      - flashing-tool
+    env:
+      global:
+        CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
+
   - name: probe-rs
     help: use probe-rs as runner
     selects:
@@ -1150,6 +1159,7 @@ modules:
           - ?debug-uart
     provides_unique:
       - embedded-test-runner
+      - flashing-tool
 
     env:
       global:
@@ -1829,7 +1839,6 @@ modules:
       - ariel-os-debug-backend
     env:
       global:
-        CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
         FEATURES:
           - ariel-os/esp-println
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This introduces an `espflash` laze module, similar to the `probe-rs` laze module, to decouple the usage of the `espflash` flashing and log printing tool from the `esp-println` laze module, as they are not actually related (at least regarding flashing). In particular this allows to still use `espflash` for flashing (both through USB and over USB CDC-ACM), even when `esp-println` is manually disabled.

As background, `esp-println` is only responsible for *logging*, either over UART or USB CDC-ACM (currently *both* of them are enabled, and whichever is used is selected automatically at runtime, but I hope we revisit that soon).

## Future work

The interaction between the flashing/log printing tools, the debug output and the logging output will be revisited very soon, after #2013.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
The following can be used to highlight the issue (on main, before this PR), and observe its resolution:

```sh
laze -C examples/log build -d esp-println -d debug-console -b espressif-esp32-c6-devkitc-1 run
```

when using the "UART"-labeled USB port, or, equivalently:

```sh
laze -C examples/log build -d esp-println -d debug-console -b ulanzi-tc001 run
```

This won't print anything as this disables the debug console, using another example with an effect observable without logging/the debug console may be a better idea depending on the board.

(Disabling `debug-console` is currently needed because of the internal, *current* interaction between logging and the debug console, but this will be addressed by #2013.)

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
I think we can skip the changelog on this one: we didn't document the `esp-println` laze module (and don't plan to, I hope we eventually remove it), and no other module would disable it internally.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
