### PR TITLE
chore(committed): allow `revert` commit type

### DIFF
--- a/committed.toml
+++ b/committed.toml
@@ -12,6 +12,7 @@ allowed_types = [
   "feat",
   "perf",
   "refactor",
+  "revert",
   "style",
   "test",
 ]


### PR DESCRIPTION
# Description

`revert` is one of the types recommended by the conventional commit specification[1].

[1]: https://www.conventionalcommits.org/en/v1.0.0/#how-does-conventional-commits-handle-revert-commits

## Testing

It so happens that I have a PR that tests this: https://github.com/ariel-os/ariel-os/pull/2125

## Change Checklist

- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
