### PR TITLE
feat(gpio)!: introduce a lifetime generic on GPIO types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,6 +3578,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpio-reuse"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+]
+
+[[package]]
 name = "grounded"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ This directory contains example applications that showcase how to use Ariel OS.
 - [coap-server](./coap-server) and [coap-client](./coap-client): Application level networking examples
 - [device-metadata/](./device-metadata): Retrieve metadata about the running device
 - [gpio/](./gpio): GPIO pin control example.
+- [gpio-reuse/](./gpio-reuse): Change GPIO role at runtime
 - [hello-world/](./hello-world): A classic, async version
 - [hello-world-threading/](./hello-world-threading): A classic, using a thread
 - [http-client/](./http-client): HTTP client example

--- a/examples/gpio-reuse/Cargo.toml
+++ b/examples/gpio-reuse/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gpio-reuse"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os", features = ["time"] }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+
+[lints]
+workspace = true

--- a/examples/gpio-reuse/README.md
+++ b/examples/gpio-reuse/README.md
@@ -1,0 +1,11 @@
+# gpio-reuse
+
+## About
+
+This application is demonstrating changing the role of a GPIO at runtime.
+
+## How to run
+
+In this directory, run
+
+    laze build -b nrf52840dk run

--- a/examples/gpio-reuse/laze.yml
+++ b/examples/gpio-reuse/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: gpio-reuse
+    selects:
+      - has_leds

--- a/examples/gpio-reuse/src/main.rs
+++ b/examples/gpio-reuse/src/main.rs
@@ -1,0 +1,33 @@
+#![no_main]
+#![no_std]
+
+use ariel_os_boards::pins;
+
+use ariel_os::{
+    gpio::{Input, Level, Output, Pull},
+    log::info,
+    time::Timer,
+};
+
+#[ariel_os::task(autostart, peripherals)]
+async fn blinky(mut peripherals: pins::LedPeripherals) {
+    loop {
+        // First, set the GPIO as input and read its level.
+        // Some HALs require dropping both the driver itself and the peripheral ZST before using it
+        // again for another driver.
+        {
+            let input = Input::new(peripherals.led0.reborrow(), Pull::Down);
+
+            let level = input.get_level();
+            info!("GPIO level: {:?}", level);
+        }
+
+        // Then, make the LED blink.
+        let mut led = Output::new(peripherals.led0.reborrow(), Level::Low);
+
+        for _ in 0..(2 * 3) {
+            led.toggle();
+            Timer::after_millis(500).await;
+        }
+    }
+}

--- a/examples/http-server/src/main.rs
+++ b/examples/http-server/src/main.rs
@@ -31,7 +31,7 @@ const SERVER_CONFIG: picoserve::Config = {
 static APP: StaticCell<picoserve::Router<routes::AppRouter>> = StaticCell::new();
 
 #[cfg(feature = "button-reading")]
-static BUTTON_INPUT: OnceLock<ariel_os::gpio::Input> = OnceLock::new();
+static BUTTON_INPUT: OnceLock<ariel_os::gpio::Input<'_>> = OnceLock::new();
 
 #[ariel_os::task(pool_size = WEB_TASK_POOL_SIZE)]
 async fn web_task(task_id: usize, app: &'static picoserve::Router<routes::AppRouter>) -> ! {

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -13,6 +13,7 @@ subdirs:
   - coap-server
   - device-metadata
   - gpio
+  - gpio-reuse
   - hello-world
   - hello-world-threading
   - http-client

--- a/examples/usb-keyboard/src/main.rs
+++ b/examples/usb-keyboard/src/main.rs
@@ -108,9 +108,9 @@ mod buttons {
 
     pub const KEY_COUNT: usize = 4;
 
-    pub struct Buttons([Input; KEY_COUNT]);
+    pub struct Buttons<'a>([Input<'a>; KEY_COUNT]);
 
-    impl Buttons {
+    impl<'a> Buttons<'a> {
         pub fn new(button_peripherals: crate::pins::Buttons) -> Self {
             Self([
                 Input::new(button_peripherals.btn1, PULL),
@@ -120,7 +120,7 @@ mod buttons {
             ])
         }
 
-        pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Input> {
+        pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Input<'a>> {
             self.0.iter_mut()
         }
     }

--- a/src/ariel-os-embassy/src/spi/main/mod.rs
+++ b/src/ariel-os-embassy/src/spi/main/mod.rs
@@ -24,7 +24,7 @@ pub use ariel_os_embassy_common::spi::main::*;
 /// SPI-specific hardware capabilities or through a generic software timeout.
 // TODO: do we actually need a CriticalSectionRawMutex here?
 pub type SpiDevice<'a> =
-    InnerSpiDevice<'a, CriticalSectionRawMutex, hal::spi::main::Spi, gpio::Output>;
+    InnerSpiDevice<'a, CriticalSectionRawMutex, hal::spi::main::Spi, gpio::Output<'a>>;
 
 /// Returns the highest SPI frequency available on the MCU that fits into the requested
 /// range.

--- a/src/ariel-os-hal/src/gpio.rs
+++ b/src/ariel-os-hal/src/gpio.rs
@@ -60,21 +60,21 @@ macro_rules! inner_impl_input_methods {
 ///
 /// If support for external interrupts is needed, use [`InputBuilder::build_with_interrupt()`] to
 /// obtain an [`IntEnabledInput`].
-pub struct Input {
-    input: HalInput<'static>,
+pub struct Input<'a> {
+    input: HalInput<'a>,
 }
 
-impl Input {
+impl<'a> Input<'a> {
     /// Returns a configured [`Input`].
-    pub fn new<P: HalInputPin + 'static>(pin: impl IntoPeripheral<'static, P>, pull: Pull) -> Self {
+    pub fn new<P: HalInputPin + 'a>(pin: impl IntoPeripheral<'a, P>, pull: Pull) -> Self {
         Self::builder(pin, pull).build()
     }
 
     /// Returns an [`InputBuilder`], allowing to configure the GPIO input further.
-    pub fn builder<T: IntoPeripheral<'static, P>, P: HalInputPin + 'static>(
+    pub fn builder<T: IntoPeripheral<'a, P>, P: HalInputPin + 'a>(
         pin: T,
         pull: Pull,
-    ) -> InputBuilder<T, P> {
+    ) -> InputBuilder<'a, T, P> {
         InputBuilder {
             pin,
             pull,
@@ -87,20 +87,20 @@ impl Input {
 }
 
 #[doc(hidden)]
-impl embedded_hal::digital::ErrorType for Input {
-    type Error = <HalInput<'static> as embedded_hal::digital::ErrorType>::Error;
+impl<'a> embedded_hal::digital::ErrorType for Input<'a> {
+    type Error = <HalInput<'a> as embedded_hal::digital::ErrorType>::Error;
 }
 
 /// A GPIO input that supports external interrupts.
 ///
 /// Can be obtained with [`InputBuilder::build_with_interrupt()`].
 #[cfg(feature = "external-interrupts")]
-pub struct IntEnabledInput {
-    input: HalIntEnabledInput<'static>,
+pub struct IntEnabledInput<'a> {
+    input: HalIntEnabledInput<'a>,
 }
 
 #[cfg(feature = "external-interrupts")]
-impl IntEnabledInput {
+impl IntEnabledInput<'_> {
     inner_impl_input_methods!(input);
 
     /// Asynchronously waits until the input level is high.
@@ -133,12 +133,12 @@ impl IntEnabledInput {
 
 #[cfg(feature = "external-interrupts")]
 #[doc(hidden)]
-impl embedded_hal::digital::ErrorType for IntEnabledInput {
-    type Error = <HalIntEnabledInput<'static> as embedded_hal::digital::ErrorType>::Error;
+impl<'a> embedded_hal::digital::ErrorType for IntEnabledInput<'a> {
+    type Error = <HalIntEnabledInput<'a> as embedded_hal::digital::ErrorType>::Error;
 }
 
 #[cfg(feature = "external-interrupts")]
-impl embedded_hal_async::digital::Wait for IntEnabledInput {
+impl embedded_hal_async::digital::Wait for IntEnabledInput<'_> {
     async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
         <HalIntEnabledInput<'_> as embedded_hal_async::digital::Wait>::wait_for_high(
             &mut self.input,
@@ -198,9 +198,9 @@ macro_rules! impl_embedded_hal_input_trait {
     };
 }
 
-impl_embedded_hal_input_trait!(Input, HalInput<'_>);
+impl_embedded_hal_input_trait!(Input<'_>, HalInput<'_>);
 #[cfg(feature = "external-interrupts")]
-impl_embedded_hal_input_trait!(IntEnabledInput, HalIntEnabledInput<'_>);
+impl_embedded_hal_input_trait!(IntEnabledInput<'_>, HalIntEnabledInput<'_>);
 
 pub mod input {
     //! Input-specific types.
@@ -221,14 +221,14 @@ pub mod input {
     pub use ariel_os_embassy_common::gpio::input::InterruptError;
 
     /// Builder type for [`Input`], can be obtained with [`Input::builder()`].
-    pub struct InputBuilder<T: IntoPeripheral<'static, P>, P: HalInputPin + 'static> {
+    pub struct InputBuilder<'a, T: IntoPeripheral<'a, P>, P: HalInputPin> {
         pub(crate) pin: T,
         pub(crate) pull: Pull,
         pub(crate) schmitt_trigger: bool,
-        pub(crate) _phantom: PhantomData<&'static P>,
+        pub(crate) _phantom: PhantomData<&'a P>,
     }
 
-    impl<T: IntoPeripheral<'static, P>, P: HalInputPin + 'static> InputBuilder<T, P> {
+    impl<'a, T: IntoPeripheral<'a, P>, P: HalInputPin + 'a> InputBuilder<'a, T, P> {
         /// Configures the input's Schmitt trigger.
         ///
         /// # Note
@@ -276,9 +276,9 @@ pub mod input {
     }
 
     // Split the impl for consistency with outputs.
-    impl<T: IntoPeripheral<'static, P>, P: HalInputPin> InputBuilder<T, P> {
+    impl<'a, T: IntoPeripheral<'a, P>, P: HalInputPin + 'a> InputBuilder<'a, T, P> {
         /// Returns an [`Input`] by finalizing the builder.
-        pub fn build(self) -> Input {
+        pub fn build(self) -> Input<'a> {
             let pin = self.pin.into_hal_peripheral();
             #[allow(irrefutable_let_patterns, reason = "conditional compilation")]
             let Ok(input) = hal::gpio::input::new(pin, self.pull, self.schmitt_trigger) else {
@@ -300,7 +300,7 @@ pub mod input {
         /// In these cases, this returns an [`Error::InterruptChannel`], with a HAL-specific error.
         // FIXME: rename this
         #[cfg(feature = "external-interrupts")]
-        pub fn build_with_interrupt(self) -> Result<IntEnabledInput, Error> {
+        pub fn build_with_interrupt(self) -> Result<IntEnabledInput<'a>, Error> {
             let pin = self.pin.into_hal_peripheral();
             let input = hal::gpio::input::new_int_enabled(pin, self.pull, self.schmitt_trigger)?;
 
@@ -310,24 +310,24 @@ pub mod input {
 }
 
 /// A GPIO output.
-pub struct Output {
-    output: HalOutput<'static>,
+pub struct Output<'a> {
+    output: HalOutput<'a>,
 }
 
-impl Output {
+impl<'a> Output<'a> {
     /// Returns a configured [`Output`].
-    pub fn new<P: HalOutputPin + 'static>(
-        pin: impl IntoPeripheral<'static, P>,
+    pub fn new<P: HalOutputPin + 'a>(
+        pin: impl IntoPeripheral<'a, P>,
         initial_level: Level,
     ) -> Self {
         Self::builder(pin, initial_level).build()
     }
 
     /// Returns an [`OutputBuilder`], allowing to configure the GPIO output further.
-    pub fn builder<T: IntoPeripheral<'static, P>, P: HalOutputPin + 'static>(
+    pub fn builder<T: IntoPeripheral<'a, P>, P: HalOutputPin + 'a>(
         pin: T,
         initial_level: Level,
-    ) -> OutputBuilder<T, P> {
+    ) -> OutputBuilder<'a, T, P> {
         OutputBuilder {
             pin,
             initial_level,
@@ -376,18 +376,18 @@ pub mod output {
     use super::{HalDriveStrength, HalSpeed, Output};
 
     /// Builder type for [`Output`], can be obtained with [`Output::builder()`].
-    pub struct OutputBuilder<T: IntoPeripheral<'static, P>, P: HalOutputPin + 'static> {
+    pub struct OutputBuilder<'a, T: IntoPeripheral<'a, P>, P: HalOutputPin> {
         pub(crate) pin: T,
         pub(crate) initial_level: Level,
         pub(crate) drive_strength: DriveStrength<HalDriveStrength>,
         pub(crate) speed: Speed<HalSpeed>,
-        pub(crate) _phantom: PhantomData<&'static P>,
+        pub(crate) _phantom: PhantomData<&'a P>,
     }
 
     // We define this in a macro because it will be useful for open-drain outputs.
     macro_rules! impl_output_builder {
         ($type:ident, $pin_trait:ident) => {
-            impl<T: IntoPeripheral<'static, P>, P: $pin_trait + 'static> $type<T, P> {
+            impl<'a, T: IntoPeripheral<'a, P>, P: $pin_trait + 'a> $type<'a, T, P> {
                 /// Configures the output's drive strength.
                 ///
                 /// # Note
@@ -472,9 +472,9 @@ pub mod output {
 
     impl_output_builder!(OutputBuilder, HalOutputPin);
 
-    impl<T: IntoPeripheral<'static, P>, P: HalOutputPin + 'static> OutputBuilder<T, P> {
+    impl<'a, T: IntoPeripheral<'a, P>, P: HalOutputPin + 'a> OutputBuilder<'a, T, P> {
         /// Returns an [`Output`] by finalizing the builder.
-        pub fn build(self) -> Output {
+        pub fn build(self) -> Output<'a> {
             // TODO: should we move this into `output::new()`s?
             let drive_strength = <HalDriveStrength as FromDriveStrength>::from(self.drive_strength);
             // TODO: should we move this into `output::new()`s?
@@ -493,11 +493,11 @@ pub mod output {
 macro_rules! impl_embedded_hal_output_traits {
     ($type:ident, $hal_type:ident) => {
         #[doc(hidden)]
-        impl embedded_hal::digital::ErrorType for $type {
-            type Error = <$hal_type<'static> as embedded_hal::digital::ErrorType>::Error;
+        impl<'a> embedded_hal::digital::ErrorType for $type<'a> {
+            type Error = <$hal_type<'a> as embedded_hal::digital::ErrorType>::Error;
         }
 
-        impl embedded_hal::digital::OutputPin for $type {
+        impl embedded_hal::digital::OutputPin for $type<'_> {
             fn set_high(&mut self) -> Result<(), Self::Error> {
                 <$hal_type<'_> as embedded_hal::digital::OutputPin>::set_high(&mut self.output)
             }
@@ -512,7 +512,7 @@ macro_rules! impl_embedded_hal_output_traits {
         // - embassy-rp
         // - esp-hal
         // - embassy-stm32
-        impl StatefulOutputPin for $type {
+        impl StatefulOutputPin for $type<'_> {
             fn is_set_high(&mut self) -> Result<bool, Self::Error> {
                 <$hal_type<'_> as StatefulOutputPin>::is_set_high(&mut self.output)
             }

--- a/src/ariel-os-hal/src/hal/dummy/gpio.rs
+++ b/src/ariel-os-hal/src/hal/dummy/gpio.rs
@@ -86,20 +86,20 @@ pub mod input {
 
     pub trait InputPin {}
 
-    pub fn new<T: InputPin>(
-        _pin: impl IntoPeripheral<'static, T>,
+    pub fn new<'a, T: InputPin>(
+        _pin: impl IntoPeripheral<'a, T>,
         _pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool,
-    ) -> Result<Input<'static>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<Input<'a>, ariel_os_embassy_common::gpio::input::Error> {
         unimplemented!();
     }
 
     #[cfg(feature = "external-interrupts")]
-    pub fn new_int_enabled<T: InputPin>(
-        _pin: impl IntoPeripheral<'static, T>,
+    pub fn new_int_enabled<'a, T: InputPin>(
+        _pin: impl IntoPeripheral<'a, T>,
         _pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool,
-    ) -> Result<IntEnabledInput<'static>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<IntEnabledInput<'a>, ariel_os_embassy_common::gpio::input::Error> {
         unimplemented!();
     }
 
@@ -125,12 +125,12 @@ pub mod output {
 
     pub trait OutputPin {}
 
-    pub fn new<T: OutputPin>(
-        _pin: impl IntoPeripheral<'static, T>,
+    pub fn new<'a, T: OutputPin>(
+        _pin: impl IntoPeripheral<'a, T>,
         _initial_level: ariel_os_embassy_common::gpio::Level,
         _drive_strength: super::DriveStrength,
         _speed: super::Speed,
-    ) -> Output<'static> {
+    ) -> Output<'a> {
         unimplemented!();
     }
 

--- a/src/ariel-os-nrf/src/gpio.rs
+++ b/src/ariel-os-nrf/src/gpio.rs
@@ -20,22 +20,22 @@ pub mod input {
     pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = false;
 
     #[doc(hidden)]
-    pub fn new<'a, P: InputPin>(
-        pin: Peri<'a, P>,
+    pub fn new<P: InputPin>(
+        pin: Peri<'_, P>,
         pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool, // Not supported by hardware
-    ) -> Result<Input<'a>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<Input<'_>, ariel_os_embassy_common::gpio::input::Error> {
         let pull = from_pull(pull);
         Ok(Input::new(pin, pull))
     }
 
     #[cfg(feature = "external-interrupts")]
     #[doc(hidden)]
-    pub fn new_int_enabled<'a, P: InputPin>(
-        mut pin: Peri<'a, P>,
+    pub fn new_int_enabled<P: InputPin>(
+        mut pin: Peri<'_, P>,
         pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool, // Not supported by hardware
-    ) -> Result<IntEnabledInput<'a>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<IntEnabledInput<'_>, ariel_os_embassy_common::gpio::input::Error> {
         let pull = from_pull(pull);
         crate::extint_registry::EXTINT_REGISTRY.use_interrupt_for_pin(&mut pin)?;
         Ok(Input::new(pin, pull))
@@ -64,12 +64,12 @@ pub mod output {
     pub const SPEED_CONFIGURABLE: bool = false;
 
     #[doc(hidden)]
-    pub fn new<'a, P: OutputPin>(
-        pin: Peri<'a, P>,
+    pub fn new<P: OutputPin>(
+        pin: Peri<'_, P>,
         initial_level: ariel_os_embassy_common::gpio::Level,
         drive_strength: DriveStrength,
         _speed: super::Speed, // Not supported by hardware
-    ) -> Output<'a> {
+    ) -> Output<'_> {
         let output_drive = match drive_strength {
             DriveStrength::Standard => OutputDrive::Standard,
             DriveStrength::High => OutputDrive::HighDrive,

--- a/src/ariel-os-nrf/src/gpio.rs
+++ b/src/ariel-os-nrf/src/gpio.rs
@@ -20,22 +20,22 @@ pub mod input {
     pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = false;
 
     #[doc(hidden)]
-    pub fn new<P: InputPin>(
-        pin: Peri<'_, P>,
+    pub fn new<'a, P: InputPin>(
+        pin: Peri<'a, P>,
         pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool, // Not supported by hardware
-    ) -> Result<Input<'_>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<Input<'a>, ariel_os_embassy_common::gpio::input::Error> {
         let pull = from_pull(pull);
         Ok(Input::new(pin, pull))
     }
 
     #[cfg(feature = "external-interrupts")]
     #[doc(hidden)]
-    pub fn new_int_enabled<P: InputPin>(
-        mut pin: Peri<'_, P>,
+    pub fn new_int_enabled<'a, P: InputPin>(
+        mut pin: Peri<'a, P>,
         pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool, // Not supported by hardware
-    ) -> Result<IntEnabledInput<'_>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<IntEnabledInput<'a>, ariel_os_embassy_common::gpio::input::Error> {
         let pull = from_pull(pull);
         crate::extint_registry::EXTINT_REGISTRY.use_interrupt_for_pin(&mut pin)?;
         Ok(Input::new(pin, pull))
@@ -64,12 +64,12 @@ pub mod output {
     pub const SPEED_CONFIGURABLE: bool = false;
 
     #[doc(hidden)]
-    pub fn new<P: OutputPin>(
-        pin: Peri<'_, P>,
+    pub fn new<'a, P: OutputPin>(
+        pin: Peri<'a, P>,
         initial_level: ariel_os_embassy_common::gpio::Level,
         drive_strength: DriveStrength,
         _speed: super::Speed, // Not supported by hardware
-    ) -> Output<'_> {
+    ) -> Output<'a> {
         let output_drive = match drive_strength {
             DriveStrength::Standard => OutputDrive::Standard,
             DriveStrength::High => OutputDrive::HighDrive,

--- a/src/ariel-os-rp/src/gpio.rs
+++ b/src/ariel-os-rp/src/gpio.rs
@@ -23,11 +23,11 @@ pub mod input {
     pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = true;
 
     #[doc(hidden)]
-    pub fn new<'a, P: InputPin>(
-        pin: Peri<'a, P>,
+    pub fn new<P: InputPin>(
+        pin: Peri<'_, P>,
         pull: ariel_os_embassy_common::gpio::Pull,
         schmitt_trigger: bool,
-    ) -> Result<Input<'a>, core::convert::Infallible> {
+    ) -> Result<Input<'_>, core::convert::Infallible> {
         let pull = from_pull(pull);
 
         let mut input = Input::new(pin, pull);
@@ -38,11 +38,11 @@ pub mod input {
 
     #[cfg(feature = "external-interrupts")]
     #[doc(hidden)]
-    pub fn new_int_enabled<'a, P: InputPin>(
-        pin: Peri<'a, P>,
+    pub fn new_int_enabled<P: InputPin>(
+        pin: Peri<'_, P>,
         pull: ariel_os_embassy_common::gpio::Pull,
         schmitt_trigger: bool,
-    ) -> Result<IntEnabledInput<'a>, InterruptError> {
+    ) -> Result<IntEnabledInput<'_>, InterruptError> {
         // This HAL does not require special treatment of external interrupts.
         match new(pin, pull, schmitt_trigger) {
             Ok(input) => Ok(input),
@@ -70,12 +70,12 @@ pub mod output {
     pub const SPEED_CONFIGURABLE: bool = true;
 
     #[doc(hidden)]
-    pub fn new<'a, P: OutputPin>(
-        pin: Peri<'a, P>,
+    pub fn new<P: OutputPin>(
+        pin: Peri<'_, P>,
         initial_level: ariel_os_embassy_common::gpio::Level,
         drive_strength: super::DriveStrength,
         speed: super::Speed,
-    ) -> Output<'a> {
+    ) -> Output<'_> {
         let initial_level = match initial_level {
             ariel_os_embassy_common::gpio::Level::Low => Level::Low,
             ariel_os_embassy_common::gpio::Level::High => Level::High,

--- a/src/ariel-os-rp/src/gpio.rs
+++ b/src/ariel-os-rp/src/gpio.rs
@@ -23,11 +23,11 @@ pub mod input {
     pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = true;
 
     #[doc(hidden)]
-    pub fn new<P: InputPin>(
-        pin: Peri<'static, P>,
+    pub fn new<'a, P: InputPin>(
+        pin: Peri<'a, P>,
         pull: ariel_os_embassy_common::gpio::Pull,
         schmitt_trigger: bool,
-    ) -> Result<Input<'static>, core::convert::Infallible> {
+    ) -> Result<Input<'a>, core::convert::Infallible> {
         let pull = from_pull(pull);
 
         let mut input = Input::new(pin, pull);
@@ -38,11 +38,11 @@ pub mod input {
 
     #[cfg(feature = "external-interrupts")]
     #[doc(hidden)]
-    pub fn new_int_enabled<P: InputPin>(
-        pin: Peri<'static, P>,
+    pub fn new_int_enabled<'a, P: InputPin>(
+        pin: Peri<'a, P>,
         pull: ariel_os_embassy_common::gpio::Pull,
         schmitt_trigger: bool,
-    ) -> Result<IntEnabledInput<'static>, InterruptError> {
+    ) -> Result<IntEnabledInput<'a>, InterruptError> {
         // This HAL does not require special treatment of external interrupts.
         match new(pin, pull, schmitt_trigger) {
             Ok(input) => Ok(input),
@@ -70,12 +70,12 @@ pub mod output {
     pub const SPEED_CONFIGURABLE: bool = true;
 
     #[doc(hidden)]
-    pub fn new<P: OutputPin>(
-        pin: Peri<'static, P>,
+    pub fn new<'a, P: OutputPin>(
+        pin: Peri<'a, P>,
         initial_level: ariel_os_embassy_common::gpio::Level,
         drive_strength: super::DriveStrength,
         speed: super::Speed,
-    ) -> Output<'static> {
+    ) -> Output<'a> {
         let initial_level = match initial_level {
             ariel_os_embassy_common::gpio::Level::Low => Level::Low,
             ariel_os_embassy_common::gpio::Level::High => Level::High,

--- a/src/ariel-os-stm32/src/gpio.rs
+++ b/src/ariel-os-stm32/src/gpio.rs
@@ -19,22 +19,22 @@ pub mod input {
     pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = false;
 
     #[doc(hidden)]
-    pub fn new<T: InputPin>(
-        pin: Peri<'static, T>,
+    pub fn new<'a, T: InputPin>(
+        pin: Peri<'a, T>,
         pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool, // Not supported by this hardware
-    ) -> Result<Input<'static>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<Input<'a>, ariel_os_embassy_common::gpio::input::Error> {
         let pull = from_pull(pull);
         Ok(Input::new(pin, pull))
     }
 
     #[cfg(feature = "external-interrupts")]
     #[doc(hidden)]
-    pub fn new_int_enabled<T: InputPin>(
-        pin: Peri<'static, T>,
+    pub fn new_int_enabled<'a, T: InputPin>(
+        pin: Peri<'a, T>,
         pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool, // Not supported by this hardware
-    ) -> Result<IntEnabledInput<'static>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<IntEnabledInput<'a>, ariel_os_embassy_common::gpio::input::Error> {
         let pull = from_pull(pull);
         let ch = crate::extint_registry::EXTINT_REGISTRY.get_interrupt_channel_for_pin(&pin)?;
         let pin: Peri<'_, AnyPin> = pin.into();
@@ -59,12 +59,12 @@ pub mod output {
     pub const SPEED_CONFIGURABLE: bool = true;
 
     #[doc(hidden)]
-    pub fn new(
-        pin: Peri<'static, impl OutputPin>,
+    pub fn new<'a>(
+        pin: Peri<'a, impl OutputPin>,
         initial_level: ariel_os_embassy_common::gpio::Level,
         _drive_strength: super::DriveStrength, // Not supported by hardware
         speed: super::Speed,
-    ) -> Output<'static> {
+    ) -> Output<'a> {
         let initial_level = match initial_level {
             ariel_os_embassy_common::gpio::Level::Low => Level::Low,
             ariel_os_embassy_common::gpio::Level::High => Level::High,

--- a/src/ariel-os-stm32/src/gpio.rs
+++ b/src/ariel-os-stm32/src/gpio.rs
@@ -19,22 +19,22 @@ pub mod input {
     pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = false;
 
     #[doc(hidden)]
-    pub fn new<'a, T: InputPin>(
-        pin: Peri<'a, T>,
+    pub fn new<T: InputPin>(
+        pin: Peri<'_, T>,
         pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool, // Not supported by this hardware
-    ) -> Result<Input<'a>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<Input<'_>, ariel_os_embassy_common::gpio::input::Error> {
         let pull = from_pull(pull);
         Ok(Input::new(pin, pull))
     }
 
     #[cfg(feature = "external-interrupts")]
     #[doc(hidden)]
-    pub fn new_int_enabled<'a, T: InputPin>(
-        pin: Peri<'a, T>,
+    pub fn new_int_enabled<T: InputPin>(
+        pin: Peri<'_, T>,
         pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool, // Not supported by this hardware
-    ) -> Result<IntEnabledInput<'a>, ariel_os_embassy_common::gpio::input::Error> {
+    ) -> Result<IntEnabledInput<'_>, ariel_os_embassy_common::gpio::input::Error> {
         let pull = from_pull(pull);
         let ch = crate::extint_registry::EXTINT_REGISTRY.get_interrupt_channel_for_pin(&pin)?;
         let pin: Peri<'_, AnyPin> = pin.into();
@@ -59,12 +59,12 @@ pub mod output {
     pub const SPEED_CONFIGURABLE: bool = true;
 
     #[doc(hidden)]
-    pub fn new<'a>(
-        pin: Peri<'a, impl OutputPin>,
+    pub fn new(
+        pin: Peri<'_, impl OutputPin>,
         initial_level: ariel_os_embassy_common::gpio::Level,
         _drive_strength: super::DriveStrength, // Not supported by hardware
         speed: super::Speed,
-    ) -> Output<'a> {
+    ) -> Output<'_> {
         let initial_level = match initial_level {
             ariel_os_embassy_common::gpio::Level::Low => Level::Low,
             ariel_os_embassy_common::gpio::Level::High => Level::High,


### PR DESCRIPTION
# Description

This adds lifetimes to GPIOS

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

Tested with:

```
laze -C examples/gpio-reuse/ build -b rpi-pico run
laze -C examples/gpio-reuse/ build -b nrf9160dk-nrf9160 run 
laze -C examples/gpio-reuse/ build -b stm32u083c-dk run
laze -C examples/gpio-reuse/ build -b seeedstudio-xiao-esp32c6 run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Fixes #2017 

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
`ariel_os::gpio::Input`, `ariel_os::gpio::IntEnabledInput` and `ariel_os::gpio::Output` now each have a generic lifetime parameter, allowing to re-use GPIOs. 
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
