### PR TITLE
refactor: remove the `executor-none` Cargo feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -251,7 +251,6 @@ jobs:
             --features "
                 dns,
                 external-interrupts,
-                executor-none,
                 i2c,
                 ipv4,
                 ipv6,

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -192,7 +192,6 @@ rcc-config-override = ["ariel-os-hal/rcc-config-override"]
 
 executor-interrupt = ["ariel-os-hal/executor-interrupt"]
 executor-thread = ["ariel-os-embassy-common/executor-thread", "threading"]
-executor-none = []
 
 # Allows to have no built-in board selected.
 no-boards = []
@@ -212,7 +211,7 @@ defmt = [
 ]
 log = ["ariel-os-hal/log"]
 
-_test = ["dhcpv4", "executor-none", "external-interrupts", "i2c", "spi", "time"]
+_test = ["dhcpv4", "external-interrupts", "i2c", "spi", "time"]
 
 [lints]
 workspace = true

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -144,12 +144,11 @@ pub type Task = fn(asynch::Spawner, &mut hal::OptionalPeripherals);
 #[distributed_slice]
 pub static EMBASSY_TASKS: [Task] = [..];
 
-#[cfg(not(any(
-    feature = "executor-interrupt",
-    feature = "executor-none",
-    feature = "executor-thread"
-)))]
-compile_error!(r#"must select one of "executor-interrupt", "executor-thread", "executor-none"!"#);
+#[cfg(all(
+    context = "ariel-os",
+    not(any(feature = "executor-interrupt", feature = "executor-thread"))
+))]
+compile_error!(r#"must select one of "executor-interrupt", "executor-thread"!"#);
 
 #[cfg(feature = "executor-interrupt")]
 #[distributed_slice(ariel_os_rt::INIT_FUNCS)]

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -150,6 +150,9 @@ pub static EMBASSY_TASKS: [Task] = [..];
 ))]
 compile_error!(r#"must select one of "executor-interrupt", "executor-thread"!"#);
 
+#[cfg(all(feature = "executor-interrupt", feature = "executor-thread"))]
+compile_error!(r#"must select only one of "executor-interrupt", "executor-thread"!"#);
+
 #[cfg(feature = "executor-interrupt")]
 #[distributed_slice(ariel_os_rt::INIT_FUNCS)]
 pub(crate) fn init() {

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -214,11 +214,7 @@ bench = ["dep:ariel-os-bench"]
 # Prints panic messages on the debug console.
 panic-printing = ["ariel-os-rt/panic-printing"]
 ## Allows to have no boards selected, useful to run target-independent tooling.
-no-boards = [
-  "ariel-os-boards/no-boards",
-  "ariel-os-embassy/no-boards",
-  "executor-none",
-]
+no-boards = ["ariel-os-boards/no-boards", "ariel-os-embassy/no-boards"]
 
 # These are selected by laze
 debug-uart = ["ariel-os-embassy/debug-uart", "ariel-os-log/debug-uart"]
@@ -240,9 +236,6 @@ executor-interrupt = [
 ]
 # Enables the ariel-os-threading thread executor.
 executor-thread = ["ariel-os-embassy/executor-thread", "threading"]
-# Don't start any executor automatically.
-# *Used for internal testing only.*
-executor-none = ["ariel-os-embassy/executor-none"]
 
 # Enables embedded-test support. Selected by laze.
 embedded-test = ["ariel-os-rt/embedded-test"]


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This is a follow-up to #2037: because the `no-boards` Cargo feature enabled `executor-none`, using `no-boards` to disable using the built-in boards would lead to two `executor-*` Cargo features being enabled which, even though not forbidden, would be odd. This proposes to completely remove the `executor-none` Cargo feature, which was only used to make sure that one executor flavor was selected when actually needed. Instead this revisits the compile-time check to fail when no executor flavor was selected *when in the `ariel-os` context* (set by laze), thus still allowing platform-independent tooling to work. The remaining `executor-*` Cargo features are also made mutually exclusive.

There is no remaining occurrences of `executor-none` in the codebase.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
CI does a lot.

Tested the following:

```sh
laze -C examples/log build -b stm32u083c-dk run
```

```sh
laze -C examples/log build -s sw/threading -b stm32u083c-dk run
```

```sh
laze -C examples/log build -b espressif-esp32-c6-devkitc-1 -v run
```

Also tested in an out-of-tree application that does not use a built-in board.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
I don't think an entry is needed, as this is merely a refactor, and the `executor-none` Cargo feature wasn't documented.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
