### PR TITLE
fix(ci): schedule CI earlier to compensate GitHub timing issues

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -9,8 +9,9 @@ on:
         required: false
         type: boolean
   schedule:
-    # run every morning at 00:07am
-    - cron: "7 0 * * *"
+    # run every morning at 00:07am UTC
+    # GitHub action seems to launch them ~4 hours late so we put the trigger 4 hours earlier.
+    - cron: "7 20 * * *"
 concurrency:
   group: ${{ github.head_ref || github.run_id }}-build-cache
   cancel-in-progress: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,9 @@ on:
       - main
   merge_group:
   schedule:
-    # run every morning at 4:17am
-    - cron: "17 4 * * *"
+    # run every morning at 04:17am UTC
+    # GitHub action seems to launch them ~4 hours late so we put the trigger 4 hours earlier.
+    - cron: "17 0 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
# Description

GitHub CI schedule feature seem to always trigger the jobs 4 hours late (they claim the cron string is for UTC, yet a job for midnight is triggered at 4 am UTC), this changes the trigger times for the cache and build CIs to compensate for this.  

## Testing

Once merged, check if the CI is triggered at the expected time.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
