### PR TITLE
feat(net): enable SLAAC

### DIFF
--- a/book/src/networking.md
+++ b/book/src/networking.md
@@ -80,7 +80,7 @@ The configuration can be customized with the following environment variables:
 Support for IPv6 is not currently enabled by default, but can be enabled by selecting the `ipv6` [laze module](./build-system.md#laze-modules).
 IPv4 and IPv6 can both be enabled at the same time.
 
-IPv6 currently only supports static configuration, which is therefore enabled by default; it can also be explicitly selected with the `network-config-ipv6-static` [laze module](./build-system.md#laze-modules).
+IPv6 currently mainly supports static configuration, which is therefore enabled by default; it can also be explicitly selected with the `network-config-ipv6-static` [laze module](./build-system.md#laze-modules).
 
 The configuration must be customized with the following environment variables:
 
@@ -90,8 +90,12 @@ The configuration must be customized with the following environment variables:
 | `CONFIG_NET_IPV6_STATIC_CIDR_PREFIX_LEN` | `64`                        |
 | `CONFIG_NET_IPV6_STATIC_GATEWAY_ADDRESS` | *No default, but mandatory* |
 
-> [!NOTE]
-> Non-static IPv6 address allocation will be supported in the future.
+There is experimental support for IPv6 configuration through SLAAC,
+which can be enabled using the `network-config-ipv6-slaac` [laze module].
+It is experimental due to shortcomings of the implementation (around DNS and privacy),
+and lack of documentation.
+Once the [associated issues](https://github.com/ariel-os/ariel-os/issues/2135) are resolved,
+it will become the default configuration for IPv6.
 
 #### Custom Configuration Provider
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1282,6 +1282,17 @@ modules:
         FEATURES:
           - ariel-os/network-config-ipv6-static
 
+  - name: network-config-ipv6-slaac
+    help: use SLAAC for IPv6 network configuration
+    selects:
+      - ipv6
+    provides_unique:
+      - network-config-ipv6
+    env:
+      global:
+        FEATURES:
+          - ariel-os/network-config-ipv6-slaac
+
   - name: ipv6
     selects:
       - network

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -189,6 +189,7 @@ timer-generic-queue-64 = ["embassy-time?/generic-queue-64"]
 timer-generic-queue-128 = ["embassy-time?/generic-queue-128"]
 
 network-config-ipv4-static = []
+network-config-ipv6-slaac = ["embassy-net/slaac"]
 network-config-ipv6-static = []
 network-config-override = []
 override-usb-config = []

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -253,5 +253,10 @@ fn ariel_os_network_config() -> embassy_net::Config {
         });
     }
 
+    #[cfg(feature = "network-config-ipv6-slaac")]
+    {
+        config.ipv6 = embassy_net::ConfigV6::Slaac;
+    }
+
     config
 }

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -109,6 +109,8 @@ liboscore-provide-assert = ["ariel-os-coap/liboscore-provide-assert"]
 network-config-ipv4-static = ["ariel-os-embassy/network-config-ipv4-static"]
 # Selects static IPv6 configuration.
 network-config-ipv6-static = ["ariel-os-embassy/network-config-ipv6-static"]
+# Selects SLAAC based IPv6 configuration.
+network-config-ipv6-slaac = ["ariel-os-embassy/network-config-ipv6-slaac"]
 
 #! ## Serial communication
 ## Enables I2C support.


### PR DESCRIPTION
# Description

Our IPv6 story was previously static-only (that's not how it's supposed to be used), but @bergzand has driven updates all the way through smoltcp and embassy-net, and now it's there.

## Testing

[edit, added:]

* Pick any networking example.
* Be on a network where there are IPv6 prefixes being announced.
* Run with `-s network-config-ipv6-slaac`.
* Run the example's connection on the printed address, or a link-local address discovered by a ping to `ff02::1%yourinterface`.

## Issues/PRs References

Builds-on: https://github.com/ariel-os/ariel-os/pull/2125
Closes: https://github.com/ariel-os/ariel-os/issues/501

## Open Questions

* Users who don't have v6 networks or who are on a link where upstream doesn't offer PD (eg. when your router has no prefixes to give out and you're on a routed connection from your PC via USB Ethernet) will need to know their device's link-local addresses, as those are well usable, but can't easily find them because
  - there is no user-facing API in embassy-net to read the LL address, and
  - <del>ping responses are off by default so users can't just `ping ff02::1%ethusb0`</del> [edit: they can use that but it makes ugly READMEs]

## Changelog Entry

<!-- changelog:begin -->
* SLAAC for configuring IPv6 addresses is now available as preview; it can be enabled using the newly introduced `network-config-ipv6-slaac`.
<!-- changelog:end -->

## Change Checklist

- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
