### PR TITLE
build: bump MSRV to 1.95

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,7 +280,7 @@ jobs:
         # configure MSRV here:
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:
-          toolchain: 1.94
+          toolchain: 1.95
           targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,thumbv6m-none-eabi,thumbv7m-none-eabi,thumbv7em-none-eabi,thumbv7em-none-eabihf,thumbv8m.main-none-eabi,thumbv8m.main-none-eabihf
           # rust-src: Used for -Zbuild-std.
           # rustfmt: Used by bindgen for liboscore
@@ -292,7 +292,7 @@ jobs:
         # No tag yet after https://github.com/esp-rs/xtensa-toolchain/pull/38 (will probably be @v1.5.5)
         uses: esp-rs/xtensa-toolchain@ec6d36527049a7f4fb2cb0c1a644668c1bb8a2a4 # main
         with:
-          version: "1.94.0.2"
+          version: "1.95.0.0"
           buildtargets: esp32,esp32s2,esp32s3
           override: false
           export: false

--- a/.github/workflows/vetting.yml
+++ b/.github/workflows/vetting.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:
-          toolchain: 1.94
+          toolchain: 1.95
 
       - name: Install cargo-vet
         uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default-members = ["examples/hello-world"]
 edition = "2024"
 # This should be the Ariel OS MSRV.
 # Some crates may have a different MSRV.
-rust-version = "1.94"
+rust-version = "1.95"
 repository = "https://github.com/ariel-os/ariel-os"
 license = "MIT OR Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Multiple resources are available to learn Ariel OS:
 
 ## Minimum Supported Rust Version (MSRV) and Policy
 
-Ariel OS compiles with stable Rust version 1.94 and up.
+Ariel OS compiles with stable Rust version 1.95 and up.
 The MSRV can be increased in patch version updates.
 
 ## Security

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1991,7 +1991,7 @@ builders:
           - rustup ${CARGO_TOOLCHAIN} target add riscv32imc-unknown-none-elf
           - rustup ${CARGO_TOOLCHAIN} target add riscv32imac-unknown-none-elf
           - rustup ${CARGO_TOOLCHAIN} component add rust-src llvm-tools
-          - if command -v espup >/dev/null; then espup update --toolchain-version 1.94.0.2 --targets=esp32,esp32s2,esp32s3; fi
+          - if command -v espup >/dev/null; then espup update --targets=esp32,esp32s2,esp32s3; fi
 
       update-book:
         build: false

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1014,7 +1014,7 @@ modules:
     env:
       global:
         # this pins our nightly version
-        CARGO_TOOLCHAIN: +nightly-2026-01-20
+        CARGO_TOOLCHAIN: +nightly-2026-04-28
         RUSTFLAGS:
           - --cfg nightly
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This bumps Ariel's toolchain to 1.95. This introduced [`cfg_select!`](https://doc.rust-lang.org/stable/core/macro.cfg_select.html) which should allow us to get rid of our dependency on `cfg-if`. See #1851 

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References
- Waiting on an image update PR https://github.com/ariel-os/garm-worker-image to test the build CI on our machines https://github.com/ariel-os/garm-worker-image/pull/20
- Depends on #2057
- Closes #1875
- Depends on #2059 
<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions
- [ ] Do we also want to bump the nightly ? 
<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Ariel OS's MSRV is now 1.95.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
