### PR TITLE
feat(nrf91): save power by initializing the modem

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -287,6 +287,10 @@ contexts:
     parent: nrf
     selects:
       - cortex-m33f
+      # Initializing the modem reduces the power consumption of the MCU.
+      # For blinky the measured consumption is ~3milliAmps without nrf91-modem to ~4 microAmps with nrf91-modem.
+      # Tested using the ppk2 in ampere mode on the Thingy:91 X and nrf9160dk.
+      - ?nrf91-modem
 
   - name: nrf9160
     parent: nrf91


### PR DESCRIPTION
# Description

This enables the `nrf91-modem` feature by default on nrf91 chips, enabling the initialization of the modem that allows reducing the power consumption from 3 milliAmps to around 4 microAmps. 

The modem initialization can be disabled by disabling the `nrf91-modem` module (`-d nrf91-modem` in the cli).


## Testing

Used a Nordic Power Profiler II to measure the consumption of the MCUs.

With nrf91-modem initialization (consumes less): 
```
laze -C examples/blinky/ build -b nordic-thingy-91-x-nrf9151 run
laze -C examples/blinky/ build -b nrf9160dk-nrf9160 run
```

Without nrf91-modem initialization (consumes more): 
```
laze -C examples/blinky/ build -b nordic-thingy-91-x-nrf9151 -d nrf91-modem run
laze -C examples/blinky/ build -b nrf9160dk-nrf9160 -d nrf91-modem run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

This makes the text section go from 12564 to 40960 and the bss from 11572 to 17144 on the nrf9151. Plus 32 kB of ram is reserved for the modem IPC. Should this be enabled by default ? Or should this be opt-in (with a page on the book talking about it) ?.

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(nRF91) The power consumption of the nRF91 SiP family has been improved by always initializing its modem.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
