### PR TITLE
fix(net): require that IPv4 or IPv6 be enabled for networking

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1227,7 +1227,14 @@ modules:
   - name: network
     selects:
       - network_device
+      # Enables IPv4 by default.
       - ?ipv4
+      # Requires at least one of {`ipv4`, `ipv6`}.
+      # This works only if `ipv4` or `ipv6` has been selected before this
+      # `network` module.
+      - ?no-ipv4-ipv6
+      - no-ipv4-ipv6:
+          - ipv4-or-ipv6-required
 
   - name: network-config-ipv4-default
     help: use default network configuration method
@@ -1272,10 +1279,16 @@ modules:
         FEATURES:
           - ariel-os/network-config-ipv4-static
 
+  # Disabled by modules that provide one of these.
+  - name: no-ipv4-ipv6
+    help: private
+
   - name: ipv4
     selects:
       - network
       - network-config-ipv4-default
+    disables:
+      - no-ipv4-ipv6
     env:
       global:
         FEATURES:
@@ -1302,6 +1315,8 @@ modules:
     selects:
       - network
       - network-config-ipv6-default
+    disables:
+      - no-ipv4-ipv6
     env:
       global:
         FEATURES:


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
The `ipv6` laze modules was introduced by #915, but it wasn't known at the at time how to express an "at least one" relation between the `ipv4` and `ipv6` laze modules. The build would fail if networking was enabled but `ipv4` (otherwise enabled by default) was manually disabled, as `embassy-net` requires at least one of them. This PR encodes that constraint in the laze configuration so the build can fail earlier.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
The `info-modules` laze task can be used to print the enabled laze modules:

```sh
laze -C examples/udp-echo/ build -b rpi-pico info-modules
```

```sh
laze -C examples/udp-echo/ build -d ipv4 -b rpi-pico info-modules
```

(This build should now fail.)

```sh
laze -C examples/udp-echo/ build -s ipv6 -b rpi-pico info-modules
```

(Enables both IPv4 and IPv6.)

```sh
laze -C examples/udp-echo/ build -d ipv4 -s ipv6 -b rpi-pico info-modules
```

(Enables only IPv6.)

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
I don't think this deserves an entry as the build would have failed anyway.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
