### PR TITLE
fix(logging): make `panic-printing` depend on `logging`

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1942,6 +1942,8 @@ modules:
   - name: panic-printing
     help: print panics, on the logging output
     context: ariel-os
+    selects:
+      - logging
     env:
       global:
         FEATURES:


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This addresses https://github.com/ariel-os/ariel-os/pull/2030#issuecomment-4353075340 by making the `panic-printing` laze module `select` `logging` as panics are printed on the logging output since #2013.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
The following now fail at laze-time as they should:

```sh
laze -C examples/log/ build -d logging -s panic-printing -b nrf52840dk
laze -C examples/log/ build -s panic-printing -d logging -b nrf52840dk
```

The following shows that disabling `logging` still disables `panic-printing`:

```sh
laze -C examples/log/ build -d logging -b nrf52840dk info-modules
```

Logging and panic printing still work as expected when enabled, and `panic-printing` is still enabled by default:

```sh
laze -C examples/log/ build -b nrf52840dk info-modules 
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Follow-up to #2013 and https://github.com/ariel-os/ariel-os/pull/2030#issuecomment-4353075340

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
No need for a dedicated entry, this is covered by #2013's.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
