### PR TITLE
fix(embassy): allow back not using a built-in board

### DIFF
--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -195,6 +195,9 @@ executor-interrupt = ["ariel-os-hal/executor-interrupt"]
 executor-thread = ["ariel-os-embassy-common/executor-thread", "threading"]
 executor-none = []
 
+# Allows to have no built-in board selected.
+no-boards = []
+
 defmt = [
   "ariel-os-embassy-common/defmt",
   "ariel-os-hal/defmt",

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -201,7 +201,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     debug!("ariel-os-embassy::init_task()");
 
     // gated so doc builds pass
-    #[cfg(context = "ariel-os")]
+    #[cfg(all(not(feature = "no-boards"), context = "ariel-os"))]
     ariel_os_boards::init(&mut peripherals);
 
     #[cfg(all(context = "stm32", feature = "external-interrupts"))]

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -215,7 +215,11 @@ bench = ["dep:ariel-os-bench"]
 # Prints panic messages on the debug console.
 panic-printing = ["ariel-os-rt/panic-printing"]
 ## Allows to have no boards selected, useful to run target-independent tooling.
-no-boards = ["ariel-os-boards/no-boards", "executor-none"]
+no-boards = [
+  "ariel-os-boards/no-boards",
+  "ariel-os-embassy/no-boards",
+  "executor-none",
+]
 
 # These are selected by laze
 debug-uart = ["ariel-os-embassy/debug-uart", "ariel-os-log/uart"]


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Follow-up to #1951, which as a side-effect made it mandatory to have one of the built-in boards enabled, as the `ariel_os_boards::init()` function is now unconditionally expected. This uses the existing `no-boards` Cargo feature to feature-gate that function call.

Alternatively, it would be possible to have a dummy, fallback board in `ariel-os-boards` but I don't know if that's the behavior we want for `ariel-os-boards`, and I think that would require modifying `sbd-gen` for that.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Tested in an out-of-tree application that does not use a built-in board.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
No need for an entry as #1951 will be part of the same release as this.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
