### PR TITLE
feat: network toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,7 @@ dependencies = [
  "defmt 1.0.1",
  "embassy-embedded-hal",
  "embassy-executor",
+ "embassy-futures",
  "embassy-sync 0.7.2",
  "embassy-time",
  "embassy-time-driver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "const-sha1",
  "defmt 1.0.1",
  "embassy-executor",
+ "embassy-net",
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",

--- a/examples/tcp-client/src/main.rs
+++ b/examples/tcp-client/src/main.rs
@@ -17,16 +17,20 @@ use ariel_os::{
 
 #[ariel_os::task(autostart)]
 async fn tcp_echo() {
-    let stack = net::network_stack().await.unwrap();
+    let interface = net::network_interface().await.unwrap();
+
+    let stack = interface.network_stack();
 
     // Increase the buffer size if you want to send bigger packets.
     let mut rx_buffer = [0; 256];
     let mut tx_buffer = [0; 256];
 
     info!("waiting for interface to come up...");
-    stack.wait_config_up().await;
 
     loop {
+        interface.enable();
+        stack.wait_link_up().await;
+        stack.wait_config_up().await;
         let mut socket = embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
         socket.set_timeout(Some(Duration::from_secs(10)));
 
@@ -51,7 +55,7 @@ async fn tcp_echo() {
             info!("txd: {}", core::str::from_utf8(msg).unwrap());
             Timer::after_secs(1).await;
         }
-
-        Timer::after_secs(4).await;
+        interface.disable();
+        Timer::after_secs(10).await;
     }
 }

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -12,6 +12,7 @@ ariel-os-utils = { workspace = true }
 const-sha1 = { version = "0.3.0", default-features = false }
 defmt = { workspace = true, optional = true }
 embassy-executor = { workspace = true }
+embassy-net = { workspace = true, optional = true }
 embassy-time = { workspace = true, optional = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }
@@ -41,6 +42,8 @@ _test = ["external-interrupts", "i2c", "spi", "uart"]
 ble = ["dep:static_cell", "dep:trouble-host"]
 
 cellular-networking = []
+
+net = ["dep:embassy-net"]
 
 [lints]
 workspace = true

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -22,6 +22,9 @@ pub mod ble;
 #[cfg(feature = "cellular-networking")]
 pub mod cellular_networking;
 
+#[cfg(feature = "net")]
+pub mod net;
+
 pub mod identity;
 
 #[cfg(feature = "spi")]

--- a/src/ariel-os-embassy-common/src/net.rs
+++ b/src/ariel-os-embassy-common/src/net.rs
@@ -1,0 +1,41 @@
+//! Common types for networking in Ariel OS.
+
+use embassy_net::Stack;
+
+/// Allows to control the state of a network interface.
+/// The network interface should be enabled by default at startup.
+pub trait InterfaceController: Copy {
+    /// Enable a previously disabled network interface.
+    fn enable(&self);
+    /// Disable this network interface.
+    /// Whether the interface is fully powered down or not depends on the implementation.
+    fn disable(&self);
+}
+
+/// A network interface.
+#[derive(Clone, Copy)]
+pub struct NetworkInterface<'a, C: InterfaceController> {
+    stack: Stack<'a>,
+    controller: C,
+}
+impl<'a, C: InterfaceController> NetworkInterface<'a, C> {
+    /// Create a new interface from the stack and interface struct.
+    pub fn new(stack: Stack<'a>, controller: C) -> Self {
+        Self { stack, controller }
+    }
+
+    /// Get the [`embassy_net::Stack`] for this interface.
+    pub fn network_stack(&self) -> Stack<'a> {
+        self.stack
+    }
+
+    /// Enable a previously disabled [`NetworkInterface`].
+    pub fn enable(&self) {
+        self.controller.enable();
+    }
+    /// Disable a previously disabled [`NetworkInterface`].
+    /// Whether the interface is fully powered down or not depends on the implementation.
+    pub fn disable(&self) {
+        self.controller.disable();
+    }
+}

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -92,7 +92,7 @@ usb = ["dep:embassy-usb", "ariel-os-hal/usb"]
 usb-hid = ["dep:usbd-hid", "embassy-usb?/usbd-hid", "usb"]
 
 # `embassy-net` requires a time driver, which HALs provide.
-net = ["dep:embassy-net", "ariel-os-hal/time"]
+net = ["dep:embassy-net", "ariel-os-embassy-common/net", "ariel-os-hal/time"]
 # NOTE: `time` is only needed on STM32 for the workaround.
 usb-ethernet = ["net", "time", "usb"]
 ## Selects the network backend that goes through tun/tap (native only)

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -427,7 +427,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
 
     #[cfg(feature = "wifi-cyw43")]
     {
-        hal::cyw43::join(control).await;
+        spawner.spawn(hal::cyw43::connection(control)).unwrap();
     };
 
     // mark used

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -392,7 +392,13 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
 
         if crate::net::STACK
             .init(embassy_sync::blocking_mutex::Mutex::new(
-                SameExecutorCell::new(stack, spawner),
+                SameExecutorCell::new(
+                    ariel_os_embassy_common::net::NetworkInterface::new(
+                        stack,
+                        net::InterfaceControllerType::new(),
+                    ),
+                    spawner,
+                ),
             ))
             .is_err()
         {

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -30,6 +30,12 @@ pub(crate) const ETHERNET_MTU: usize = 1514;
 pub type NetworkStack = Stack<'static>;
 
 // Will need a refactor if we want to use multiple network interfaces (probably with linkme).
+#[cfg(feature = "ltem-nrf-modem")]
+pub(crate) type InterfaceControllerType = ariel_os_hal::hal::ltem::LtemInterfaceController;
+
+#[cfg(not(any(
+    feature = "ltem-nrf-modem",
+)))]
 pub(crate) type InterfaceControllerType = DummyController;
 
 pub(crate) static STACK: OnceLock<

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -32,10 +32,11 @@ pub type NetworkStack = Stack<'static>;
 // Will need a refactor if we want to use multiple network interfaces (probably with linkme).
 #[cfg(feature = "ltem-nrf-modem")]
 pub(crate) type InterfaceControllerType = ariel_os_hal::hal::ltem::LtemInterfaceController;
+#[cfg(feature = "wifi-esp")]
+pub(crate) type InterfaceControllerType =
+    ariel_os_hal::hal::wifi::esp_wifi::EspWifiInterfaceController;
 
-#[cfg(not(any(
-    feature = "ltem-nrf-modem",
-)))]
+#[cfg(not(any(feature = "ltem-nrf-modem", feature = "wifi-esp",)))]
 pub(crate) type InterfaceControllerType = DummyController;
 
 pub(crate) static STACK: OnceLock<
@@ -46,6 +47,7 @@ pub(crate) static STACK: OnceLock<
 pub(crate) struct DummyController {}
 
 impl DummyController {
+    #[allow(unused)]
     pub fn new() -> Self {
         Self {}
     }

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -11,6 +11,7 @@
     reason = "should be addressed eventually"
 )]
 
+use ariel_os_log::warn;
 use embassy_net::{Runner, Stack};
 use embassy_sync::{
     blocking_mutex::{Mutex, raw::CriticalSectionRawMutex},
@@ -35,8 +36,14 @@ pub(crate) type InterfaceControllerType = ariel_os_hal::hal::ltem::LtemInterface
 #[cfg(feature = "wifi-esp")]
 pub(crate) type InterfaceControllerType =
     ariel_os_hal::hal::wifi::esp_wifi::EspWifiInterfaceController;
+#[cfg(feature = "wifi-cyw43")]
+pub(crate) type InterfaceControllerType = ariel_os_hal::hal::cyw43::Cyw43WifiInterfaceController;
 
-#[cfg(not(any(feature = "ltem-nrf-modem", feature = "wifi-esp",)))]
+#[cfg(not(any(
+    feature = "ltem-nrf-modem",
+    feature = "wifi-esp",
+    feature = "wifi-cyw43"
+)))]
 pub(crate) type InterfaceControllerType = DummyController;
 
 pub(crate) static STACK: OnceLock<
@@ -53,7 +60,9 @@ impl DummyController {
     }
 }
 impl InterfaceController for DummyController {
-    fn disable(&self) {}
+    fn disable(&self) {
+        warn!("Disabling this network interface is not supported.");
+    }
     fn enable(&self) {}
 }
 /// Returns a new [`NetworkStack`].

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -17,6 +17,8 @@ use embassy_sync::{
     once_lock::OnceLock,
 };
 
+use ariel_os_embassy_common::net::{InterfaceController, NetworkInterface};
+
 use crate::{NetworkDevice, cell::SameExecutorCell};
 
 #[allow(dead_code)]
@@ -27,13 +29,41 @@ pub(crate) const ETHERNET_MTU: usize = 1514;
 /// Required to create a UDP or TCP socket.
 pub type NetworkStack = Stack<'static>;
 
-pub(crate) static STACK: OnceLock<Mutex<CriticalSectionRawMutex, SameExecutorCell<NetworkStack>>> =
-    OnceLock::new();
+// Will need a refactor if we want to use multiple network interfaces (probably with linkme).
+pub(crate) type InterfaceControllerType = DummyController;
 
+pub(crate) static STACK: OnceLock<
+    Mutex<CriticalSectionRawMutex, SameExecutorCell<NetworkInterface<'_, InterfaceControllerType>>>,
+> = OnceLock::new();
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct DummyController {}
+
+impl DummyController {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+impl InterfaceController for DummyController {
+    fn disable(&self) {}
+    fn enable(&self) {}
+}
 /// Returns a new [`NetworkStack`].
 ///
 /// Returns [`None`] if networking is not yet initialized.
 pub async fn network_stack() -> Option<NetworkStack> {
+    // SAFETY: TODO(`for_current_executore()` unsoundness)
+    let spawner = unsafe { crate::asynch::Spawner::for_current_executor().await };
+    STACK
+        .get()
+        .await
+        .lock(|inner| inner.get(spawner).map(NetworkInterface::network_stack))
+}
+
+/// Returns a new [`NetworkInterface`].
+///
+/// Returns [`None`] if networking is not yet initialized.
+pub async fn network_interface<'a>() -> Option<NetworkInterface<'a, impl InterfaceController>> {
     // SAFETY: TODO(`for_current_executore()` unsoundness)
     let spawner = unsafe { crate::asynch::Spawner::for_current_executor().await };
     STACK.get().await.lock(|inner| inner.get(spawner).copied())

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -33,6 +33,7 @@ esp-hal = { workspace = true, default-features = false, features = [
   "rt",
 ] }
 
+embassy-futures = { workspace = true, optional = true }
 esp-radio = { workspace = true, default-features = false, features = [
   "esp-alloc",
   "unstable",
@@ -158,6 +159,8 @@ wifi = []
 
 ## Enables built-in Wi-Fi hardware.
 wifi-esp = [
+  "dep:embassy-futures",
+  "dep:embassy-sync",
   # `embassy-time` is used for Wi-Fi-specific functionality.
   "dep:embassy-time",
   "_radio-esp",

--- a/src/ariel-os-esp/src/wifi/esp_wifi.rs
+++ b/src/ariel-os-esp/src/wifi/esp_wifi.rs
@@ -1,5 +1,7 @@
-use ariel_os_log::{debug, info};
+use ariel_os_log::{debug, info, warn};
 use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, watch::Watch};
 use embassy_time::{Duration, Timer};
 use esp_radio::wifi::{
     Config, ModeConfig, WifiController, WifiDevice, WifiEvent, WifiStationState, sta::StationConfig,
@@ -7,9 +9,39 @@ use esp_radio::wifi::{
 
 pub type NetworkDevice = WifiDevice<'static>;
 
+// State of the wifi interface so it can be controlled from another task.
+static WIFI_CONTROL_WANTED_STATE: Watch<CriticalSectionRawMutex, State, 1> = Watch::new();
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum State {
+    Enabled,
+    Disabled,
+}
+
+/// Interface controller for the esp wifi.
+#[derive(Debug, Clone, Copy)]
+pub struct EspWifiInterfaceController {}
+impl EspWifiInterfaceController {
+    /// Create a new interface controller.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ariel_os_embassy_common::net::InterfaceController for EspWifiInterfaceController {
+    fn disable(&self) {
+        WIFI_CONTROL_WANTED_STATE.sender().send(State::Disabled);
+    }
+    fn enable(&self) {
+        WIFI_CONTROL_WANTED_STATE.sender().send(State::Enabled);
+    }
+}
+
 pub fn init(peripherals: &mut crate::OptionalPeripherals, spawner: Spawner) -> NetworkDevice {
     let config = Config::default();
     let wifi = peripherals.WIFI.take().unwrap();
+
+    WIFI_CONTROL_WANTED_STATE.sender().send(State::Enabled);
 
     let (controller, interfaces) = esp_radio::wifi::new(wifi, config).unwrap();
 
@@ -20,18 +52,39 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals, spawner: Spawner) -> N
 
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
+    let mut control_receiver = WIFI_CONTROL_WANTED_STATE.receiver().unwrap();
+
     debug!("start connection task");
 
     #[cfg(not(feature = "defmt"))]
     debug!("Device capabilities: {:?}", controller.capabilities());
 
     loop {
+        if control_receiver.get().await == State::Disabled {
+            // Turn off the wifi modem.
+            if let Err(err) = controller.stop_async().await {
+                warn!("Error when stopping wifi: {}", err);
+            }
+
+            control_receiver.changed().await;
+            continue;
+        }
+
         match esp_radio::wifi::station_state() {
             WifiStationState::Connected => {
-                // wait until we're no longer connected
-                controller
-                    .wait_for_event(WifiEvent::StationDisconnected)
-                    .await;
+                // wait until we're no longer connected or we receive a command to stop.
+                match select(
+                    controller.wait_for_event(WifiEvent::StationDisconnected),
+                    control_receiver.changed(),
+                )
+                .await
+                {
+                    Either::First(_) => {}
+                    // We want to change the state, this is handled at the start of the loop.
+                    Either::Second(_) => {
+                        continue;
+                    }
+                }
                 Timer::after(Duration::from_secs(5)).await
             }
             _ => {}

--- a/src/ariel-os-nrf/src/ltem.rs
+++ b/src/ariel-os-nrf/src/ltem.rs
@@ -28,19 +28,23 @@ enum Command {
     Disable,
 }
 
-/// Disable the LTE-M link.
-///
-/// Will be replaced by the new network interface toggle API.
-#[doc(hidden)]
-pub fn disable() {
-    CONTROL_SIGNAL.signal(Command::Disable);
+#[derive(Debug, Clone, Copy)]
+pub struct LtemInterfaceController {}
+impl LtemInterfaceController {
+    #[allow(clippy::new_without_default)]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
 }
-/// Enable the LTE-M link.
-///
-/// Will be replaced by the new network interface toggle API.
-#[doc(hidden)]
-pub fn enable() {
-    CONTROL_SIGNAL.signal(Command::Enable);
+
+impl ariel_os_embassy_common::net::InterfaceController for LtemInterfaceController {
+    fn disable(&self) {
+        CONTROL_SIGNAL.signal(Command::Disable);
+    }
+    fn enable(&self) {
+        CONTROL_SIGNAL.signal(Command::Enable);
+    }
 }
 
 #[embassy_executor::task]

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -31,9 +31,10 @@ cyw43 = { version = "0.5.0", features = ["firmware-logs"], optional = true }
 cyw43-firmware = { version = "0.1.0", optional = true }
 cyw43-pio = { version = "0.8.0", optional = true }
 
+embassy-sync = { workspace = true, optional = true }
+
 # BLE dependencies
 bt-hci = { workspace = true, optional = true }
-embassy-sync = { workspace = true, optional = true }
 trouble-host = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
@@ -99,7 +100,7 @@ ble-central = ["ble-cyw43"]
 defmt = ["dep:defmt", "cyw43?/defmt", "embassy-rp/defmt"]
 
 ## Enables Wi-Fi support.
-wifi = []
+wifi = ["dep:embassy-sync"]
 
 ## Enables support for the CYW43 Wi-Fi chip.
 wifi-cyw43 = ["_cyw43", "cyw43-firmware?/wifi", "wifi"]

--- a/src/ariel-os-rp/src/cyw43.rs
+++ b/src/ariel-os-rp/src/cyw43.rs
@@ -24,14 +24,34 @@ use cyw43::JoinOptions;
 #[cfg(feature = "ble-cyw43")]
 use crate::ble::{self, SLOTS};
 
+#[cfg(feature = "wifi")]
+pub use crate::wifi::Cyw43WifiInterfaceController;
+
 pub type NetworkDevice = cyw43::NetDriver<'static>;
 
 static STATE: StaticCell<cyw43::State> = StaticCell::new();
 
 #[cfg(feature = "wifi")]
-pub async fn join(mut control: cyw43::Control<'static>) {
+#[embassy_executor::task]
+pub async fn connection(mut control: cyw43::Control<'static>) {
+    use crate::wifi::State;
     use ariel_os_log::info;
+
+    crate::wifi::WIFI_CONTROL_WANTED_STATE
+        .sender()
+        .send(State::Enabled);
+    let mut control_receiver = crate::wifi::WIFI_CONTROL_WANTED_STATE.receiver().unwrap();
+
     loop {
+        if control_receiver.get().await == State::Disabled {
+            // Make sure we left the access point.
+            control.leave().await;
+
+            // Wait for the wanted state to change
+            control_receiver.changed().await;
+            continue;
+        }
+
         //control.join_open(WIFI_NETWORK).await;
         match control
             .join(
@@ -42,12 +62,21 @@ pub async fn join(mut control: cyw43::Control<'static>) {
         {
             Ok(_) => {
                 info!("Wifi connected!");
-                break;
+
+                // Wait for the wanted state to change.
+                // Having a loop here avoids rejoining when `Enabled` is put again in `WIFI_CONTROL_WANTED_STATE`.
+                while control_receiver.get().await == State::Enabled {
+                    control_receiver.changed().await;
+                }
             }
             Err(err) => {
                 info!(" Wifi join failed with status={}", err.status);
             }
         }
+
+        // Calling `join()` subsequently without calling `leave()` inbetween creates a panic.
+        // Leaving before retrying to join is the simplest way to avoid a panic.
+        control.leave().await;
     }
 }
 

--- a/src/ariel-os-rp/src/wifi.rs
+++ b/src/ariel-os-rp/src/wifi.rs
@@ -1,6 +1,36 @@
 use ariel_os_utils::str_from_env;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, watch::Watch};
 
 // TODO: this should be factored out in ariel-os-embassy again
 pub(crate) const WIFI_NETWORK: &str =
     str_from_env!("CONFIG_WIFI_NETWORK", "Wi-Fi SSID (network name)");
 pub(crate) const WIFI_PASSWORD: &str = str_from_env!("CONFIG_WIFI_PASSWORD", "Wi-Fi password");
+
+// State of the wifi interface so it can be controlled from another task.
+pub(crate) static WIFI_CONTROL_WANTED_STATE: Watch<CriticalSectionRawMutex, State, 1> =
+    Watch::new();
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum State {
+    Enabled,
+    Disabled,
+}
+
+/// Interface controller for the CYW43 driver.
+#[derive(Debug, Clone, Copy)]
+pub struct Cyw43WifiInterfaceController {}
+impl Cyw43WifiInterfaceController {
+    /// Create a new interface controller.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ariel_os_embassy_common::net::InterfaceController for Cyw43WifiInterfaceController {
+    fn disable(&self) {
+        WIFI_CONTROL_WANTED_STATE.sender().send(State::Disabled);
+    }
+    fn enable(&self) {
+        WIFI_CONTROL_WANTED_STATE.sender().send(State::Enabled);
+    }
+}


### PR DESCRIPTION
# Description

This adds an API to give (when possible) the ability to the application to toggle on or off a network interface.

Not all interfaces can do it:
- `ltem-nrf-modem` can fully shut down the LTEM part of the modem.
- `wifi-esp` can stop the wifi part of the modem (implementation in the next version, esp-radio 0.18 will be a bit more difficult, see https://github.com/esp-rs/esp-hal/issues/4980 , https://github.com/esp-rs/esp-hal/issues/5376).
- `wifi-cyw43` only leaves the wifi network, doing some work upstream could help.
- `ethernet-stm32` cannot be easily toggled, some upstream work is needed if we want the feature.
- `usb-ethernet` could be done by disabling the whole USB, not sure we want that (could stop other classes). 

## Testing

`examples/tcp-client` has been modified to toggle the network.

```
laze -C examples/tcp-client build -b rpi-pico-w run
laze -C examples/tcp-client build -b seeedstudio-xiao-esp32c6 run
laze -C examples/tcp-client build -b nrf9160dk-nrf9160 run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Added a network interface API that allows to toggle on and off the interface.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
