### PR TITLE
chore(examples): remove unused/changed debug-console from device-metadata

### DIFF
--- a/examples/device-metadata/laze.yml
+++ b/examples/device-metadata/laze.yml
@@ -1,7 +1,6 @@
 apps:
   - name: device-metadata
     selects:
-      - debug-console
       - ?nrf91-modem-metadata
 
 modules:


### PR DESCRIPTION
# Description

On main, device-metadata stopped building, probably somewhere around 2b2d64c9817af38f8370a252d16cdc0f244b8747.

## Testing

* `laze -C examples/device-metadata/ build  -b nrf9151-dk` used to give a laze error:

```
laze: not building binary "device-metadata" for builder "nrf9151-dk"

Caused by:
    0: "device-metadata" cannot resolve "debug-console"
    1: "debug-console" cannot resolve "logging-over-debug-channel"
    2: "logging-over-debug-channel" cannot resolve "debug-channel-transport-required"
    3: module "debug-channel-transport-required" not found
```

* now it just works

## Issues/PRs References

Probably something related to https://github.com/ariel-os/ariel-os/pull/2030, didn't dig into the details.

## Open Questions

* Why didn't build test catch this?

## Change Checklist

- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
