### PR TITLE
feat(net): allow users to implement custom networking

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1713,6 +1713,19 @@ modules:
         FEATURES:
           - ariel-os/tuntap
 
+  - name: user-net-driver-channel
+    help: Network backend is provided by the user.
+
+      While Ariel OS can not let user define an arbitrary embassy-net driver
+      (as that type needs to be named), an embassy_net_driver can be
+      implemented.
+    provides_unique:
+      - network_device
+    env:
+      global:
+        FEATURES:
+          - ariel-os/user-net-driver-channel
+
   - name: idle-threads
     help: create idle-threads to be taken when no other threads are ready
     env:

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -20,6 +20,8 @@ embassy-hal-internal = { workspace = true }
 embassy-net = { workspace = true, optional = true, features = [
   "medium-ethernet",
 ] }
+embassy-net-driver = { version = "0.2", optional = true }
+embassy-net-driver-channel = { version = "0.4", optional = true }
 embassy-sync = { workspace = true }
 embassy-time = { workspace = true, optional = true }
 embassy-time-queue-utils = { workspace = true, optional = true }
@@ -143,6 +145,8 @@ ltem-nrf-modem = [
   "net",
   "nrf91-modem",
 ]
+
+user-net-driver-channel = ["embassy-net-driver-channel", "embassy-net-driver", "embassy-net/medium-ip"]
 
 ble = [
   "dep:trouble-host",

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -121,6 +121,9 @@ cfg_select! {
     feature = "ltem-nrf-modem" => {
         use crate::hal::ltem::NetworkDevice;
     }
+    feature = "user-net-driver-channel" => {
+        type NetworkDevice = embassy_net_driver_channel::Device<'static, 1500>;
+    }
     context = "ariel-os" => {
         compile_error!("no backend for net is active");
     }
@@ -356,6 +359,8 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     let device = crate::hal::tuntap::create();
     #[cfg(feature = "ltem-nrf-modem")]
     let (device, control) = hal::ltem::init(spawner).await;
+    #[cfg(feature = "user-net-driver-channel")]
+    let device = net::user_net_device(spawner);
 
     #[cfg(feature = "net")]
     {
@@ -379,6 +384,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
             feature = "ethernet",
             feature = "tuntap",
             feature = "ltem-nrf-modem",
+            feature = "user-net-driver-channel",
         )))]
         // The creation of `device` is not organized in such a way that they could be put in a
         // cfg-if without larger refactoring; relying on unused variable lints to keep the

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -255,3 +255,51 @@ fn ariel_os_network_config() -> embassy_net::Config {
 
     config
 }
+
+#[cfg(feature = "user-net-driver-channel")]
+// FIXME: Do we need all those layers?
+static USER_NET_RUNNER: embassy_sync::once_lock::OnceLock<
+    embassy_sync::blocking_mutex::Mutex<
+        embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
+        crate::cell::SameExecutorCell<
+            core::cell::Cell<Option<embassy_net_driver_channel::Runner<'static, 1500>>>,
+        >,
+    >,
+> = embassy_sync::once_lock::OnceLock::new();
+
+/// Obtains a runner through which the user can implement the network device.
+///
+/// # Panics
+///
+/// if called more than once.
+#[cfg(feature = "user-net-driver-channel")]
+pub async fn user_net_runner() -> embassy_net_driver_channel::Runner<'static, 1500> {
+    // SAFETY: TODO(`for_current_executore()` unsoundness)
+    let spawner = unsafe { embassy_executor::Spawner::for_current_executor().await };
+    USER_NET_RUNNER
+        .get()
+        .await
+        .lock(|inner| inner.get(spawner).expect("is auto-initialized").take())
+        .expect("called twice")
+}
+
+pub(super) fn user_net_device(
+    spawner: embassy_executor::Spawner,
+) -> embassy_net_driver_channel::Device<'static, 1500> {
+    use embassy_net_driver_channel::{State, new};
+    use static_cell::StaticCell;
+    static STATE: StaticCell<State<1500, 1, 1>> = StaticCell::new();
+    let state = STATE.init_with(State::new);
+
+    let (runner, device) = new(state, embassy_net_driver::HardwareAddress::Ip);
+    if USER_NET_RUNNER
+        .init(embassy_sync::blocking_mutex::Mutex::new(
+            crate::cell::SameExecutorCell::new(Some(runner).into(), spawner),
+        ))
+        .is_err()
+    {
+        unreachable!("Run only once");
+    }
+
+    device
+}

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -101,6 +101,7 @@ coap-server-config-unprotected = [
   "ariel-os-coap/coap-server-config-unprotected",
 ]
 coap-transport-udp = ["ariel-os-coap/coap-transport-udp"]
+user-net-driver-channel = ["ariel-os-embassy/user-net-driver-channel"]
 # Forwarded features that are not even user selected, but influenced by the
 # build system that knows who provides an abort and assert handler.
 liboscore-provide-abort = ["ariel-os-coap/liboscore-provide-abort"]


### PR DESCRIPTION
# Description

Currently, applications have to use one of the provided network backends; an out-of-tree application can't just say "yeah I have an Ethernet interface, and I'll wire it up".

We can't fix that easily in general, but we can for implementations of embassy-net-driver that use embassy-net-driver-channel: For the general case we'd need to have Ariel call something from the user crate that is an impl trait, we currently even need a named type. But drivers that use the simpler/higher-level embassy-net-driver-channel just use that crate's types.

There are some limitations still -- we need to agree on the MTU (scalar features anyone?) and number of rx/tx slots, and probably also the medium. (But that we can probably get rid of, because the user can select the embassy-net/medium-\* feature, and could pass the 2nd argument to new in `user_net_device()`).

## Testing

TBD

## Issues/PRs References

This is currently how I implement networking for hophop in https://github.com/ariel-os/hophop/pull/35.

On the long run, I shouldn't need it there, for hophop can become an optional dependency of Ariel OS and then just offer a NetworkDevice type, but it's useful for experimentation, and I guess that over time, more people will want to add their network back-ends to Ariel in a low-threshold way.

## Open Questions

* Is this a good approach in the first place?
* The USER_NET_RUNNER (fortunately private) type is a mouthful.

## Changelog Entry

<!-- changelog:begin -->
TBD
<!-- changelog:end -->

## Change Checklist

- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
