### PR TITLE
fix(docs): move ariel-os-esp source files in the rustdoc docs 

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -162,6 +162,15 @@ jobs:
           mkdir -p ./_site/dev/docs/api
           mv target/riscv32imac-unknown-none-elf/doc/ariel_os_esp/ ./_site/dev/docs/api
           mv target/doc/* ./_site/dev/docs/api
+          mv target/riscv32imac-unknown-none-elf/doc/src/ariel_os_esp ./_site/dev/docs/api/src
+          mv target/riscv32imac-unknown-none-elf/doc/static.files/* ./_site/dev/docs/api/static.files
+          # get the ariel-os-esp sidebar contents
+          # save the first line of the src-files.js in a variable
+          TEXT=`head -n 1 target/riscv32imac-unknown-none-elf/doc/src-files.js`
+          # use sed keep only the first element of the JSON string (i.e. "ariel_os_esp")
+          TEXT=`echo $TEXT | sed "s/createSrcSidebar('//" - | sed "s/');//" - | jq '.[0]' -cr`
+          # hack ariel-os-esp source files in the source files sidebar
+          sed -i "s/\[\"ariel_os\",\[\"\",\[\],\[\"lib.rs\",\"sensors.rs\"\]\]\]/[\"ariel_os\",[\"\",[],[\"lib.rs\",\"sensors.rs\"]]],$TEXT/g" ./_site/dev/docs/api/src-files.js
           # hack ariel-os-esp in the sidebar
           sed -i 's/"ariel_os","ariel_os_nrf"/"ariel_os","ariel_os_esp","ariel_os_nrf"/g' ./_site/dev/docs/api/crates.js
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This PR fixes some broken in our API docs caused by our dual target rustdoc workflow (`riscv32imac` for `ariel-os-esp`, `host` for the rest). This is done primarily by including the `ariel-os-esp` sources in the docs.

~~This PR is against #2028 to use the PR'ed CI changes that would otherwise not have the correct permissions.~~
This PR was changed to be against main and so that #2028 depends on this instead of the other way around.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References
This is a follow-up/refactor on #1894 
<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
