### PR TITLE
chore: don't provide Nordic's LTE modem network when using DECT core

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -2110,6 +2110,8 @@ modules:
     # option, and because nrf-modem too only does the selection in one way.
     context:
       - nrf9151
+    conflicts:
+      - ltem-nrf-modem
     env:
       global:
         FEATURES:


### PR DESCRIPTION
# Description

The features are practically incompatible; the incompatibility was just not declared.

This becomes visible when trying to use #2101 which would introduce a surprising conflict (because who'd have thunk that there is already a network active?).

## Testing

* ``laze -C examples/udp-echo/ build -s nrf-radiocore-firmware-dect -b nrf9151-dk run` used to build but run into linker errors.
* now laze refuses to try.

## Issues/PRs References

Found while trying #2101

## Change Checklist

- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
