### PR TITLE
build(espflash): introduce a `reset` laze task

### DIFF
--- a/book/src/flashing-debugging.md
+++ b/book/src/flashing-debugging.md
@@ -87,6 +87,7 @@ Ariel OS provides the [laze tasks][laze-tasks-book] listed in the following tab
 | ----------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `run`             | ESP32 devices                      | Compiles, flashes, and runs an application. [Logs][logging-transports-book] (not the debug channel output) are printed in the terminal. Currently uses [`espflash`][espflah-cratesio].                                                           |
 | `flash-dfuse`     | DfuSe devices, i.e., STM32 devices | Compiles and flashes an application via DfuSe, the non-standard ST protocol based on USB DFU, before rebooting the target. Requires bootloader support for DfuSe in the microcontroller, and [dfu-util][dfu-util-homepage] on the host.          |
+| `reset`           | ESP32 devices                      | Reboots the target. Currently uses [`espflash`][espflah-cratesio].                                                                                                                                                                               |
 
 ## Debug Channel Transports
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1112,6 +1112,12 @@ modules:
         cmd:
           - espflash monitor ${ESPFLASH_LOG_FORMAT} --elf ${out} $@
 
+      reset:
+        help: reset the target
+        build: false
+        cmd:
+          - espflash reset --after hard-reset $@
+
   - name: probe-rs
     help: use probe-rs as runner
     selects:


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This introduces the missing `reset` laze task for `espflash` (there was already one for probe-rs).

## Future Work

A similar PR will follow to introduce a task for flashing only with `espflash`, but its exact name is not yet determined.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested on unihiker-k10 and espressif-esp32-c6-devkitc-1 (on both USB ports: `espflash` over UART and USB CDC-ACM).

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(ESP32) A `reset` laze task is now available to reset a connected target over UART or USB CDC-ACM.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
