### PR TITLE
refactor(logging): introduce a `usb-cdc-acm-esp` laze module

### DIFF
--- a/boards/dfrobot-firebeetle2-esp32-c6.yaml
+++ b/boards/dfrobot-firebeetle2-esp32-c6.yaml
@@ -2,6 +2,8 @@ version: 0.3.0
 targets:
   dfrobot-firebeetle2-esp32-c6:
     chip: esp32c6fx4
+    flags:
+      - has_usb_cdc_acm_port
     leds:
       led0:
         pin: GPIO15

--- a/boards/espressif-esp32-c3-devkit-rust-1.yaml
+++ b/boards/espressif-esp32-c3-devkit-rust-1.yaml
@@ -2,6 +2,8 @@ version: 0.3.0
 targets:
   espressif-esp32-c3-devkit-rust-1:
     chip: esp32-c3-mini-1
+    flags:
+      - has_usb_cdc_acm_port
     buttons:
       button0:
         pin: GPIO9

--- a/boards/espressif-esp32-c3-lcdkit.yaml
+++ b/boards/espressif-esp32-c3-lcdkit.yaml
@@ -2,3 +2,5 @@ version: 0.3.0
 targets:
   espressif-esp32-c3-lcdkit:
     chip: esp32-c3-mini-1
+    flags:
+      - has_usb_cdc_acm_port

--- a/boards/espressif-esp32-c6-devkitc-1.yaml
+++ b/boards/espressif-esp32-c6-devkitc-1.yaml
@@ -2,6 +2,8 @@ version: 0.3.0
 targets:
   espressif-esp32-c6-devkitc-1:
     chip: esp32-c6-wroom-1
+    flags:
+      - has_usb_cdc_acm_port
     buttons:
       button0:
         pin: GPIO9

--- a/boards/espressif-esp32-s3-devkitc-1.yaml
+++ b/boards/espressif-esp32-s3-devkitc-1.yaml
@@ -3,6 +3,7 @@ targets:
   espressif-esp32-s3-devkitc-1:
     chip: esp32-s3-wroom-1
     flags:
+      - has_usb_cdc_acm_port
       - has_usb_device_port
     buttons:
       button0:

--- a/boards/seeedstudio-xiao-esp32c6.yaml
+++ b/boards/seeedstudio-xiao-esp32c6.yaml
@@ -2,6 +2,8 @@ version: 0.3.0
 targets:
   seeedstudio-xiao-esp32c6:
     chip: esp32c6fx4
+    flags:
+      - has_usb_cdc_acm_port
     leds:
       led0:
         pin: GPIO15

--- a/boards/unihiker-k10.yaml
+++ b/boards/unihiker-k10.yaml
@@ -3,6 +3,7 @@ targets:
   unihiker-k10:
     chip: esp32-s3-wroom-1
     flags:
+      - has_usb_cdc_acm_port
       - has_usb_device_port
     buttons:
       button0:

--- a/boards/waveshare-esp32-s3-matrix.yaml
+++ b/boards/waveshare-esp32-s3-matrix.yaml
@@ -4,6 +4,7 @@ targets:
     # website: https://www.waveshare.com/wiki/ESP32-S3-Matrix
     chip: esp32s3fx4r2
     flags:
+      - has_usb_cdc_acm_port
       - has_usb_device_port
     # To be added, eg. through ariel.global_env.ESPFLASH_ARGS and once
     # <https://github.com/esp-rs/espflash/issues/1023> is resolved:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -406,6 +406,7 @@ contexts:
       - riscv
     provides:
       - has_ble_esp
+      - has_usb_cdc_acm
       - sw/benchmark
     provides_unique: [c-function-abort]
     env:
@@ -423,6 +424,7 @@ contexts:
       - riscv
     provides:
       - has_ble_esp
+      - has_usb_cdc_acm
       - sw/benchmark
     provides_unique: [c-function-abort]
     env:
@@ -476,6 +478,7 @@ contexts:
       # TODO: re-enable as soon as upstream peripheral drivers become `Send`
       # in combination with multi-core.
       # - has_multi_core_support
+      - has_usb_cdc_acm
       - sw/benchmark
     env:
       RUSTC_TARGET: xtensa-esp32s3-none-elf
@@ -1440,6 +1443,12 @@ modules:
       global:
         FEATURES:
           - ariel-os/usb
+
+  # Provided by ESP32 MCUs with a non-generic USB CDC-ACM peripheral (they may
+  # *also* have a generic USB peripheral).
+  - name: has_usb_cdc_acm
+    selects:
+      - doc-only
 
   # Provided by boards having a USB port connected to a USB peripheral
   # supporting USB CDC-ACM while not being a generic USB peripheral.

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1437,12 +1437,25 @@ modules:
           - ariel-os/nrf91-modem
 
   - name: usb
+    disables:
+      # Currently the generic USB should take priority.
+      - usb-cdc-acm-esp
     selects:
       - hw/usb-device-port
     env:
       global:
         FEATURES:
           - ariel-os/usb
+
+  # Available on ESP32 boards with ESP32 having a non-generic USB CDC-ACM
+  # peripheral (they may *also* have a generic USB peripheral) and a USB port
+  # connected to it.
+  - name: usb-cdc-acm-esp
+    context:
+      - esp
+    selects:
+      - has_usb_cdc_acm
+      - has_usb_cdc_acm_port
 
   # Provided by ESP32 MCUs with a non-generic USB CDC-ACM peripheral (they may
   # *also* have a generic USB peripheral).
@@ -1881,14 +1894,9 @@ modules:
 
   - name: logging-over-usb
     help: use USB CDC-ACM as logging transport
-    # Temporarily restricted to ESP32s having a USB CDC-ACM/JTAG USB peripheral
-    # until introducing a `usb-cdc-acm-esp` module.
-    # Should be later extended to chips with a generic USB peripheral.
-    context:
-      - esp32s3
-      - esp32c3
-      - esp32c6
     selects:
+      # Temporarily restricted to ESP32s having a USB CDC-ACM/JTAG USB peripheral.
+      - usb-cdc-acm-esp
       - context::esp:
           - esp-println
     provides_unique:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1441,6 +1441,13 @@ modules:
         FEATURES:
           - ariel-os/usb
 
+  # Provided by boards having a USB port connected to a USB peripheral
+  # supporting USB CDC-ACM while not being a generic USB peripheral.
+  # A board may *also* have `has_usb_device_port`.
+  - name: has_usb_cdc_acm_port
+    selects:
+      - doc-only
+
   - name: hw/usb-device-port
     help: provided if a device has a USB device port wired up
     selects:

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -35,6 +35,7 @@ builders:
   provides:
   - has_buttons
   - has_leds
+  - has_usb_cdc_acm_port
 - name: dwm1001
   parent: nrf52832
   provides:
@@ -45,12 +46,16 @@ builders:
   provides:
   - has_buttons
   - has_leds
+  - has_usb_cdc_acm_port
 - name: espressif-esp32-c3-lcdkit
   parent: esp32-c3-mini-1
+  provides:
+  - has_usb_cdc_acm_port
 - name: espressif-esp32-c6-devkitc-1
   parent: esp32-c6-wroom-1
   provides:
   - has_buttons
+  - has_usb_cdc_acm_port
 - name: espressif-esp32-devkitc
   parent: esp-wroom-32
   provides:
@@ -64,6 +69,7 @@ builders:
   parent: esp32-s3-wroom-1
   provides:
   - has_buttons
+  - has_usb_cdc_acm_port
   - has_usb_device_port
 - name: heltec-wifi-lora-32-v3
   parent: esp32s3fx8
@@ -163,6 +169,7 @@ builders:
   provides:
   - has_buttons
   - has_leds
+  - has_usb_cdc_acm_port
 - name: seeedstudio-xiao-nrf52840-plus
   parent: nrf52840
   provides:
@@ -312,8 +319,10 @@ builders:
   parent: esp32-s3-wroom-1
   provides:
   - has_buttons
+  - has_usb_cdc_acm_port
   - has_usb_device_port
 - name: waveshare-esp32-s3-matrix
   parent: esp32s3fx4r2
   provides:
+  - has_usb_cdc_acm_port
   - has_usb_device_port


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This introduces the necessary laze module to model the non-generic USB CDC-ACM(/JTAG) USB peripheral found on some (but not all) ESP32s and limits the availability of the `logging-over-usb` module introduced by #2030 accordingly. It is the intent that `logging-over-usb` be eventually implemented using the generic USB peripheral when available (#1805), but this is out of scope.

This also addresses an issue introduced in #2039 (see https://github.com/ariel-os/ariel-os/pull/2039#discussion_r3193850801) on the [Heltec WiFi LoRa 32 V3](https://web.archive.org/web/20250807184214/https://heltec.org/project/wifi-lora-32-v3/), as that board does *not* expose the USB peripheral at all (despite using an ESP32-S3).

For reference:

- The "plain" ESP32 (and the ESP32-C2) have no USB peripheral at all.
- The ESP32-S2 has a generic USB peripheral but no USB CDC-ACM/JTAG USB peripheral.
- The ESP32-S3 has both a generic USB peripheral and a USB CDC-ACM/JTAG USB peripheral.
- The ESP32-C3, (ESP32-C5, ESP32-C61) and ESP32-C6 have a USB CDC-ACM/JTAG USB peripheral but no generic USB peripheral.

(Chips we don't currently support are mentioned in parentheses.)

The USB CDC-ACM/JTAG USB peripheral and the generic USB peripheral cannot be used at the same time on the same USB port (it is possible to add an external PHY and use both peripherals with separate USB ports, but supporting this is not a priority) so this PR disables `logging-over-usb` when USB is otherwise used by the application for now (I hope we can have a composite USB device later).

## How to review this PR

This PR is better reviewed commit by commit.
The changes to the SBD files could be moved to a dedicated PR.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

Should laze-time fail:

```sh
laze -C examples/log/ build -s logging-over-usb -b rpi-pico
laze -C examples/log/ build -s logging-over-usb -b espressif-esp32-devkitc
laze -C examples/log/ build -s logging-over-usb -b espressif-esp32-s2-devkitc-1
laze -C examples/udp-echo/ build -s logging-over-usb -s usb-ethernet -b espressif-esp32-s3-devkitc-1
```

(The last failure is because the USB CDC-ACM/JTAG USB peripheral cannot be used at the same time as the generic USB peripheral over the same USB port.)

Should compile:

```sh
laze -C examples/log/ build -s logging-over-usb -b espressif-esp32-c3-devkit-rust-1
laze -C examples/log/ build -s logging-over-usb -b espressif-esp32-c6-devkitc-1
laze -C examples/log/ build -s logging-over-usb -b espressif-esp32-s3-devkitc-1
```

The following can be used to check that the [Heltec WiFi LoRa 32 V3](https://web.archive.org/web/20250807184214/https://heltec.org/project/wifi-lora-32-v3/) *defaults* to using the UART transport:

```sh
laze -C examples/log/ build -b heltec-wifi-lora-32-v3 info-modules
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #2030

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
