### PR TITLE
feat(power): provide an API to enter sleep mode in a portable manner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ version = "0.4.0"
 dependencies = [
  "cortex-m",
  "esp-hal",
+ "riscv",
 ]
 
 [[package]]
@@ -508,6 +509,7 @@ dependencies = [
  "ariel-os-debug",
  "ariel-os-log",
  "ariel-os-macros",
+ "ariel-os-power",
  "ariel-os-threads",
  "ariel-os-utils",
  "cortex-m",

--- a/src/ariel-os-power/Cargo.toml
+++ b/src/ariel-os-power/Cargo.toml
@@ -14,5 +14,8 @@ cortex-m = { workspace = true }
 [target.'cfg(context = "esp")'.dependencies]
 esp-hal = { workspace = true }
 
+[target.'cfg(context = "riscv")'.dependencies]
+riscv = { workspace = true }
+
 [lints]
 workspace = true

--- a/src/ariel-os-power/src/lib.rs
+++ b/src/ariel-os-power/src/lib.rs
@@ -2,7 +2,43 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(not(context = "native"), no_std)]
+#![cfg_attr(context = "xtensa", feature(asm_experimental_arch))]
 
 mod reset;
 
 pub use reset::*;
+
+/// Enters sleep mode.
+///
+/// In this mode, the clock of the CPU is off.
+///
+/// # Important Note
+///
+/// This is currently implemented on a best-effort basis.
+/// Some microcontrollers may not support these low-power settings, they may not be implemented
+/// yet, or they may be lacking testing.
+/// Do measure the power consumption of your hardware when relevant for your application.
+///
+/// # Wake-up conditions
+///
+/// Any interrupt usually makes the microcontroller exit this mode.
+pub fn enter_sleep_mode() {
+    #![allow(unsafe_code, reason = "used on Xtensa")]
+
+    cfg_select! {
+        context = "cortex-m" => {
+            cortex_m::asm::wfi();
+        }
+        context = "riscv" => {
+            riscv::asm::wfi();
+        }
+        context = "xtensa" => {
+            // The options are similar to those used for wfi on RISC-V and Cortex-M:
+            // the instruction does not modify memory or the stack, and does preserve flags.
+            // SAFETY: executing `waiti 0` is sound.
+            unsafe {
+                core::arch::asm!("waiti 0", options(nomem, nostack, preserves_flags));
+            }
+        }
+    }
+}

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -10,6 +10,7 @@ ariel-os-alloc = { workspace = true, optional = true }
 ariel-os-debug = { workspace = true }
 ariel-os-log = { workspace = true }
 ariel-os-macros = { path = "../ariel-os-macros", optional = true }
+ariel-os-power = { workspace = true }
 ariel-os-threads = { path = "../ariel-os-threads", optional = true }
 ariel-os-utils = { workspace = true }
 embedded-test = { workspace = true, optional = true }

--- a/src/ariel-os-rt/src/cortexm.rs
+++ b/src/ariel-os-rt/src/cortexm.rs
@@ -218,11 +218,6 @@ pub fn init() {
     }
 }
 
-#[allow(dead_code, reason = "conditional compilation")]
-pub fn wfi() {
-    cortex_m::asm::wfi();
-}
-
 /// Returns a `Stack` handle for the currently active thread.
 pub(crate) fn stack() -> crate::stack::Stack {
     #[cfg(feature = "threading")]

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -47,7 +47,6 @@ cfg_select! {
             use crate::stack::Stack;
 
             pub fn init() {}
-            pub fn wfi() {}
             pub fn sp() -> usize { 0 }
             pub fn stack() -> Stack { Stack::default() }
         }
@@ -195,7 +194,7 @@ fn startup() -> ! {
         test_main();
 
         loop {
-            arch::wfi();
+            ariel_os_power::enter_sleep_mode();
         }
     }
 }

--- a/src/ariel-os-rt/src/riscv.rs
+++ b/src/ariel-os-rt/src/riscv.rs
@@ -9,11 +9,6 @@ fn main() -> ! {
 
 pub fn init() {}
 
-#[allow(dead_code, reason = "conditional compilation")]
-pub fn wfi() {
-    riscv::asm::wfi();
-}
-
 /// Returns the current `SP` register value.
 pub(crate) fn sp() -> usize {
     let sp: usize;

--- a/src/ariel-os-rt/src/xtensa.rs
+++ b/src/ariel-os-rt/src/xtensa.rs
@@ -9,16 +9,6 @@ fn main() -> ! {
 
 pub fn init() {}
 
-#[allow(dead_code, reason = "conditional compilation")]
-pub fn wfi() {
-    // The options are similar to those used for wfi on RISC-V and Cortex-M:
-    // the instruction does not modify memory or the stack, and does preserve flags.
-    // SAFETY: executing `waiti 0` is sound.
-    unsafe {
-        core::arch::asm!("waiti 0", options(nomem, nostack, preserves_flags));
-    }
-}
-
 /// Returns the current stack pointer register value
 pub(crate) fn sp() -> usize {
     let sp: usize;


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
*This is very WIP: anything about this can still change, including the very existence of this API.*

This introduces a simple API to turn off the CPU's clock, and awake from any interrupt.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
TODO

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Related to #2077

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
