### PR TITLE
build(espflash): introduce an `attach` laze task

### DIFF
--- a/book/src/build-system.md
+++ b/book/src/build-system.md
@@ -22,7 +22,7 @@ For example, to run the hello-world example from the `ariel-os` directory, the c
 
 Tasks available in Ariel OS include:
 
-- `run`, `flash`, `flash-dfuse`, `flash-erase-all`, `reset`: See [Flashing & Debugging][flashing-debugging-book] for flashing and debug-related tasks.
+- `run`, `flash`, `flash-dfuse`, `flash-erase-all`, `attach`, `reset`: See [Flashing & Debugging][flashing-debugging-book] and [Logging][logging-book] for flashing and logging-related tasks.
 - `debug`: Starts a GDB debug session for the selected application.
   The application needs to be flashed using the `flash` task beforehand.
 - `tree`: Prints the application's `cargo tree`.
@@ -140,3 +140,4 @@ apps:
 [laze-module-selects-book]: https://kaspar030.github.io/laze/dev/reference/module/selects.html
 [laze-module-conflicts-book]: https://kaspar030.github.io/laze/dev/reference/module/conflicts.html
 [flashing-debugging-book]: ./flashing-debugging.md
+[logging-book]: ./logging.md

--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -106,6 +106,29 @@ When `espflash` is selected at the time of compilation, `logging-over-debug-chan
 > - Other logging transports will later be supported, including UART and USB CDC-ACM on non-ESP32 devices.
 > - Using multiple transports at the same time may be supported in the future.
 
+## Fetching and Displaying the Logging Output on the Host
+
+When the [flashing][flashing-board-book] transport allows it, the `run` laze task not only flashes the board but also fetches and displays the logging output on the host.
+In addition, the `attach` laze task is available to fetch and display the logging output from an already-flashed, running target.
+Both the `run` and `attach` tasks may be [terminated by the target][closing-debug-console-book] when using [semihosting][semihosting-book].
+
+The available laze tasks are summarized in the following table:
+
+| [laze task][laze-tasks-book] | Supported          | Host tool              | [Logging transport](#logging-transports) |
+| ---------------------------- | ------------------ | ---------------------- | ---------------------------------------- |
+| `run`                        | On all chips       | probe-rs               | [Debug channel][debug-channel-book]      |
+| `run`                        | On ESP32 MCUs only | `espflash`             | USB CDC-ACM or UART                      |
+| `attach`                     | On all chips       | probe-rs               | [Debug channel][debug-channel-book]      |
+| `attach`                     | On ESP32 MCUs only | `espflash`             | USB CDC-ACM or UART                      |
+
+When multiple tasks of the same name exist, which variant is used depends on which host tool is enabled through its associated [laze module][laze-modules-book] (e.g., `probe-rs` or `espflash`).
+
+> [!NOTE]
+> Depending on the logging transport and on the [debug channel transport][debug-channel-book] used (if used as logging transport), the `attach` task may display some logs that have been issued before the task was started: this may happen when the transport uses internal buffers that are only emptied when fetched by a host tool (e.g., [RTT][rtt-book]).
+
+> [!TIP]
+> It is possible to [`flash` the board][flashing-board-book] using one host tool, before switching to another one to fetch and display the logging output (e.g., in production).
+
 [defmt]: https://github.com/knurling-rs/defmt
 [defmt documentation]: https://defmt.ferrous-systems.com/
 [log]: https://github.com/rust-lang/log
@@ -117,3 +140,8 @@ When `espflash` is selected at the time of compilation, `logging-over-debug-chan
 [debug-console-debug-console-book]: ./debug-console.md#debug-console
 [espflah-cratesio]: https://crates.io/crates/espflash
 [debug-channel-book]: ./flashing-debugging.md#debug-channel-transports
+[flashing-board-book]: ./flashing-debugging.md#flashing-a-board
+[closing-debug-console-book]: ./debug-console.md#closing-the-debug-console-from-firmware
+[semihosting-book]: ./flashing-debugging.md#semihosting
+[laze-tasks-book]: ./build-system.md#laze-tasks
+[rtt-book]: ./flashing-debugging.md#real-time-transfer-rtt

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1105,6 +1105,12 @@ modules:
     env:
       global:
         CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
+    tasks:
+      attach:
+        help: attach `espflash` to a running target
+        build: false
+        cmd:
+          - espflash monitor ${ESPFLASH_LOG_FORMAT} --elf ${out} $@
 
   - name: probe-rs
     help: use probe-rs as runner


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This introduces the missing `attach` laze task for `espflash` (there was already one for probe-rs), and documents it by introducing a section in the Logging page.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested the `attach` tasks by first modifying the `hello-world` example by adding a loop with a few iterations and delays (while keeping the `exit()` call after the bounded loop) and then using the following:

```sh
laze -C examples/hello-world build -b stm32u083c-dk flash
laze -C examples/hello-world build -b stm32u083c-dk attach
```

(The second command must be run while the aforementioned loop is still running, before `exit()` is called, otherwise the core is already locked up.)

```sh
laze -C examples/hello-world build -s logging-over-uart -b espressif-esp32-c6-devkitc-1 run
laze -C examples/hello-world build -s logging-over-uart -b espressif-esp32-c6-devkitc-1 attach
```

(The port allowing access to UART0 must be used. We have to use `run` for now as there is no `flash` task yet for these; it'll be added in a soon-to-be-opened PR. The `run` task can be interrupted after flashing is done, before using the `attach` task.)

```sh
laze -C examples/hello-world build -b espressif-esp32-c6-devkitc-1 run
laze -C examples/hello-world build -b espressif-esp32-c6-devkitc-1 attach
```

(The "USB"-labeled USB port must be used.)

```sh
laze -C examples/hello-world build -s probe-rs -b espressif-esp32-c6-devkitc-1 run
laze -C examples/hello-world build -s probe-rs -b espressif-esp32-c6-devkitc-1 attach
```

(The "USB"-labeled USB port must be used. `attach` should terminate on its own due to the call to `exit()`, however this doesn't work for me (neither does it on an ESP32-C3), while it does work with the `run` command and also when using `attach` on an ESP32-S3, so I believe this is a probe-rs bug. I'll file an issue upstream later but I don't consider this a blocker for this PR.)

```sh
laze -C examples/hello-world build -b unihiker-k10 run
laze -C examples/hello-world build -b unihiker-k10 attach
```

(Works as expected.)

```sh
laze -C examples/hello-world build -s probe-rs -b unihiker-k10 run
laze -C examples/hello-world build -s probe-rs -b unihiker-k10 attach
```

(`attach` does terminate on the ESP32-S3 due to the `exit()` call.)

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #1987

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
An `attach` laze task is now available to fetch and display the logs from a running target.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
