### PR TITLE
refactor(logging-esp)!: enable each `esp-println` output individually

### DIFF
--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -87,7 +87,8 @@ The table below presents those supported in Ariel OS and which hardware and hos
 | [USB CDC-ACM][usb-cdc-acm-glossary-book] | On ESP32 MCUs only      | `logging-over-usb`           | USB cable attached to the user USB port                                                   | Serial monitor                  |
 | [UART][uart-glossary-book]               | On ESP32 MCUs only      | `logging-over-uart`          | USB ⟷ UART adapter attached to the supported UART pins (may already be part of the board) | Serial monitor                  |
 
-On ESP32 devices, Ariel OS uses [`espflash`][espflah-cratesio] by default to obtain and print logs.
+On ESP32 devices, Ariel OS uses [`espflash`][espflah-cratesio] by default to obtain and print logs, whose usage is determined by the `espflash` [laze module][laze-modules-book].
+When `espflash` is selected at the time of compilation, `logging-over-debug-channel` is not enabled and one of the other available logging transports is used instead.
 
 > [!IMPORTANT]
 > When using [`defmt` as logging facade](#defmt), a `defmt`-enabled host tool must be used so that logs are rendered correctly, as `defmt` uses its own encoding on the wire.

--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -87,6 +87,8 @@ The table below presents those supported in Ariel OS and which hardware and hos
 | [USB CDC-ACM][usb-cdc-acm-glossary-book] | On ESP32 MCUs only      | `logging-over-usb`           | USB cable attached to the user USB port                                                   | Serial monitor                  |
 | [UART][uart-glossary-book]               | On ESP32 MCUs only      | `logging-over-uart`          | USB ⟷ UART adapter attached to the supported UART pins (may already be part of the board) | Serial monitor                  |
 
+On ESP32 devices, Ariel OS uses [`espflash`][espflah-cratesio] by default to obtain and print logs.
+
 > [!IMPORTANT]
 > When using [`defmt` as logging facade](#defmt), a `defmt`-enabled host tool must be used so that logs are rendered correctly, as `defmt` uses its own encoding on the wire.
 > probe-rs and `espflash` both support `defmt`'s encoding transparently.
@@ -106,12 +108,6 @@ The table below presents those supported in Ariel OS and which hardware and hos
 >
 > - Other logging transports will later be supported, including UART and USB CDC-ACM on non-ESP32 devices.
 > - Using multiple transports at the same time may be supported in the future.
-
-On ESP32 devices, Ariel OS uses [`espflash`][espflah-cratesio] by default to obtain and print logs.
-Currently, the firmware automatically switches at runtime between using USB CDC-ACM or UART as logging transport.
-
-> [!WARNING]
-> This is likely to change in the future, and it may become necessary to select a specific laze module to choose which logging transport to enable and use.
 
 [defmt]: https://github.com/knurling-rs/defmt
 [defmt documentation]: https://defmt.ferrous-systems.com/

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1877,6 +1877,10 @@ modules:
           - esp-println
     provides_unique:
       - logging-transport
+    env:
+      global:
+        FEATURES:
+          - ariel-os/logging-over-usb
 
   - name: logging-over-uart
     help: use UART as logging transport
@@ -1892,6 +1896,10 @@ modules:
       - ?debug-uart
     provides_unique:
       - logging-transport
+    env:
+      global:
+        FEATURES:
+          - ariel-os/logging-over-uart
 
   # Temporary module for boards that have ad hoc support.
   - name: debug-uart

--- a/src/ariel-os-log/Cargo.toml
+++ b/src/ariel-os-log/Cargo.toml
@@ -8,7 +8,11 @@ license.workspace = true
 
 [package.metadata.feature-groups]
 logging-facade.xor = { features = ["defmt", "log"] }
-logging-transport.xor = { features = ["defmt-rtt", "esp-println", "uart"] }
+logging-transport.xor = { features = [
+  "defmt-rtt",
+  "logging-over-uart",
+  "logging-over-usb",
+] }
 
 [dependencies]
 ariel-os-debug = { workspace = true }
@@ -22,7 +26,6 @@ log = { workspace = true, optional = true }
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-println = { workspace = true, optional = true, features = [
-  "auto",
   "colors",
   "critical-section",
 ] }
@@ -48,13 +51,17 @@ defmt = ["dep:defmt", "esp-println?/defmt-espflash"]
 ## Enables `log` as logging facade.
 log = ["dep:ariel-os-utils", "dep:const-str", "dep:critical-section", "dep:log"]
 
+# Enables the `esp-println` crate.
+esp-println = ["dep:esp-println"]
+
 # Logging transports.
+debug-uart = ["dep:embassy-sync", "logging-over-uart"]
 # `defmt-rtt` forces the logging transport to be the debug output, so it has to
 # go through this crate.
 defmt-rtt = ["ariel-os-debug/defmt-rtt"]
-esp-println = ["dep:esp-println"]
+logging-over-uart = ["esp-println?/uart"]
+logging-over-usb = ["esp-println?/jtag-serial"]
 std = []
-uart = ["dep:embassy-sync"]
 
 _test = []
 

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -95,7 +95,11 @@ pub mod log {
 
     #[cfg(all(
         context = "ariel-os",
-        not(any(feature = "esp-println", feature = "std", feature = "uart"))
+        not(any(
+            feature = "esp-println",
+            feature = "logging-over-uart",
+            feature = "std"
+        ))
     ))]
     pub use ariel_os_debug::debug_output_println as println;
 
@@ -105,7 +109,7 @@ pub mod log {
     #[cfg(feature = "std")]
     pub use std::println;
 
-    #[cfg(feature = "uart")]
+    #[cfg(feature = "debug-uart")]
     pub use crate::uart_println as println;
 
     /// Prints to the logging output, with a newline.
@@ -349,7 +353,7 @@ impl<T: AsRef<[u8]>> defmt::Format for Cbor<T> {
     }
 }
 
-#[cfg(feature = "uart")]
+#[cfg(feature = "debug-uart")]
 #[doc(hidden)]
 pub mod backend {
     use embassy_sync::once_lock::OnceLock;

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -221,7 +221,9 @@ no-boards = [
 ]
 
 # These are selected by laze
-debug-uart = ["ariel-os-embassy/debug-uart", "ariel-os-log/uart"]
+debug-uart = ["ariel-os-embassy/debug-uart", "ariel-os-log/debug-uart"]
+logging-over-uart = ["ariel-os-log/logging-over-uart"]
+logging-over-usb = ["ariel-os-log/logging-over-usb"]
 rtt-target = ["ariel-os-debug/rtt-target"]
 defmt-rtt = ["ariel-os-log/defmt-rtt"]
 esp-println = ["ariel-os-log/esp-println"]


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This leverages the `logging-over-usb` and `logging-over-uart` laze modules introduced by #2030 to only enable the required output of `esp-println` to avoid monopolizing both the JTAG+USB CDC-ACM USB peripheral and UART peripheral all the time and (slightly) reduce the size of the binary. This also arguably makes it less surprising both during development and production, as at least one of the outputs could unknowingly stay enabled.

## Future work

- `esp-println` should later be replaced with custom implementations using the drivers available in `esp-hal`. This will (a) fix potential issues as `esp-println` just steals peripherals and (b) remove the dependency on `esp-println` which [is expected to be eventually archived](https://redirect.github.com/esp-rs/esp-hal/issues/4666#issuecomment-4353684721).
- Leveraging #1833, we could add a note to the relevant board pages to explain how to use the available USB port(s) (especially for boards with two of them, like the Espressif devkits).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
The `log` example can be tested on ESP32 devkits with two USB ports: one labeled "USB" and the other labeled "UART". Using the "USB"-labeled port doesn't require any change, as `logging-over-usb` is selected by default when `espflash` is used (which is the default), but using the "UART"-labeled port now requires selecting `logging-over-uart` explicitly.

Undocumented support for logging-over-UART still works on other boards (e.g., nRF52840-DK, STM32U083C-DK)

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #2030
- Depends on #2036

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(ESP32) As the runtime auto-selection of the logging transport has been disabled on these MCUs, it must now be selected at build time using either `logging-over-usb` or `logging-over-uart` (`logging-over-usb` is the default when available).
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
