### PR TITLE
feat(nrf91-gnss): add power mode config option

### DIFF
--- a/src/sensors/ariel-os-sensor-nrf91-gnss/src/config.rs
+++ b/src/sensors/ariel-os-sensor-nrf91-gnss/src/config.rs
@@ -11,6 +11,36 @@ pub enum GnssOperationMode {
     SingleShot(u16),
 }
 
+/// Power saving modes for the GNSS module.
+///
+/// From the [`nrfxlib` documentation]:
+///
+/// > In the duty-cycling performance mode, duty-cycled tracking is engaged when it can be done without significant performance degradation. In the duty-cycling power mode, duty-cycled tracking is engaged more aggressively with acceptable performance degradation.
+///
+/// [nrfxlib documentation]: https://nrfconnectdocs.nordicsemi.com/ncs/3.3.0/nrfxlib/nrf_modem/doc/gnss_interface.html#power-saving-mode
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum GnssPowerSavingMode {
+    /// No duty cycling.
+    Disabled,
+    /// Duty cycling while preserving tracking performance.
+    DutyCyclingPerformance,
+    /// Duty cycling engaged more aggressively with "acceptable performance degradation".
+    DutyCyclingAggressive,
+}
+
+impl GnssPowerSavingMode {
+    fn to_nrf_modem(self) -> nrf_modem::GnssPowerSaveMode {
+        match self {
+            GnssPowerSavingMode::Disabled => nrf_modem::GnssPowerSaveMode::Disabled,
+            GnssPowerSavingMode::DutyCyclingPerformance => {
+                nrf_modem::GnssPowerSaveMode::DutyCyclingPerformance
+            }
+            GnssPowerSavingMode::DutyCyclingAggressive => nrf_modem::GnssPowerSaveMode::DutyCycling,
+        }
+    }
+}
+
 /// Configuration for the GNSS sensor.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -20,6 +50,8 @@ pub struct Config {
     pub operation_mode: GnssOperationMode,
     /// Whether NMEA messages should be logged as logs (adds extra processing).
     pub log_nmea: bool,
+    /// GNSS power saving mode (duty cycling).
+    pub power_saving_mode: GnssPowerSavingMode,
 }
 
 impl Default for Config {
@@ -27,6 +59,7 @@ impl Default for Config {
         Self {
             operation_mode: GnssOperationMode::Continuous,
             log_nmea: false,
+            power_saving_mode: GnssPowerSavingMode::Disabled,
         }
     }
 }
@@ -49,6 +82,6 @@ pub(crate) fn convert_gnss_config(config: &Config) -> nrf_modem::GnssConfig {
         },
         // Tcxo offers more precise 1PPS but uses more energy, we don't use 1PPS so Rtc makes more sense.
         timing_source: nrf_modem::GnssTimingSource::Rtc,
-        power_mode: nrf_modem::GnssPowerSaveMode::Disabled,
+        power_mode: config.power_saving_mode.to_nrf_modem(),
     }
 }


### PR DESCRIPTION
# Description

This PR adds a field in the config struct to configure the power saving option of the nrf91 GNSS.

## Testing
Testing on the Thingy91X showed that `GnssPowerSaveMode::Disabled` consumes more than `GnssPowerSaveMode::DutyCyclingPerformance` that consumes more than `GnssPowerSaveMode::DutyCycling`.

I also noticed that continuous operation consumes the most and periodic operation mode (300s) consumes more than single shot mode fetched every 300s.

Power measurement was done over 15 minutes, measured using a Nordic PPK2 and a custom program, [ppk2-collector](https://github.com/nponsard/ppk2-collector). The code executed on the MCU was the `sensors-debug` example modified in my [test-gnss-consumption](https://github.com/nponsard/ariel-os/tree/test-gnss-consumption) branch.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Added the ability to configure the power saving mode on the nrf91 GNSS driver.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
