### PR TITLE
build(lib): remove the outdated `rust-toolchain`s pinning to nightly

### DIFF
--- a/src/lib/rbi/rust-toolchain
+++ b/src/lib/rbi/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/src/lib/ringbuffer/rust-toolchain
+++ b/src/lib/ringbuffer/rust-toolchain
@@ -1,1 +1,0 @@
-nightly


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This proposes to remove the `rust-toolchain` file of the `rbi` and `ringbuffer` packages, which pinned the toolchain to `nightly`. This seems not necessary anymore, and keeping it makes the `cargo-test` slower as it needs to install a separate toolchain each time (see [the logs of #2057](https://github.com/ariel-os/ariel-os/actions/runs/25101010993/job/73549919032) for instance; grep for "components").

The [`rbi` package is published on crates.io](https://crates.io/crates/rbi); it's unclear how removing the `rust-toolchain` file impacts this (I've only checked that the file wasn't in an `include` manifest key).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
