### PR TITLE
fix(ci): update time of files changed since last cache build

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -95,27 +95,36 @@ jobs:
         if: steps.clear-cache.outputs.result == 'true'
         run: echo "FALLBACK_KEY=none" >> "$GITHUB_ENV"
 
-      # Allows to reuse more cache
-      - name: Touch file time to commits time
-        if: steps.should-skip.outputs.result != 'true'
-        # https://stackoverflow.com/questions/21735435/git-clone-changes-file-modification-time
-        run: |
-          git ls-tree -r --name-only HEAD | while read filename; do
-            unixtime=$(git log -1 --format="%at" -- "${filename}")
-            touchtime=$(date -d @$unixtime +'%Y%m%d%H%M.%S')
-            touch -t ${touchtime} "${filename}"
-          done
-
       - name: Cache with post-job cleanup
         if: steps.should-skip.outputs.result != 'true'
         uses: gacts/run-and-post-run@81b6ce503cde93862cec047c54652e45c5dca991 # v1
         with:
           run: |
-            cache-thing pull -f build -f /home/runner/.cargo/git -f /home/runner/.cargo/registry --prefix global --fallback-key ${FALLBACK_KEY} || true
+            cache-thing pull -f /home/runner/metadata -f build -f /home/runner/.cargo/git -f /home/runner/.cargo/registry --prefix global --fallback-key ${FALLBACK_KEY} || true
 
           post: |
             export  RUST_LOG=trace
             cache-thing clean --prefix global || true
+
+      # Allows to reuse more cache
+      - name: Touch file time to commits time
+        if: steps.should-skip.outputs.result != 'true'
+        # https://stackoverflow.com/questions/21735435/git-clone-changes-file-modification-time
+        run: |
+          if [ -f /home/runner/metadata/cache-ref ]; then
+            git ls-tree -r --name-only HEAD | while read filename; do
+              unixtime=$(git log -1 --format="%at" -- "${filename}")
+              touchtime=$(date -d @$unixtime +'%Y%m%d%H%M.%S')
+              touch -t ${touchtime} "${filename}"
+            done
+
+            # Treat all files modified after the cached commit as "changed", by touching them.
+            git diff --name-only $(cat /home/runner/metadata/cache-ref) | while read filename; do
+              touch "${filename}"
+            done
+          else
+             echo "/home/runner/metadata/cache-ref not found, skipping step"
+          fi
 
       - id: get_toolchain
         if: steps.should-skip.outputs.result != 'true'
@@ -153,9 +162,12 @@ jobs:
       - name: show sccache stats
         run: sccache --show-stats
 
+      - name: update ref of nightly
+        run: git rev-parse HEAD > /home/runner/metadata/cache-ref
+
       - name: "Save cache of nightly run"
         if: steps.should-skip.outputs.result != 'true'
         env:
           RUST_LOG: trace
         run: |
-          cache-thing push -f build -f /home/runner/.cargo/git -f /home/runner/.cargo/registry --prefix global --fixed-key nightly --only-fixed-key || true
+          cache-thing push -f /home/runner/metadata -f build -f /home/runner/.cargo/git -f /home/runner/.cargo/registry --prefix global --fixed-key nightly --only-fixed-key || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
         with:
           run: |
             export  RUST_LOG=trace
-            cache-thing pull -f build -f /home/runner/.cargo/git -f /home/runner/.cargo/registry --prefix global --suffix "${{ matrix.partition }}" --fallback-key nightly || true
+            cache-thing pull -f /home/runner/metadata -f build -f /home/runner/.cargo/git -f /home/runner/.cargo/registry --prefix global --suffix "${{ matrix.partition }}" --fallback-key nightly || true
 
           post: |
             export  RUST_LOG=trace
@@ -337,11 +337,21 @@ jobs:
         if: steps.should-skip.outputs.result != 'true' && runner.environment == 'self-hosted'
         # https://stackoverflow.com/questions/21735435/git-clone-changes-file-modification-time
         run: |
+          if [ -f /home/runner/metadata/cache-ref ]; then
             git ls-tree -r --name-only HEAD | while read filename; do
               unixtime=$(git log -1 --format="%at" -- "${filename}")
               touchtime=$(date -d @$unixtime +'%Y%m%d%H%M.%S')
               touch -t ${touchtime} "${filename}"
             done
+
+            # Treat all files modified after the cached commit as "changed", by touching them.
+            git diff --name-only $(cat /home/runner/metadata/cache-ref) | while read filename; do
+              touch "${filename}"
+            done
+          else
+             echo "/home/runner/metadata/cache-ref not found, skipping step"
+          fi
+
       - name: "start sccache daemon"
         if: steps.should-skip.outputs.result != 'true' && runner.environment == 'self-hosted'
         # work around https://github.com/ninja-build/ninja/issues/2052


### PR DESCRIPTION
# Description

Some of the files going through the CI may have a commit date earlier than the date the cache was built, this made cargo skip building more files than was intended, keeping outdated information.

This PR changes the file time attribution to force all files that are different from the cached commit to be considered as new (using file modification time).

## Testing

This will be a bit tricky to test. The cache needs to be built with the new `/home/runner/metadata` directory (containing an easily accessible git ref to compare to). 

Then create commits that are older than the cache build time modifying some core libraries (e.g. `ariel-os-embassy`) and a commit newer than the cache build time that modifies an example to use the modified core library. 

No build error should occur.

Failing CI reproducing the bug: https://github.com/ariel-os/ariel-os/actions/runs/24767820546/job/72466372510?pr=2035
After manually adding the commit hash in `/home/runner/metadata/cache-ref` done in commit 9e6200dbf1052e206fadbfaf093e0f28ac520d77, the build succeeds: https://github.com/ariel-os/ariel-os/actions/runs/24768016545/job/72466943707?pr=2035

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Fixed an issue where the CI was using cached files instead of the files in the PR. 
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
