### PR TITLE
refactor(hal): unify define_peripherals!()

### DIFF
--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -13,7 +13,6 @@
 ///
 // Inspired by https://github.com/adamgreig/assign-resources/tree/94ad10e2729afdf0fd5a77cd12e68409a982f58a
 // under MIT license
-#[cfg(not(context = "esp"))]
 #[macro_export]
 macro_rules! define_peripherals {
     (
@@ -31,8 +30,8 @@ macro_rules! define_peripherals {
         pub struct $peripherals {
             $(
                 $(#[$inner])*
-                pub $peripheral_name: $crate::hal::peripheral::Peri<'static, peripherals::$peripheral_field>
-            ),*
+                pub $peripheral_name: $crate::__peripheral_ty!($peripheral_field),
+            )*
         }
 
         $($(
@@ -53,46 +52,30 @@ macro_rules! define_peripherals {
     }
 }
 
-// This is almost identical to the version above, only the line that contains `Peri` is different.
-// TODO: unify
+// This helper macro creates a peripheral type from its name.
+// We need two variants: one for embassy hal `Peri`, one for the esp-hal style peripheral
+// singletons.
+// This is split out of `define_peripherals` so the gating on `esp` is done at definition time in
+// this crate, and not at usage time, as that would make all crates using `define_peripherals` need
+// to add a check-cfg for `esp`.
+// These macros are not importable from applications as they are not part of the re-exported
+// `ariel_os_hal::api`.
+#[cfg(not(context = "esp"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __peripheral_ty {
+    ($field:ident) => {
+        $crate::hal::peripheral::Peri<'static, peripherals::$field>
+    };
+}
+
 #[cfg(context = "esp")]
 #[macro_export]
-macro_rules! define_peripherals {
-    (
-        $(#[$outer:meta])*
-        $peripherals:ident {
-            $(
-                $(#[$inner:meta])*
-                $peripheral_name:ident : $peripheral_field:ident $(=$peripheral_alias:ident)?
-            ),*
-            $(,)?
-        }
-    ) => {
-        #[allow(dead_code,non_snake_case)]
-        $(#[$outer])*
-        pub struct $peripherals {
-            $(
-                $(#[$inner])*
-                pub $peripheral_name: peripherals::$peripheral_field<'static>
-            ),*
-        }
-
-        $($(
-            #[allow(missing_docs, non_camel_case_types)]
-            pub type $peripheral_alias = peripherals::$peripheral_field;
-        )?)*
-
-        impl $crate::hal::TakePeripherals<$peripherals> for &mut $crate::hal::OptionalPeripherals {
-            fn take_peripherals(&mut self) -> $peripherals {
-                $peripherals {
-                    $(
-                        $(#[$inner])*
-                        $peripheral_name: self.$peripheral_field.take().unwrap()
-                    ),*
-                }
-            }
-        }
-    }
+#[doc(hidden)]
+macro_rules! __peripheral_ty {
+    ($field:ident) => {
+        peripherals::$field<'static>
+    };
 }
 
 /// This macro allows to group peripheral structs defined with


### PR DESCRIPTION
# Description

`define_peripherals!()` had two copies only differing in one line since #1328.

I realized we'll need a fix also for the UART integration, so this is chopped out from that work.

## Testing

I sanity checked this with `examples/blinky` on `nrf52840dk`, and `examples/gpio` on the `espressif-esp32-c6-devkitc-1` (modified to not need leds), so both basic paths (esp and non-esp) are working.

Getting this to compile was fiddly macro language stuff. Now that it does I'm positive compile-testing is sufficient.

## Issues/PRs References

Fixing a TODO introduced in #1328.


<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
