### PR TITLE
fix(embassy): enable `defmt` feature in executor as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,7 @@ checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
 dependencies = [
  "cortex-m",
  "critical-section",
+ "defmt 1.1.0",
  "document-features",
  "embassy-executor-macros",
  "embassy-executor-timer-queue",

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -203,6 +203,7 @@ no-boards = []
 defmt = [
   "ariel-os-embassy-common/defmt",
   "ariel-os-hal/defmt",
+  "embassy-executor/defmt",
   "embassy-net?/defmt",
   "embassy-time?/defmt",
   "embassy-usb?/defmt",


### PR DESCRIPTION


# Description

Otherwise one gets the error message

> the trait bound `SpawnError: Format` is not satisfied

when trying to write code like

```rust
match spawner.spawn(my_task()) {
    Ok(_) => {}
    Err(msg) => {
        warn!("Failed to spawn task: {}", msg);
    }
};
````

## Testing

I tested this in my personal Ariel OS application project.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

Are there other crates we should pass the `defmt` flag to?

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The `defmt` Cargo feature is now enabled on the underlying executor crate when `defmt` is enabled on Ariel OS.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
