### PR TITLE
fix(build-nrf): change dependency pattern

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -235,7 +235,7 @@ contexts:
     selects:
       - cortex-m4f
     provides:
-      - has_nrf_ble
+      - has_ble_nrf
     env:
       PROBE_RS_CHIP: nrf52832_xxAA
 
@@ -244,7 +244,7 @@ contexts:
     selects:
       - cortex-m4f
     provides:
-      - has_nrf_ble
+      - has_ble_nrf
     env:
       PROBE_RS_CHIP: nrf52833_xxAA
 
@@ -253,7 +253,7 @@ contexts:
     selects:
       - cortex-m4f
     provides:
-      - has_nrf_ble
+      - has_ble_nrf
     env:
       PROBE_RS_CHIP: nrf52840_xxAA
 
@@ -275,7 +275,7 @@ contexts:
       - cortex-m33
     provides:
       - has_hwrng
-      - has_nrf_ble
+      - has_ble_nrf
       # Currently hard-faults.
       # - has_storage_support
     disables:
@@ -1411,14 +1411,16 @@ modules:
     selects:
       - doc_only
 
-  - name: has_nrf_ble
-    context:
-      - nrf52
-      - nrf53
+  - name: ble-nrf
     selects:
+      - has_ble_nrf
       - hwrng
     provides:
       - has_ble
+
+  - name: has_ble_nrf
+    selects:
+      - doc_only
 
   - name: ble-peripheral
     help: Enables BLE peripheral functionality


### PR DESCRIPTION
# Description

This changes the dependency pattern in laze to ensure the hardware really has BLE capabilities. Previously nrf5340-app couldn't be selected because it didn't have an HWRNG, but adding an HWRNG makes it selectable when it shouldn't.

<!-- A summary of your changes and why you made them. -->

## Testing

Better tested in #1804 : 


Laze should refuse to build 
```
laze build -b nordic-thingy-91-x-nrf5340-app -C examples/ble-advertiser/  
```

And still be able to build 
```
laze build -b nordic-thingy-91-x-nrf5340-net -C examples/ble-advertiser/  
```


<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Fixed the dependency selection logic for BLE on nRF.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
