### PR TITLE
Add ESP32 persistent storage support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "embassy-sync 0.7.2",
  "embassy-time",
  "embedded-storage-async",
+ "esp-idf-part",
  "postcard",
  "sequential-storage",
  "serde",
@@ -976,6 +977,21 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "ble-advertiser"
@@ -1679,6 +1695,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,7 +1879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1922,6 +1959,31 @@ checksum = "c0f73a4a4a91609e977ae3b7bd831ffa292edfd42ad140a3244a61d805b0e05e"
 dependencies = [
  "critical-section",
  "defmt 1.1.0",
+]
+
+[[package]]
+name = "deku"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9711031e209dc1306d66985363b4397d4c7b911597580340b93c9729b55f6eb"
+dependencies = [
+ "bitvec",
+ "deku_derive",
+ "no_std_io2",
+ "rustversion",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2886,6 +2948,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-idf-part"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ebc2381d030e4e89183554c3fcd4ad44dc5ab34961ab09e09b4adbe4f94b61"
+dependencies = [
+ "bitflags 2.9.1",
+ "csv",
+ "deku",
+ "md-5",
+ "parse_int",
+ "regex",
+ "serde",
+ "serde_plain",
+ "strum",
+ "thiserror",
+]
+
+[[package]]
 name = "esp-metadata-generated"
 version = "0.3.0"
 source = "git+https://github.com/ariel-os/esp-hal?rev=531c629afdd80ea464682ce7f4db8baed97967a6#531c629afdd80ea464682ce7f4db8baed97967a6"
@@ -3416,6 +3496,12 @@ dependencies = [
  "defmt 0.3.100",
  "gcd",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -4419,6 +4505,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,6 +4586,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -4811,6 +4916,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parse_int"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c464266693329dd5a8715098c7f86e6c5fd5d985018b8318f53d9c6c2b21a31"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -5234,6 +5348,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "ral-registers"
@@ -5759,6 +5879,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6129,6 +6258,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-triple"
@@ -7119,6 +7254,15 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xtensa-lx"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,7 @@ dependencies = [
  "esp-radio",
  "esp-radio-rtos-driver",
  "esp-rom-sys",
+ "esp-storage",
  "esp-sync",
  "fugit",
  "paste",
@@ -2778,7 +2779,7 @@ dependencies = [
  "document-features",
  "embedded-storage",
  "esp-config",
- "esp-hal-procmacros",
+ "esp-hal-procmacros 0.21.0 (git+https://github.com/ariel-os/esp-hal?rev=531c629afdd80ea464682ce7f4db8baed97967a6)",
  "esp-metadata-generated",
  "esp-rom-sys",
  "jiff",
@@ -2825,7 +2826,7 @@ dependencies = [
  "embedded-io-async 0.7.0",
  "enumset",
  "esp-config",
- "esp-hal-procmacros",
+ "esp-hal-procmacros 0.21.0 (git+https://github.com/ariel-os/esp-hal?rev=531c629afdd80ea464682ce7f4db8baed97967a6)",
  "esp-metadata-generated",
  "esp-riscv-rt",
  "esp-rom-sys",
@@ -2854,6 +2855,20 @@ dependencies = [
  "ufmt-write",
  "xtensa-lx",
  "xtensa-lx-rt",
+]
+
+[[package]]
+name = "esp-hal-procmacros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e025a7a7a0affdb4ff913b5c4494aef96ee03d085bf83c27453ae3a71d50da6"
+dependencies = [
+ "document-features",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "termcolor",
 ]
 
 [[package]]
@@ -2928,7 +2943,7 @@ dependencies = [
  "esp-alloc",
  "esp-config",
  "esp-hal",
- "esp-hal-procmacros",
+ "esp-hal-procmacros 0.21.0 (git+https://github.com/ariel-os/esp-hal?rev=531c629afdd80ea464682ce7f4db8baed97967a6)",
  "esp-metadata-generated",
  "esp-phy",
  "esp-radio-rtos-driver",
@@ -2982,6 +2997,21 @@ dependencies = [
  "cfg-if",
  "document-features",
  "esp-metadata-generated",
+]
+
+[[package]]
+name = "esp-storage"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1495fc1f5549bdd840b52d9ceb201746200e1620d2636f46958c11e765623b80"
+dependencies = [
+ "document-features",
+ "embedded-storage",
+ "esp-hal",
+ "esp-hal-procmacros 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "esp-metadata-generated",
+ "esp-rom-sys",
+ "esp-sync",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ esp-radio-rtos-driver = { version = "0.2.0", default-features = false }
 esp-rom-sys = { version = "0.1.2", default-features = false }
 esp-sync = { version = "0.1.0", default-features = false }
 esp-wifi-sys = { version = "0.8.1", default-features = false }
+esp-idf-part = { version = "0.6.0"}
 
 esp-storage = { version = "0.8.0" }
 xtensa-lx-rt = { version = "0.21.0", default-features = false }

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -366,6 +366,7 @@ contexts:
       - ?espflash
     provides:
       - has_hwrng
+      - has_storage_support
     env:
       esp_wifi_heapsize_required: $(72*1024)
       RUSTFLAGS:
@@ -417,8 +418,6 @@ contexts:
 
   - name: esp32c3fx4
     parent: esp32c3
-    provides:
-      - has_storage_support
 
   - name: esp32c6
     parent: esp
@@ -428,7 +427,6 @@ contexts:
       - has_ble_esp
       - has_usb_cdc_acm
       - sw/benchmark
-      - has_storage_support
     provides_unique: [c-function-abort]
     env:
       RUSTC_TARGET: riscv32imac-unknown-none-elf
@@ -1311,17 +1309,15 @@ modules:
 
   - name: esp32-storage-partition
     context:
-      - esp32c3fx4
-      - esp32c6
+      - esp
     env:
       global:
-        ARIEL_ESP_PARTITION_TABLE: "${relroot}/${root}/src/ariel-os-esp/partitions/esp32-4m-storage-64k.csv"
         ESPFLASH_ARGS:
           - --partition-table
           - ${ARIEL_ESP_PARTITION_TABLE}
         CARGO_ENV:
-          - ESP_STORAGE_OFFSET="0x003f0000"
-          - ESP_STORAGE_SIZE="0x00010000"
+          - ARIEL_ESP_PARTITION_TABLE="$$(realpath "${ARIEL_ESP_PARTITION_TABLE}")"
+          - ARIEL_ESP_STORAGE_PARTITION=${ARIEL_ESP_STORAGE_PARTITION}
 
   - name: sw/threading
     selects:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -417,6 +417,8 @@ contexts:
 
   - name: esp32c3fx4
     parent: esp32c3
+    provides:
+      - has_storage_support
 
   - name: esp32c6
     parent: esp
@@ -426,6 +428,7 @@ contexts:
       - has_ble_esp
       - has_usb_cdc_acm
       - sw/benchmark
+      - has_storage_support
     provides_unique: [c-function-abort]
     env:
       RUSTC_TARGET: riscv32imac-unknown-none-elf
@@ -1104,7 +1107,8 @@ modules:
       - flashing-tool
     env:
       global:
-        CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
+        ESPFLASH_ARGS: []
+        CARGO_RUNNER: '"espflash flash ${ESPFLASH_ARGS} --monitor ${ESPFLASH_LOG_FORMAT}"'
     tasks:
       attach:
         help: attach `espflash` to a running target
@@ -1293,6 +1297,7 @@ modules:
   - name: sw/storage
     selects:
       - has_storage_support
+      - ?esp32-storage-partition
     env:
       global:
         FEATURES:
@@ -1303,6 +1308,20 @@ modules:
   - name: has_storage_support
     selects:
       - doc-only
+
+  - name: esp32-storage-partition
+    context:
+      - esp32c3fx4
+      - esp32c6
+    env:
+      global:
+        ARIEL_ESP_PARTITION_TABLE: "${relroot}/${root}/src/ariel-os-esp/partitions/esp32-4m-storage-64k.csv"
+        ESPFLASH_ARGS:
+          - --partition-table
+          - ${ARIEL_ESP_PARTITION_TABLE}
+        CARGO_ENV:
+          - ESP_STORAGE_OFFSET="0x003f0000"
+          - ESP_STORAGE_SIZE="0x00010000"
 
   - name: sw/threading
     selects:

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -57,6 +57,7 @@ esp-hal = { workspace = true, features = ["esp32"] }
 esp-radio = { workspace = true, default-features = false, features = [
   "esp32",
 ], optional = true }
+esp-storage = { workspace = true, optional = true, features = ["esp32"] }
 esp-sync = { workspace = true, optional = true, features = ["esp32"] }
 
 [target.'cfg(context = "esp32c3")'.dependencies]
@@ -83,6 +84,7 @@ esp-hal = { workspace = true, features = ["esp32s2"] }
 esp-radio = { workspace = true, default-features = false, features = [
   "esp32s2",
 ], optional = true }
+esp-storage = { workspace = true, optional = true, features = ["esp32s2"] }
 esp-sync = { workspace = true, optional = true, features = ["esp32s2"] }
 
 [target.'cfg(context = "esp32s3")'.dependencies]
@@ -91,6 +93,7 @@ esp-hal = { workspace = true, features = ["esp32s3"] }
 esp-radio = { workspace = true, default-features = false, features = [
   "esp32s3",
 ], optional = true }
+esp-storage = { workspace = true, optional = true, features = ["esp32s3"] }
 esp-sync = { workspace = true, optional = true, features = ["esp32s3"] }
 
 [features]

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -40,6 +40,7 @@ esp-radio-rtos-driver = { workspace = true, default-features = false, features =
   "ipc-implementations",
 ], optional = true }
 esp-rom-sys = { workspace = true }
+esp-storage = { workspace = true, optional = true }
 esp-sync = { workspace = true, optional = true }
 fugit = { workspace = true, optional = true }
 paste = { workspace = true }
@@ -64,6 +65,7 @@ esp-hal = { workspace = true, features = ["esp32c3"] }
 esp-radio = { workspace = true, default-features = false, features = [
   "esp32c3",
 ], optional = true }
+esp-storage = { workspace = true, optional = true, features = ["esp32c3"] }
 esp-sync = { workspace = true, optional = true, features = ["esp32c3"] }
 
 [target.'cfg(context = "esp32c6")'.dependencies]
@@ -72,6 +74,7 @@ esp-hal = { workspace = true, features = ["esp32c6"] }
 esp-radio = { workspace = true, default-features = false, features = [
   "esp32c6",
 ], optional = true }
+esp-storage = { workspace = true, optional = true, features = ["esp32c6"] }
 esp-sync = { workspace = true, optional = true, features = ["esp32c6"] }
 
 [target.'cfg(context = "esp32s2")'.dependencies]
@@ -176,6 +179,9 @@ _radio-esp = [
   "esp-radio?/esp-alloc",
   "time",
 ]
+
+## Enables storage support
+storage = ["dep:esp-storage", "dep:embassy-embedded-hal"]
 
 #! ## Executor type selection for the (autostarted) main executor
 #! Exactly one of the features below must be enabled at once.

--- a/src/ariel-os-esp/partitions/esp32-4m-storage-64k.csv
+++ b/src/ariel-os-esp/partitions/esp32-4m-storage-64k.csv
@@ -1,0 +1,5 @@
+# Name,       Type, SubType, Offset,    Size,     Flags
+nvs,          data, nvs,     0x9000,    0x6000,
+phy_init,     data, phy,     0xf000,    0x1000,
+factory,      app,  factory, 0x10000,   0x3e0000,
+ariel_store,  0x40, 0x00,    0x3f0000,  0x10000,

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -58,6 +58,10 @@ pub mod usb;
 #[doc(hidden)]
 pub mod wifi;
 
+#[cfg(feature = "storage")]
+#[doc(hidden)]
+pub mod storage;
+
 #[doc(hidden)]
 pub mod peripheral {}
 

--- a/src/ariel-os-esp/src/storage.rs
+++ b/src/ariel-os-esp/src/storage.rs
@@ -1,0 +1,10 @@
+use embassy_embedded_hal::adapter::BlockingAsync;
+use esp_storage::FlashStorage;
+
+pub type Flash = BlockingAsync<FlashStorage<'static>>;
+pub type FlashError = esp_storage::FlashStorageError;
+
+pub fn init(peripherals: &mut crate::OptionalPeripherals) -> Flash {
+    let flash = FlashStorage::new(peripherals.FLASH.take().unwrap());
+    BlockingAsync::new(flash)
+}

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -127,7 +127,7 @@ hwrng = [
 ]
 
 storage = [
-  #"ariel-os-esp/storage",
+  "ariel-os-esp/storage",
   "ariel-os-nrf/storage",
   "ariel-os-rp/storage",
   "ariel-os-stm32/storage",

--- a/src/ariel-os-storage/Cargo.toml
+++ b/src/ariel-os-storage/Cargo.toml
@@ -19,5 +19,8 @@ serde = { workspace = true, default-features = false }
 [target.'cfg(context = "rp")'.dependencies]
 embassy-time = { workspace = true, default-features = false }
 
+[build-dependencies]
+esp-idf-part = { workspace = true }
+
 [lints]
 workspace = true

--- a/src/ariel-os-storage/build.rs
+++ b/src/ariel-os-storage/build.rs
@@ -7,6 +7,53 @@ fn main() {
     // Important: only homogeneous flash organizations are currently supported.
     // Trying to restrict the storage size to the subset of homogeneous flash would not work as it
     // could be pushed out of it by a large enough binary.
+
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    if is_in_current_contexts(&["esp"]) {
+        let offset = env::var("ESP_STORAGE_OFFSET");
+        let storage_size = env::var("ESP_STORAGE_SIZE");
+
+        let (offset, size) = match (offset, storage_size) {
+            (Ok(offset), Ok(storage_size)) => (offset, storage_size),
+            (Err(_), Err(_)) => panic!(
+                "ESP storage support was selected, but ESP_STORAGE_OFFSET and\
+                ESP_STORAGE_SIZE are not set. Is the ESP storage partition\
+                module missing from laze?"
+            ),
+            _ => panic!(
+                "ESP storage support was selected, but one of ESP_STORAGE_OFFSET or ESP_STORAGE_SIZE is not set."
+            ),
+        };
+
+        let storage_offset =
+            u32::from_str_radix(offset.trim_start_matches("0x").trim_start_matches("0X"), 16)
+                .expect("Invalid ESP_STORAGE_OFFSET env var");
+
+        let storage_size =
+            u32::from_str_radix(size.trim_start_matches("0x").trim_start_matches("0X"), 16)
+                .expect("Invalid ESP_STORAGE_SIZE env var");
+
+        let storage_end = storage_offset
+            .checked_add(storage_size)
+            .expect("ESP storage range overflows u32");
+
+        let storage_x = format!(
+            "\
+            PROVIDE(__storage_start = 0x{storage_offset:08x});
+            PROVIDE(__storage_end   = 0x{storage_end:08x});
+            "
+        );
+
+        std::fs::write(out.join("storage.x"), storage_x).unwrap();
+
+        println!("cargo:rerun-if-env-changed=CARGO_CFG_CONTEXT");
+        println!("cargo:rerun-if-env-changed=ESP_STORAGE_OFFSET");
+        println!("cargo:rerun-if-env-changed=ESP_STORAGE_SIZE");
+        println!("cargo:rustc-link-search={}", out.display());
+        return;
+    }
+
     let (storage_size_total, flash_page_size) = if is_in_current_contexts(&[
         "stm32f303cb",
         "stm32f303re",
@@ -32,9 +79,6 @@ fn main() {
 
     // `sequential-storage` needs at least two flash pages.
     assert!(storage_size_total / flash_page_size >= 2);
-
-    // Put the linker script somewhere the linker can find it
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
     let mut storage_template = std::fs::read_to_string("storage.ld.in").unwrap();
     storage_template = storage_template.replace("${ALIGNMENT}", &format!("{flash_page_size}"));

--- a/src/ariel-os-storage/build.rs
+++ b/src/ariel-os-storage/build.rs
@@ -1,4 +1,7 @@
-use std::{env, path::PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 const KIBIBYTES: u32 = 1024;
 
@@ -7,50 +10,10 @@ fn main() {
     // Important: only homogeneous flash organizations are currently supported.
     // Trying to restrict the storage size to the subset of homogeneous flash would not work as it
     // could be pushed out of it by a large enough binary.
-
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
     if is_in_current_contexts(&["esp"]) {
-        let offset = env::var("ESP_STORAGE_OFFSET");
-        let storage_size = env::var("ESP_STORAGE_SIZE");
-
-        let (offset, size) = match (offset, storage_size) {
-            (Ok(offset), Ok(storage_size)) => (offset, storage_size),
-            (Err(_), Err(_)) => panic!(
-                "ESP storage support was selected, but ESP_STORAGE_OFFSET and\
-                ESP_STORAGE_SIZE are not set. Is the ESP storage partition\
-                module missing from laze?"
-            ),
-            _ => panic!(
-                "ESP storage support was selected, but one of ESP_STORAGE_OFFSET or ESP_STORAGE_SIZE is not set."
-            ),
-        };
-
-        let storage_offset =
-            u32::from_str_radix(offset.trim_start_matches("0x").trim_start_matches("0X"), 16)
-                .expect("Invalid ESP_STORAGE_OFFSET env var");
-
-        let storage_size =
-            u32::from_str_radix(size.trim_start_matches("0x").trim_start_matches("0X"), 16)
-                .expect("Invalid ESP_STORAGE_SIZE env var");
-
-        let storage_end = storage_offset
-            .checked_add(storage_size)
-            .expect("ESP storage range overflows u32");
-
-        let storage_x = format!(
-            "\
-            PROVIDE(__storage_start = 0x{storage_offset:08x});
-            PROVIDE(__storage_end   = 0x{storage_end:08x});
-            "
-        );
-
-        std::fs::write(out.join("storage.x"), storage_x).unwrap();
-
-        println!("cargo:rerun-if-env-changed=CARGO_CFG_CONTEXT");
-        println!("cargo:rerun-if-env-changed=ESP_STORAGE_OFFSET");
-        println!("cargo:rerun-if-env-changed=ESP_STORAGE_SIZE");
-        println!("cargo:rustc-link-search={}", out.display());
+        emit_esp_storage_symbols(&out);
         return;
     }
 
@@ -88,6 +51,80 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed=CARGO_CFG_CONTEXT");
     println!("cargo:rerun-if-changed=storage.ld.in");
+    println!("cargo:rustc-link-search={}", out.display());
+}
+
+fn emit_esp_storage_symbols(out: &Path) {
+    const MISSING_ESP_PARTITION_TABLE_HINT: &str = concat!(
+        "ESP storage is enabled, but no ESP partition table was configured.\n",
+        "\n",
+        "Add a partition table CSV to your application and point ESP_PARTITION_TABLE ",
+        "at it from your application's laze-project.yml:\n",
+        "\n",
+        "env:\n",
+        "  global:\n",
+        "    ESP_PARTITION_TABLE: \"./esp32.csv\"\n",
+        "\n",
+        "The build system resolves this path and passes it to Cargo as ",
+        "ARIEL_ESP_PARTITION_TABLE. The table must contain the storage partition ",
+        "configured by ARIEL_ESP_STORAGE_PARTITION; the default name is `ariel_store`."
+    );
+    const ESP_FLASH_SECTOR_SIZE: u32 = 4096;
+
+    let partition_table = std::env::var("ARIEL_ESP_PARTITION_TABLE")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| panic!("{MISSING_ESP_PARTITION_TABLE_HINT}"));
+
+    let partition_name = std::env::var("ARIEL_ESP_STORAGE_PARTITION")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "ariel_store".to_owned());
+
+    let csv = std::fs::read_to_string(&partition_table).unwrap_or_else(|err| {
+        panic!("failed to read ESP partition table `{partition_table}`: {err}")
+    });
+
+    let table = esp_idf_part::PartitionTable::try_from_str(&csv).unwrap_or_else(|err| {
+        panic!("failed to read ESP partition table `{partition_table}`: {err}")
+    });
+
+    let part = table.find(&partition_name).unwrap_or_else(|| {
+        panic!("failed to find ESP storage partition `{partition_name}` in `{partition_table}`")
+    });
+
+    let storage_start = part.offset();
+    let storage_size = part.size();
+    let storage_end = storage_start
+        .checked_add(storage_size)
+        .expect("ESP storage partition range overflows u32");
+
+    assert!(
+        storage_start.is_multiple_of(ESP_FLASH_SECTOR_SIZE),
+        "ESP storage partition `{partition_name}` offset 0x{storage_start:08x} is not sector-aligned"
+    );
+    assert!(
+        storage_size.is_multiple_of(ESP_FLASH_SECTOR_SIZE),
+        "ESP storage partition `{partition_name}` size 0x{storage_size:08x} is not sector-aligned"
+    );
+    assert!(
+        storage_size >= 2 * ESP_FLASH_SECTOR_SIZE,
+        "ESP storage partition `{partition_name}` must be at least two flash sectors"
+    );
+
+    let storage_x = format!(
+        "\
+        PROVIDE(__storage_start = 0x{storage_start:08x});
+        PROVIDE(__storage_end   = 0x{storage_end:08x});
+        "
+    );
+
+    std::fs::write(out.join("storage.x"), storage_x).unwrap();
+
+    println!("cargo:rerun-if-env-changed=ARIEL_ESP_PARTITION_TABLE");
+    println!("cargo:rerun-if-env-changed=ARIEL_ESP_STORAGE_PARTITION");
+    println!("cargo:rerun-if-changed={partition_table}");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_CONTEXT");
     println!("cargo:rustc-link-search={}", out.display());
 }
 

--- a/src/ariel-os-storage/src/lib.rs
+++ b/src/ariel-os-storage/src/lib.rs
@@ -46,6 +46,8 @@ fn flash_range_from_linker() -> Range<u32> {
     const OFFSET: usize = 0x1000_0000;
     #[cfg(context = "stm32")]
     const OFFSET: usize = 0x0800_0000;
+    #[cfg(context = "esp")]
+    const OFFSET: usize = 0;
     // Default for platform-independent tooling.
     #[cfg(not(context = "ariel-os"))]
     const OFFSET: usize = 0x0;


### PR DESCRIPTION
# Description

This draft adds Persistent Storage support for ESP32-based Ariel OS targets.

The implementation wires `ariel-os-storage` into the ESP HAL backend using `esp-storage`, and provides an ESP partition table with a dedicated `ariel_store` flash partition.

The storage area is represented as an explicit ESP flash partition instead of a linker-reserved section inside the app partition. This makes the flash layout visible to the ESP tooling and should cause flashing to fail if the application image no longer fits into its app partition.

For now, applications that enable storage on ESP need to provide their own ESP partition table. The configured table is passed both to `espflash` and to the `ariel-os-storage` build script. The build script parses the table, looks up the configured storage partition, validates it, and emits the `__storage_start`/`__storage_end` linker symbols from that partition.

The default storage partition name is `ariel_store` and can be overridden through `ARIEL_ESP_STORAGE_PARTITION`.

Since the partition table is now application-provided, this PR no longer relies on a single default flash layout. Storage support is therefore enabled for all ESP MCUs, with the concrete flash layout left to the application.

## Testing

I have successfully tested it using the storage example on:

- ESP32-C3 with 4 MB flash
- ESP32-C6 with 4 MB flash

## Issues/PRs References

## Open Questions

This PR now avoids selecting a default ESP flash layout by requiring applications to provide a partition table with a named storage partition.

The remaining interface question is how this should fit with the partitioning work tracked in #639.

Feedback would be very welcome.

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
