### PR TITLE
feat(logging)!: revisit how logging and the debug channel interact

### DIFF
--- a/book/src/debug-console.md
+++ b/book/src/debug-console.md
@@ -1,15 +1,12 @@
 # Debug Console
 
 <!-- NOTE: "Currently" because it could be extended with other semihosting functionality to make it an actual console. -->
-The debug console is currently conceptually composed of the debug output and of the ability for the target to close it (when supported).
+The debug console is currently conceptually composed of the debug channel output and of the ability for the target to close it (when supported).
 The debug console is enabled by default and the corresponding [laze module][laze-modules-book] is `debug-console`.
 
 ## Printing on the Debug Console
 
-The [`ariel_os::log::println!()`][println-macro-rustdoc] macro is used to print on the debug console.
-
-When the debug console is enabled, panic messages are automatically printed to it.
-If this is unwanted, the `panic-printing` [laze module][laze-modules-book] can be disabled.
+When the `logging-over-debug-channel` [laze module][laze-modules-book] is enabled, [logs][logging-book] are printed on the debug channel output.
 
 ## Closing the Debug Console from Firmware
 
@@ -30,5 +27,5 @@ This is needed to later be able to attach a semihosting-enabled host tool to the
 > ```
 
 [laze-modules-book]: ./build-system.md#laze-modules
-[println-macro-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/log/macro.println.html
+[logging-book]: ./logging.md
 [debug-exit-fn-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/debug/fn.exit.html

--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -3,6 +3,11 @@
 Ariel OS supports logging on all platforms and it is enabled by default with the `logging` [laze module][laze-modules-book].
 Logging offers a set of macros that print on the debug console with helpful logging formatting.
 
+## Printing Panics
+
+Panics are automatically printed on the logging output.
+If this is unwanted, the `panic-printing` [laze module][laze-modules-book] can be disabled.
+
 ## Logging
 
 Within Rust code, import `ariel_os::log` items, then use Ariel OS logging macros:

--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Ariel OS supports logging on all platforms and it is enabled by default with the `logging-facade` [laze module][laze-modules-book].
+Ariel OS supports logging on all platforms and it is enabled by default with the `logging` [laze module][laze-modules-book].
 Logging offers a set of macros that print on the debug console with helpful logging formatting.
 
 ## Logging

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -22,6 +22,8 @@ contexts:
     selects:
       - executor-default
       - ?critical-section
+      # Optional as we want to be able to disable it in applications.
+      - ?logging
       - ?hw/device-identity
       - ?lto
 
@@ -361,9 +363,7 @@ contexts:
   - name: esp
     parent: ariel-os
     selects:
-      - ?debug-console
       - ?espflash
-      - ?esp-println
     provides:
       - has_hwrng
     env:
@@ -502,6 +502,7 @@ contexts:
     parent: ariel-os
     selects:
       - infini-core
+      - logging-over-stdout
       - ?debug-console
     provides:
       - has_device_identity
@@ -959,16 +960,6 @@ modules:
           - CC="${CC}"
           - CFLAGS="${CFLAGS}"
 
-  - name: debug-console
-    context: ariel-os
-    selects:
-      - ?logging-facade-default
-      - ?panic-printing
-    env:
-      global:
-        FEATURES:
-          - ariel-os/debug-console
-
   - name: emit-stack-sizes
     conflicts:
       - stable
@@ -1021,45 +1012,6 @@ modules:
         CARGO_TOOLCHAIN: +nightly-2026-04-28
         RUSTFLAGS:
           - --cfg nightly
-
-  # This module should be hard-selected when an application *requires* logging.
-  - name: logging-facade-default
-    selects:
-      - ?defmt
-      - ?log
-      - logging-facade
-
-  - name: defmt
-    help: Use the `defmt` crate as the logging facade
-    provides_unique:
-      - logging-facade
-    env:
-      global:
-        FEATURES:
-          - ariel-os/defmt
-        RUSTFLAGS:
-          - -Clink-arg=-Tdefmt.x
-        ESPFLASH_LOG_FORMAT: "--log-format defmt"
-        CARGO_ENV:
-          - DEFMT_LOG=info,${LOG}
-
-  - name: log
-    help: Use the `log` crate as the logging facade
-    provides_unique:
-      - logging-facade
-    env:
-      global:
-        FEATURES:
-          - ariel-os/log
-        CARGO_ENV:
-          - LOG_LEVEL=${LOG}
-
-  - name: panic-printing
-    context: ariel-os
-    env:
-      global:
-        FEATURES:
-          - ariel-os/panic-printing
 
   - name: lto
     context: ariel-os
@@ -1155,12 +1107,6 @@ modules:
     help: use probe-rs as runner
     selects:
       - ?debug-console
-      - ?semihosting
-      - defmt:
-          - defmt-rtt
-      - log:
-          - ?rtt-target
-          - ?debug-uart
     provides_unique:
       - embedded-test-runner
       - flashing-tool
@@ -1821,26 +1767,141 @@ modules:
         FEATURES:
           - ariel-os/infini-core
 
+  - name: debug-console
+    help: enable support for the debug console
+    context: ariel-os
+    selects:
+      # Mandatory.
+      - logging-over-debug-channel
+      # Optional for now, at least until multiple logging transports can be used
+      # at the same time: allows using semihosting while a logging transport
+      # other than `logging-over-debug-channel` is used.
+      - ?semihosting
+    env:
+      global:
+        FEATURES:
+          - ariel-os/debug-console
+
+  - name: logging
+    help: enables logging functionality
+    selects:
+      # Mandatory; the logging transport must be selected before the facade.
+      - logging-transport-default
+      # Mandatory.
+      - logging-facade-default
+      # Optional as we want to be able to disable it in applications.
+      - ?panic-printing
+
+  # Ordered by priority.
+  # Currently the logging transports are mutually exclusive.
+  - name: logging-transport-default
+    help: 'private: use `logging` instead'
+    selects:
+      - ?logging-over-stdout
+      - ?logging-over-debug-channel
+      - ?logging-over-usb
+      - ?logging-over-uart
+      - logging-transport
+
+  - name: logging-over-debug-channel
+    help: use the debug channel as logging transport
+    selects:
+      - probe-rs:
+          - ?debug-channel-rtt
+      # It would technically be possible to also support semihosting as debug
+      # channel transport, even though it is extremely slow.
+      - ?no-debug-channel-transport
+      - no-debug-channel-transport:
+          - debug-channel-transport-required
+    provides_unique:
+      - logging-transport
+
+  # Disabled by modules that provide a `debug-channel-transport`.
+  - name: no-debug-channel-transport
+    help: private
+
+  - name: debug-channel-rtt
+    help: use RTT as debug channel transport
+    selects:
+      # These conditional selects act as "late dependencies": the gated modules
+      # would be selected *later* in the resolution process if the gating
+      # modules get selected further down the line.
+      - defmt:
+          - defmt-rtt
+      - log:
+          - rtt-target
+    disables:
+      - no-debug-channel-transport
+    provides_unique:
+      # Debug channel transports are mutually exclusive.
+      - debug-channel-transport
+
+  # Enables `defmt-rtt` in `ariel-os-debug` and `ariel-os-log`.
   - name: defmt-rtt
-    help: use defmt-rtt in ariel-os-debug
+    help: private
     provides_unique:
       - ariel-os-debug-backend
+      - rtt-implementation
     env:
       global:
         FEATURES:
           - ariel-os/defmt-rtt
 
+  # Enables `rtt-target` in `ariel-os-debug`.
   - name: rtt-target
-    help: use rtt-target in ariel-os-debug
+    help: private
     provides_unique:
       - ariel-os-debug-backend
+      - rtt-implementation
     env:
       global:
         FEATURES:
           - ariel-os/rtt-target
 
+  - name: logging-over-stdout
+    help: use native's stdout as logging transport
+    context:
+      - native-chip
+    provides_unique:
+      - logging-transport
+
+  - name: logging-over-usb
+    help: use USB CDC-ACM as logging transport
+    # Temporarily restricted to ESP32s having a USB CDC-ACM/JTAG USB peripheral
+    # until introducing a `usb-cdc-acm-esp` module.
+    # Should be later extended to chips with a generic USB peripheral.
+    context:
+      - esp32s3
+      - esp32c3
+      - esp32c6
+    selects:
+      - context::esp:
+          - esp-println
+    provides_unique:
+      - logging-transport
+
+  - name: logging-over-uart
+    help: use UART as logging transport
+    # Temporarily restricted to ESP and boards that have ad hoc support.
+    context:
+      - esp
+      - nrf52840dk
+      - nrf52dk
+      - stm32u083c-dk
+    selects:
+      - context::esp:
+          - esp-println
+      - ?debug-uart
+    provides_unique:
+      - logging-transport
+
+  # Temporary module for boards that have ad hoc support.
   - name: debug-uart
-    help: use UART in ariel-os-debug
+    help: private
+    context:
+      - nrf52840dk
+      - nrf52dk
+      - stm32u083c-dk
     selects:
       - log # We could later support defmt as well
     provides_unique:
@@ -1850,8 +1911,49 @@ modules:
         FEATURES:
           - ariel-os/debug-uart
 
+  - name: logging-facade-default
+    help: 'private: use `logging` instead'
+    selects:
+      - ?defmt
+      - ?log
+      - logging-facade
+
+  - name: defmt
+    help: Use the `defmt` crate as the logging facade
+    provides_unique:
+      - logging-facade
+    env:
+      global:
+        FEATURES:
+          - ariel-os/defmt
+        RUSTFLAGS:
+          - -Clink-arg=-Tdefmt.x
+        ESPFLASH_LOG_FORMAT: "--log-format defmt"
+        CARGO_ENV:
+          - DEFMT_LOG=info,${LOG}
+
+  - name: log
+    help: Use the `log` crate as the logging facade
+    provides_unique:
+      - logging-facade
+    env:
+      global:
+        FEATURES:
+          - ariel-os/log
+        CARGO_ENV:
+          - LOG_LEVEL=${LOG}
+
+  - name: panic-printing
+    help: print panics, on the logging output
+    context: ariel-os
+    env:
+      global:
+        FEATURES:
+          - ariel-os/panic-printing
+
+  # Enables `esp-println` in `ariel-os-log`.
   - name: esp-println
-    help: use esp-println in ariel-os-debug
+    help: private
     context:
       - esp
     provides_unique:
@@ -1862,7 +1964,7 @@ modules:
           - ariel-os/esp-println
 
   - name: semihosting
-    help: enable semihosting in ariel-os-debug
+    help: enable semihosting functionality
     env:
       global:
         FEATURES:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1780,7 +1780,7 @@ modules:
     env:
       global:
         FEATURES:
-          - ariel-os/debug-console
+          - ariel-os/debug-channel
 
   - name: logging
     help: enables logging functionality

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -313,6 +313,8 @@ contexts:
   - name: rp
     help: Raspberry Pi Pico (2) MCU support (based on embassy-rp)
     parent: ariel-os
+    selects:
+      - ?probe-rs
     provides:
       - has_hwrng
       - has_swi
@@ -324,7 +326,6 @@ contexts:
       # This module must stay before `cortex-m0-plus` to keep correct linker settings order.
       - rp-link-arg
       - cortex-m0-plus
-      - ?probe-rs
     provides:
       - has_multi_core_support
       - has_storage_support
@@ -343,7 +344,6 @@ contexts:
     parent: rp
     selects:
       - cortex-m33f
-      - ?probe-rs
     provides:
       - has_multi_core_support
       - has_storage_support

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1840,7 +1840,6 @@ modules:
   - name: defmt-rtt
     help: private
     provides_unique:
-      - ariel-os-debug-backend
       - rtt-implementation
     env:
       global:
@@ -1851,7 +1850,6 @@ modules:
   - name: rtt-target
     help: private
     provides_unique:
-      - ariel-os-debug-backend
       - rtt-implementation
     env:
       global:
@@ -1904,8 +1902,6 @@ modules:
       - stm32u083c-dk
     selects:
       - log # We could later support defmt as well
-    provides_unique:
-      - ariel-os-debug-backend
     env:
       global:
         FEATURES:
@@ -1956,8 +1952,6 @@ modules:
     help: private
     context:
       - esp
-    provides_unique:
-      - ariel-os-debug-backend
     env:
       global:
         FEATURES:

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -7,11 +7,11 @@ repository.workspace = true
 license.workspace = true
 
 [package.metadata.feature-groups]
-debug-output.xor = { features = ["defmt-rtt", "rtt-target"] }
+debug-channel.xor = { features = ["defmt-rtt", "rtt-target"] }
 exit-implementation.xor = { features = ["semihosting", "std"] }
 
 [package.metadata.features]
-debug-console = { groups = ["debug-output"] }
+debug-channel = { groups = ["debug-channel"] }
 
 [dependencies]
 defmt-rtt = { workspace = true, optional = true }
@@ -25,7 +25,8 @@ semihosting = { workspace = true, optional = true, features = [
 ] }
 
 [features]
-debug-console = []
+# Enables the debug channel.
+debug-channel = []
 
 # Implementation backends for `exit()`.
 semihosting = ["dep:semihosting"]

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -11,7 +11,7 @@ mod exit;
 
 pub use exit::*;
 
-#[cfg(all(feature = "debug-console", feature = "defmt-rtt"))]
+#[cfg(feature = "defmt-rtt")]
 mod backend {
     use defmt_rtt as _;
 
@@ -19,7 +19,7 @@ mod backend {
     pub fn init() {}
 }
 
-#[cfg(all(feature = "debug-console", feature = "rtt-target"))]
+#[cfg(feature = "rtt-target")]
 mod backend {
     #[cfg(feature = "defmt")]
     pub use defmt::println as debug_output_println;
@@ -56,10 +56,7 @@ mod backend {
     }
 }
 
-#[cfg(not(all(
-    feature = "debug-console",
-    any(feature = "defmt-rtt", feature = "rtt-target"),
-)))]
+#[cfg(not(any(feature = "defmt-rtt", feature = "rtt-target")))]
 mod backend {
     #[doc(hidden)]
     pub fn init() {}

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -51,7 +51,7 @@ cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 alloc = ["dep:ariel-os-alloc"]
 threading = ["dep:ariel-os-threads"]
 
-debug-console = ["ariel-os-debug/debug-console"]
+debug-channel = ["ariel-os-debug/debug-channel"]
 embedded-test = ["dep:ariel-os-macros", "dep:embedded-test"]
 executor-interrupt = []
 panic-printing = []

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -157,7 +157,7 @@ pub static INIT_FUNCS: [fn()] = [..];
 fn startup() -> ! {
     arch::init();
 
-    #[cfg(feature = "debug-console")]
+    #[cfg(feature = "debug-channel")]
     ariel_os_debug::init();
 
     ariel_os_log::init();

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -196,9 +196,8 @@ timer-generic-queue-64 = ["ariel-os-embassy/timer-generic-queue-64"]
 timer-generic-queue-128 = ["ariel-os-embassy/timer-generic-queue-128"]
 
 #! ## Development and debugging
-# Enables the debug console, required to use
-# [`println!`](ariel_os_log::println).
-debug-console = ["ariel-os-rt/debug-console"]
+# Enables the debug channel.
+debug-channel = ["ariel-os-rt/debug-channel"]
 # Enables logging support through `defmt`, see [`log`].
 defmt = [
   "ariel-os-bench?/defmt",


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This revisits how logging and the debug channel interact, by both introducing new laze modules and changing the definitions of existing ones, to align with the definitions of #1987. In particular this decouples the debug console from the logging output.

For now, it's not expected that `logging-over-*` laze modules other than `logging-over-debug-output` be used *directly* by users (even though `logging-over-usb` is selected internally on ESP)~~, so making them only selectable when allowed by the hardware is out of scope of this PR, and is deferred to a follow-up~~.

## How to review this PR

This PR is better reviewed commit by commit. I can easily split it over existing commits if needed.

Most of the new laze configuration is likely better reviewed by both reading it and checking that it expresses what we want at a high-level, checking that the properties documented as comments are indeed implemented correctly (e.g., mutual exclusion of modules), and by playing with various combinations of the modules, including some that are expected to be rejected.

## Future work

Documenting the *new* laze modules will be done in #2036 and #1987, only the already-documented laze modules that are renamed in this PR should be documented in this PR.
The Debug Console and Logging documentation has been restructured in #2034.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

The following commands can be used for testing, the `info-modules` and `size` laze tasks and running in hardware are interesting to check (`hello-world` is used as an example as it uses logging and also `exit()`s):

```sh
laze -C examples/hello-world build -b stm32u083c-dk -v run
```

```sh
laze -C examples/hello-world build -d panic-printing -b stm32u083c-dk -v run
```

```sh
laze -C examples/hello-world build -d debug-console -b stm32u083c-dk -v run
```

(This will only make the firmware not `exit()`, logging will still be enabled.)

```sh
laze -C examples/hello-world build -d logging -b stm32u083c-dk -v run
```

(This will only make the firmware `exit()`, logging will not be enabled.)

```sh
laze -C examples/hello-world build -d debug-console -d logging -b stm32u083c-dk -v run
```

(This will make the firmware not `exit()` and logging will also not be enabled.)

```sh
laze -C examples/hello-world build -s logging-over-uart -b stm32u083c-dk run
```

The output can be obtained using `picocom /dev/ttyACM0 --baud 115200` for instance.

(The nrf52840dk can be used instead of the stm32u083c-dk.)

```sh
laze -C examples/hello-world build -b espressif-esp32-c6-devkitc-1 -v run
```

```sh
laze -C examples/hello-world build -d panic-printing -b espressif-esp32-c6-devkitc-1 -v run
```

```sh
laze -C examples/hello-world build -s probe-rs -d debug-console -b espressif-esp32-c6-devkitc-1 -v run
```

(Enabling `probe-rs` is necessary as `espflash`, which is used by default on `esp`, cannot offer a debug console as it doesn't support debug interface protocols.)

```sh
laze -C examples/hello-world build -b native -v run
```

```sh
laze -C examples/hello-world build -d logging -b native -v run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #2013
- Depends on #2052
- Closes #657

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
"Debug logging" has been renamed to "logging" and the definitions of logging and of the debug console have been revisited: `ariel_os::log` should be used instead of `ariel_os::debug::log`, and `ariel_os::log::println!()` instead of `ariel_os::debug::println!()`, which has been removed. In addition, the `logging` laze module should now be used instead of `logging-facade` (formerly `debug-logging-facade`) when enabling or disabling logging as a whole. Panics are now always printed to the logging output. ([#2008](https://github.com/ariel-os/ariel-os/pull/2008)) ([#2013](https://github.com/ariel-os/ariel-os/pull/2013))
<!-- changelog:end -->
The changelog entry of #2013 should likely be merged into this one when both have landed.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
