### PR TITLE
fix(debug-console): only select a transport when logging is enabled

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -505,8 +505,9 @@ contexts:
     parent: ariel-os
     selects:
       - infini-core
+      # NOTE: semantically this should only be enabled when `logging` is
+      # enabled, but laze does not support conditions on contexts.
       - logging-over-stdout
-      - ?debug-console
     provides:
       - has_device_identity
       - has_hwrng
@@ -1812,16 +1813,13 @@ modules:
     help: enable support for the debug console
     context: ariel-os
     selects:
-      # Mandatory.
-      - logging-over-debug-channel
+      - logging:
+          # Mandatory when logging is otherwise enabled.
+          - logging-over-debug-channel
       # Optional for now, at least until multiple logging transports can be used
       # at the same time: allows using semihosting while a logging transport
       # other than `logging-over-debug-channel` is used.
       - ?semihosting
-    env:
-      global:
-        FEATURES:
-          - ariel-os/debug-channel
 
   - name: logging
     help: enables logging functionality
@@ -1856,6 +1854,10 @@ modules:
           - debug-channel-transport-required
     provides_unique:
       - logging-transport
+    env:
+      global:
+        FEATURES:
+          - ariel-os/debug-channel
 
   # Disabled by modules that provide a `debug-channel-transport`.
   - name: no-debug-channel-transport


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This fixes a bad interaction between the `logging` and `debug-console` laze modules, which was already present in the refactor from #2030 (specifically https://github.com/ariel-os/ariel-os/pull/2030/changes/2b2d64c9817af38f8370a252d16cdc0f244b8747), but has only been surfaced by #2074: trying to compile with the following command on main:

```sh
laze -C examples/hello-world/ build -d logging -b stm32u083c-dk
```

would result in the following (legitimate) featurecomb error:

```sh
error: feature `debug-channel` requires that some features from feature group `debug-channel` be enabled.
       Candidate features: `defmt-rtt`, `rtt-target`
 --> src/ariel-os-debug/src/lib.rs:7:1
  |
7 | #[featurecomb::comb]
  | ^^^^^^^^^^^^^^^^^^^^
  |
```

This is because the `debug-console` laze module still selects the `logging-over-debug-channel` laze module even if `logging` is disabled (e.g., on the CLI). Because no logging *facade* gets selected when `logging` is disabled, no RTT implementation gets enabled by the `debug-channel-rtt` laze module:

https://github.com/ariel-os/ariel-os/blob/bddd93f81a61c000cdbfa71a6241fd97d8e7ee46/laze-project.yml#L1864-L1873

When that happens, featurecomb errors out (as expected), as `ariel-os-debug`'s `debug-channel` Cargo feature *requires* an RTT implementation be selected.

This PR fixes this by:

- Making the `debug-console` laze module only enable `logging-over-debug-channel` when `logging` is selected.
- Making the `logging-over-debug-channel` laze module enable the `ariel-os/debug-channel` Cargo feature, instead of having the `debug-console` laze module enabling that Cargo feature (which just made little sense).
- Making the `native-chip` context not select `debug-console` as that apparently prevents a logging facade from being selected, thus breaking the logging macros. Logging is still enabled by default as per the "global" optional selection of the `logging` module.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
See #2030 for the testing procedure: only the parts about `stm32u083c-dk` and `native` are relevant.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
