### PR TITLE
fix(debug): fix usage of featurecomb's `features` table

### DIFF
--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -10,8 +10,8 @@ license.workspace = true
 debug-channel.xor = { features = ["defmt-rtt", "rtt-target"] }
 exit-implementation.xor = { features = ["semihosting", "std"] }
 
-[package.metadata.features]
-debug-channel = { groups = ["debug-channel"] }
+[package.metadata.feature-groups.features]
+debug-channel.requires = { groups = ["debug-channel"] }
 
 [dependencies]
 defmt-rtt = { workspace = true, optional = true }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
The `features` table of featurecomb of `ariel-os-log` was misused and wasn't enforcing that a debug channel was selected when the `debug-channel` Cargo feature of `ariel-os-log` was enabled. This fixes it.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
It can be tested that the table is now properly picked up by featurecomb by introducing a misspelling in the name of the `debug-channel` Cargo feature used as the key in the table and checking that featurecomb complains about the non-existing feature. Because manifest's values are aggressively cached by Cargo, the manifest can for instance be invalidated by commenting out the `lints` section. 

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- That featurecomb's `features`'s table was added in #1029.

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
