### PR TITLE
fix(esp): rely on `espflash`'s detection of the log format from the ELF

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1105,7 +1105,7 @@ modules:
       - flashing-tool
     env:
       global:
-        CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
+        CARGO_RUNNER: '"espflash flash --monitor"'
     tasks:
       flash:
         help: flash the target using `espflash`
@@ -1116,7 +1116,7 @@ modules:
         help: attach `espflash` to a running target
         build: false
         cmd:
-          - espflash monitor ${ESPFLASH_LOG_FORMAT} --elf ${out} $@
+          - espflash monitor --elf ${out} $@
 
       reset:
         help: reset the target
@@ -1977,7 +1977,6 @@ modules:
           - ariel-os/defmt
         RUSTFLAGS:
           - -Clink-arg=-Tdefmt.x
-        ESPFLASH_LOG_FORMAT: "--log-format defmt"
         CARGO_ENV:
           - DEFMT_LOG=info,${LOG}
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This removes the explicit configuration of the log format based on the enabled log facade laze module (`defmt` or `log`) of `espflash`, and instead makes it rely on the auto-detection of the log format as written into the ELF by [`esp-println@0.14.0`](
https://github.com/esp-rs/esp-hal/blob/b412755f8514720d1789005b569e9261311b105c/esp-println/CHANGELOG.md#v0140---2025-06-03) and supported by [`espflash@4.0.0`](https://github.com/esp-rs/espflash/blob/bd32b852e57fa531e37f71c61ef3a76cc9cd89a4/CHANGELOG.md#400---2025-07-01). On top of simplifying the configuration a bit, this fixes a potential issue when using the `attach` task *without* passing `-s log` when the binary was compiled with `-s log` (see the testing section below).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

Previously the following would fail

```sh
laze -C examples/hello-world build -s log -b espressif-esp32-c6-devkitc-1 flash
laze -C examples/hello-world build -b espressif-esp32-c6-devkitc-1 attach
```

with the following error message:

```sh
Error: espflash::monitor::defmt::no_defmt

  × No defmt data was found in the elf file
```

This now works because the fact that `defmt` is *not* used is now detected from the ELF itself.

The following (which uses `defmt`) of course still works:

```sh
laze -C examples/hello-world build -b espressif-esp32-c6-devkitc-1 run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(ESP32) `espflash` is now configured to rely on its auto-detection of the log format (whether `defmt` is used) from metadata written into the ELF. Previously the expected log format was based on the log facade laze module (`defmt` or `log`) selected in the command printing logs.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash