### PR TITLE
ci: use a stable toolchain where possible

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -126,10 +126,6 @@ jobs:
              echo "/home/runner/metadata/cache-ref not found, skipping step"
           fi
 
-      - id: get_toolchain
-        if: steps.should-skip.outputs.result != 'true'
-        run: echo "toolchain=$(scripts/rust-toolchain.sh)" >> $GITHUB_OUTPUT
-
       - name: "Show installed versions"
         run: |
           set -x

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,13 +25,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - id: get_toolchain
-        run: echo "toolchain=$(scripts/rust-toolchain.sh)" >> $GITHUB_OUTPUT
-
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:
-          toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
+          toolchain: stable
 
       - name: Install laze
         uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2
@@ -83,6 +80,7 @@ jobs:
       - id: get_toolchain
         run: echo "toolchain=$(scripts/rust-toolchain.sh)" >> $GITHUB_OUTPUT
 
+      # Clippy linting is better done with the nightly set of lints.
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:
@@ -339,6 +337,7 @@ jobs:
       - id: get_toolchain
         run: echo "toolchain=$(scripts/rust-toolchain.sh)" >> $GITHUB_OUTPUT
 
+      # Generating the rustdoc docs requires nightly features.
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:

--- a/src/ariel-os-macros/tests/ui/spawner/missing_peripherals_param.stderr
+++ b/src/ariel-os-macros/tests/ui/spawner/missing_peripherals_param.stderr
@@ -10,4 +10,4 @@ error: ... because this function has a second parameter
  --> tests/ui/spawner/missing_peripherals_param.rs:9:9
   |
 9 | fn main(_spawner: Spawner, _peripherals: Peripherals) {}
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |         ^^^^^^^^

--- a/src/ariel-os-macros/tests/ui/task/incorrect_fn_peripheral_param_type.stderr
+++ b/src/ariel-os-macros/tests/ui/task/incorrect_fn_peripheral_param_type.stderr
@@ -1,7 +1,7 @@
-error[E0599]: no method named `take_peripherals` found for mutable reference `&mut OptionalPeripherals` in the current scope
+error[E0599]: no method named `take_peripherals` found for mutable reference `&mut ariel_os::hal::OptionalPeripherals` in the current scope
  --> tests/ui/task/incorrect_fn_peripheral_param_type.rs:5:1
   |
 5 | #[ariel_os::task(autostart, peripherals)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `&mut OptionalPeripherals`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `&mut ariel_os::hal::OptionalPeripherals`
   |
   = note: this error originates in the attribute macro `ariel_os::task` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Since #1811 it should be possible for the `cargo-test` job to use a stable toolchain. This is useful for #2054 as the `trybuild` snapshots apparently flip-flop between Rust 1.95 and the current nightly (nightly-2026-04-29).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
CI does it.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
