### PR TITLE
refactor(logging): clean up the last occurrences of "debug output"

### DIFF
--- a/src/ariel-os-debug/src/exit.rs
+++ b/src/ariel-os-debug/src/exit.rs
@@ -29,7 +29,7 @@ impl ExitCode {
     }
 }
 
-/// Terminates the debug output session.
+/// Terminates the debug console.
 ///
 /// # Note
 ///

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -21,7 +21,7 @@ mod backend {
 
 #[cfg(feature = "rtt-target")]
 mod backend {
-    pub use rtt_target::rprintln as debug_output_println;
+    pub use rtt_target::rprintln as debug_channel_println;
 
     #[doc(hidden)]
     pub fn init() {

--- a/src/ariel-os-embassy/src/debug_uart.rs
+++ b/src/ariel-os-embassy/src/debug_uart.rs
@@ -31,9 +31,9 @@ fn write_debug_uart(buffer: &[u8]) -> Result<(), ariel_os_log::backend::Error> {
     use embedded_io_async::Write as _;
 
     embassy_futures::block_on(async {
-        // This effectively drops any debug output until the UART driver is populated.
+        // This effectively drops logs until the UART driver is populated.
         // If we instead waited on it to be set, this would deadlock when trying to print
-        // on the debug output before the driver is populated.
+        // on the logging output before the driver is populated.
         if let Some(uart) = DEBUG_UART.try_get() {
             let mut uart = uart.lock().await;
 

--- a/src/ariel-os-log/Cargo.toml
+++ b/src/ariel-os-log/Cargo.toml
@@ -56,8 +56,8 @@ esp-println = ["dep:esp-println"]
 
 # Logging transports.
 debug-uart = ["dep:embassy-sync", "logging-over-uart"]
-# `defmt-rtt` forces the logging transport to be the debug output, so it has to
-# go through this crate.
+# `defmt-rtt` uses the debug channel as the logging transport, so it has to go
+# through this crate.
 defmt-rtt = ["ariel-os-debug/defmt-rtt"]
 logging-over-uart = ["esp-println?/uart"]
 logging-over-usb = ["esp-println?/jtag-serial"]

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -80,7 +80,7 @@ pub mod log {
             feature = "std"
         ))
     ))]
-    pub use ariel_os_debug::debug_output_println as println;
+    pub use ariel_os_debug::debug_channel_println as println;
 
     #[cfg(feature = "esp-println")]
     pub use esp_println::println;
@@ -382,7 +382,7 @@ pub mod backend {
 
             if let Some(debug_uart_write_fn) = DEBUG_UART_WRITE_FN.try_get() {
                 // Panicking in this case would not be useful as (a) it is recoverable, we would
-                // just be dropping some debug output and (b) there would not be a output to print
+                // just be dropping some logs and (b) there would not be a logging output to print
                 // the panic on, as there can currently only be one backend at once.
                 let _ = debug_uart_write_fn(bytes);
             }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Follow-up to #2098, this cleans up the last occurrences of "debug output".

I've grepped for `debug.output` and `debug$`: the only remaining occurrence is in `coapcore`, where it has a more generic meaning.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Tested with:

```sh
laze -C examples/hello-world build -b stm32u083c-dk run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
