### PR TITLE
chore(support): remove now unneeded `allow(unused)` in Cargo script

### DIFF
--- a/doc/gen_book.rs
+++ b/doc/gen_book.rs
@@ -13,9 +13,6 @@ slug = { version = "0.1" }
 thiserror = { version = "1.0.61" }
 ---
 
-// TODO: remove when upstream fixes issue
-#![allow(unused)]
-
 mod schema;
 
 use std::{
@@ -983,7 +980,6 @@ fn merge_notes(notes: Option<String>, note_snippet_content: Option<Vec<String>>)
     } else {
         return notes;
     }
-    None
 }
 
 #[derive(Debug, thiserror::Error, Diagnostic)]

--- a/doc/schema.rs
+++ b/doc/schema.rs
@@ -87,30 +87,3 @@ impl SupportInfo {
         }
     }
 }
-
-pub enum Tier {
-    Tier1,
-    Tier2,
-    Tier3,
-}
-
-impl argh::FromArgValue for Tier {
-    fn from_arg_value(value: &str) -> Result<Self, String> {
-        match value {
-            "tier-1" | "1" => Ok(Self::Tier1),
-            "tier-2" | "2" => Ok(Self::Tier2),
-            "tier-3" | "3" => Ok(Self::Tier3),
-            _ => Err("invalid board support tier".to_string()),
-        }
-    }
-}
-
-impl ToString for Tier {
-    fn to_string(&self) -> String {
-        match self {
-            Tier::Tier1 => "1".to_string(),
-            Tier::Tier2 => "2".to_string(),
-            Tier::Tier3 => "3".to_string(),
-        }
-    }
-}


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Now that [the fix](https://redirect.github.com/rust-lang/rust/pull/149147) for [rust#147648](https://redirect.github.com/rust-lang/rust/issues/147648) has landed in Rust 1.93, this removes the now unneeded `allow(unused)` in the Cargo script generating the support info, addressing #1505. This PR also addresses the couple of warnings stemming from the removal of that attribute.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Running `laze build update-book` doesn't trigger warnings anymore, even without `allow(unused)`.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Fixes #1505

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
