### PR TITLE
docs: add scrolling to the board matrix

### DIFF
--- a/book/src/chips/esp32-d0wd.md
+++ b/book/src/chips/esp32-d0wd.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/esp32c3.md
+++ b/book/src/chips/esp32c3.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -126,12 +127,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/esp32c6.md
+++ b/book/src/chips/esp32c6.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/esp32c6fx4.md
+++ b/book/src/chips/esp32c6fx4.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -126,12 +127,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/esp32s2.md
+++ b/book/src/chips/esp32s2.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/esp32s3.md
+++ b/book/src/chips/esp32s3.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -148,12 +149,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/esp32s3fx4r2.md
+++ b/book/src/chips/esp32s3fx4r2.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/native-chip.md
+++ b/book/src/chips/native-chip.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/nrf51822-xxaa.md
+++ b/book/src/chips/nrf51822-xxaa.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/nrf52832.md
+++ b/book/src/chips/nrf52832.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/nrf52833.md
+++ b/book/src/chips/nrf52833.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/nrf52840.md
+++ b/book/src/chips/nrf52840.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -170,12 +171,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/nrf5340-app.md
+++ b/book/src/chips/nrf5340-app.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -126,12 +127,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/nrf5340-net.md
+++ b/book/src/chips/nrf5340-net.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -126,12 +127,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/nrf9151.md
+++ b/book/src/chips/nrf9151.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -126,12 +127,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/nrf9160.md
+++ b/book/src/chips/nrf9160.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/rp2040.md
+++ b/book/src/chips/rp2040.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -126,12 +127,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/rp235xa.md
+++ b/book/src/chips/rp235xa.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -126,12 +127,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32c031c6.md
+++ b/book/src/chips/stm32c031c6.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32f042k6.md
+++ b/book/src/chips/stm32f042k6.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32f303re.md
+++ b/book/src/chips/stm32f303re.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32f401re.md
+++ b/book/src/chips/stm32f401re.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32f411re.md
+++ b/book/src/chips/stm32f411re.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32h753zi.md
+++ b/book/src/chips/stm32h753zi.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32h755zi.md
+++ b/book/src/chips/stm32h755zi.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32l475vg.md
+++ b/book/src/chips/stm32l475vg.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32u083mc.md
+++ b/book/src/chips/stm32u083mc.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32u585ai.md
+++ b/book/src/chips/stm32u585ai.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -126,12 +127,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32wb55rg.md
+++ b/book/src/chips/stm32wb55rg.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32wba55cg.md
+++ b/book/src/chips/stm32wba55cg.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32wba65ri.md
+++ b/book/src/chips/stm32wba65ri.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/chips/stm32wle5jc.md
+++ b/book/src/chips/stm32wle5jc.md
@@ -54,6 +54,7 @@ dt, dd {
 Boards using this chip.
 
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -104,12 +105,35 @@ Boards using this chip.
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -1,4 +1,5 @@
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -1002,12 +1003,35 @@
 	  </tbody>
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/templates/support-matrix.html.tmpl
+++ b/book/templates/support-matrix.html.tmpl
@@ -62,9 +62,7 @@
 }
 @media (min-width: 1920px) {
   .support-matrix {
-    position: relative;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin: 0 auto;
   }
 }
 .support-cell {

--- a/book/templates/support-matrix.html.tmpl
+++ b/book/templates/support-matrix.html.tmpl
@@ -1,4 +1,5 @@
 <!-- This table is auto-generated. Do not edit manually. -->
+<div class="support-matrix-container">
 <table class="support-matrix">
   <thead>
     <tr>
@@ -33,7 +34,32 @@
     {%- endfor %}
   </tbody>
 </table>
+</div>
 <style>
+.support-matrix-container {
+  overflow: auto;
+  max-height: 60vh;
+}
+.support-matrix thead {
+  z-index: 3;
+  position: relative;
+}
+/* Makes the row with column names sticky */
+.support-matrix thead tr:last-child {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg);
+}
+.support-matrix th:first-child {
+  background-color: inherit;
+}
+/* Makes the first column sticky */
+.support-matrix thead tr:last-child th:first-child,
+.support-matrix tbody tr:first-child td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
 @media (min-width: 1920px) {
   .support-matrix {
     position: relative;


### PR DESCRIPTION
# Description

In book/hardware-functionality-support.html is the, meanwhile huge, support matrix table now user friendly scroll-able.

## Testing

with web browser, this change is **not** _source code_ related.

## Issue Reference

Closes #1967

## Changelog Entry


<!-- changelog:begin -->
The board support table can now be scrolled horizontal and vertically in the documentation, improving the viewing experience.
<!-- changelog:end -->

## Change Checklist


- [v] The [commit history][conventional-commits] are clean.
- [v] I have followed the [Coding Conventions][coding-conventions].
- [v] I have tested and performed a self-review of my own code.
- [V] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html

P.S.

Please **no**  `---autosquash`
