### PR TITLE
refactor(rtt-target): remove unused remnants of `defmt` support

### DIFF
--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -21,38 +21,13 @@ mod backend {
 
 #[cfg(feature = "rtt-target")]
 mod backend {
-    #[cfg(feature = "defmt")]
-    pub use defmt::println as debug_output_println;
-
-    #[cfg(not(feature = "defmt"))]
     pub use rtt_target::rprintln as debug_output_println;
 
     #[doc(hidden)]
     pub fn init() {
-        #[cfg(not(feature = "defmt"))]
-        {
-            use rtt_target::ChannelMode::NoBlockTrim;
+        use rtt_target::ChannelMode::NoBlockTrim;
 
-            rtt_target::rtt_init_print!(NoBlockTrim);
-        }
-
-        #[cfg(feature = "defmt")]
-        {
-            use rtt_target::ChannelMode::NoBlockSkip;
-            const DEFMT_BUFFER_SIZE: usize = 1024;
-            let channels = rtt_target::rtt_init! {
-                up: {
-                    0: {
-                        size: DEFMT_BUFFER_SIZE,
-                        mode: NoBlockSkip,
-                        // probe-run autodetects whether defmt is in use based on this channel name
-                        name: "defmt"
-                    }
-                }
-            };
-
-            rtt_target::set_defmt_channel(channels.up.0);
-        }
+        rtt_target::rtt_init_print!(NoBlockTrim);
     }
 }
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
In #2013, the ability to use `defmt` with `rtt-target` (not RTT in general, specifically the `rtt-target` implementation) was knowingly broken/removed (see https://github.com/ariel-os/ariel-os/pull/2013#discussion_r3084770748). In addition, #2030 set the `help` message of the `rtt-target` laze module to "private" and that laze module was never documented. It is my opinion that there is no reason to keep two implementations of `defmt` over RTT, as `defmt-rtt` is otherwise used (and has been the default since its introduction in #1603), and as using the `rtt-target` implementation increases the binary size by a couple of hundred bytes. This PR therefore proposes to resolve the inconsistency by removing the remnants of that implementation.

Alternatively, the implementation of `defmt`+`rtt-target` could be fixed, and the `rtt-target` laze module documented in the book as an alternative implementation.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested the following:

```sh
laze -C examples/log build -b stm32u083c-dk run
```

(Unchanged by this PR, uses `defmt-rtt`.)

```sh
laze -C examples/log build -s log -b stm32u083c-dk run
```

(Unchanged by this PR, uses `log` and `rtt-target`.)

```sh
laze -C examples/log build -s rtt-target -b stm32u083c-dk run
```

(Forces the *undocumented* `rtt-target` laze module, technically unchanged by this PR, but different from the behavior from 0.4.0: uses `log` and `rtt-target`.)

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
To me this is not a breaking change (the alternative implementations were never given any visibility), so this doesn't need an entry.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
