### PR TITLE
fix(ci): touch only files that are present

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,7 +346,9 @@ jobs:
 
             # Treat all files modified after the cached commit as "changed", by touching them.
             git diff --name-only $(cat /home/runner/metadata/cache-ref) | while read filename; do
-              touch "${filename}"
+              if [ -f "${filename}" ]; then
+                touch "${filename}"
+              fi
             done
           else
              echo "/home/runner/metadata/cache-ref not found, skipping step"


### PR DESCRIPTION
# Description

The step "Touch file time to commits time" tries to touch all modified files between the cached commit and the commit in the PR, if a folder is not preset in the checked out tree but files inside it have been modified between the two commits, touch will throw an error like in this run: https://github.com/ariel-os/ariel-os/actions/runs/24995583111/job/73191643712 . 

This PR fixes that by first checking if the file exists before touching it.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
