### PR TITLE
docs(book): document logging transports

### DIFF
--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -76,7 +76,50 @@ Note: On Cortex-M devices, the order of `ariel_os::log::println!()` output and
 
 Ariel OS's logger for `log` supports configuring the log level globally, but does not currently support per-crate filtering.
 
+## Logging Transports
+
+Logging can use various transports, but currently only one can be used at a time.
+The table below presents those supported in Ariel OS and which hardware and host tool are required:
+
+| Logging transport                        | Supported               | laze module                  | Required hardware                                                                         | Required host tool              |
+| ---------------------------------------- | :---------------------: | ---------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------- |
+| Debug channel                            | Available on all chips  | `logging-over-debug-channel` | Debug probe attached to the debug interface                                               | Debug channel-enabled host tool |
+| [USB CDC-ACM][usb-cdc-acm-glossary-book] | On ESP32 MCUs only      | `logging-over-usb`           | USB cable attached to the user USB port                                                   | Serial monitor                  |
+| [UART][uart-glossary-book]               | On ESP32 MCUs only      | `logging-over-uart`          | USB ⟷ UART adapter attached to the supported UART pins (may already be part of the board) | Serial monitor                  |
+
+> [!IMPORTANT]
+> When using [`defmt` as logging facade](#defmt), a `defmt`-enabled host tool must be used so that logs are rendered correctly, as `defmt` uses its own encoding on the wire.
+> probe-rs and `espflash` both support `defmt`'s encoding transparently.
+>
+> When a separate serial monitor is needed, [`defmt-print`][defmt-print-cratesio] can be used as `defmt`-enabled serial monitor.
+> If this is not possible, `defmt` should be disabled and [`log`](#log) used instead as logging facade.
+
+<!-- TODO: link to "debug interface" when the page exists -->
+> [!TIP]
+> When a logging transport other than the debug channel is enabled, logging can still be used when the debug channel is disabled either in software (by disabling the `logging-over-debug-channel` laze module) or in hardware when the debug interface itself is disabled.
+> This means that logging can still be used in production, even if the debug interface has been disabled.
+>
+> If this is unwanted, logging can be disabled altogether by disabling the [`logging`](#logging) laze module.
+
+> [!NOTE]
+> Future plans for logging facilities:
+>
+> - Other logging transports will later be supported, including UART and USB CDC-ACM on non-ESP32 devices.
+> - Using multiple transports at the same time may be supported in the future.
+
+On ESP32 devices, Ariel OS uses [`espflash`][espflah-cratesio] by default to obtain and print logs.
+Currently, the firmware automatically switches at runtime between using USB CDC-ACM or UART as logging transport.
+
+> [!WARNING]
+> This is likely to change in the future, and it may become necessary to select a specific laze module to choose which logging transport to enable and use.
+
 [defmt]: https://github.com/knurling-rs/defmt
 [defmt documentation]: https://defmt.ferrous-systems.com/
 [log]: https://github.com/rust-lang/log
 [laze-modules-book]: ./build-system.md#laze-modules
+[usb-cdc-acm-glossary-book]: ./glossary.md#usb-cdc-acm
+[uart-glossary-book]: ./glossary.md#uart
+[log-mod-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/log/index.html
+[defmt-print-cratesio]: https://crates.io/crates/defmt-print
+[debug-console-debug-console-book]: ./debug-console.md#debug-console
+[espflah-cratesio]: https://crates.io/crates/espflash


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Following #2030, this documents the logging transports in the Logging page introduced by #2034. This new section is extracted from #1987. I think moving this section to the Logging page simply makes more sense, and helps emphasize the orthogonality to the debug console.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #2030

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
New laze modules have been introduced to select the transport used by logging: `logging-over-debug-channel`, `logging-over-usb`, and `logging-over-uart`. Not every transport is available on every MCU and board. Documentation about logging transports has been added to the book.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
