### PR TITLE
docs(book): remove an outdated note about `print!` and logging ordering

### DIFF
--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -69,9 +69,6 @@ The defmt logger supports configuring the log level per crate and per module, as
 $ laze build -C examples/log --builders nrf52840dk -DLOG=info,ariel_os_rt=trace run
 ```
 
-Note: On Cortex-M devices, the order of `ariel_os::log::println!()` output and
-      `defmt` log output is not deterministic.
-
 ### [log]
 
 Ariel OS's logger for `log` supports configuring the log level globally, but does not currently support per-crate filtering.


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This removes an outdated note about the `print!`/`println!` and logging statements being potentially interleaved (when using RTT). This note was added in #629 but I believe this was outdated by removing the second up RTT channel in #1052, which was used to carry the `print!`/`println!()` statements specifically: the `println!()` macro now always uses the `defmt` channel, as this macro is that of the `defmt` crate.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
Not adding an entry as this is arguably part of the logging refactor.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
