### PR TITLE
feat: Add support for memory protection unit for Armv8-M based microcontrollers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,8 @@ xtensa-lx-rt = { version = "0.21.0", default-features = false }
 
 linkme = { version = "0.3.32" }
 
+bitflags = { version = "2.13.0" }
+
 ariel-os = { path = "src/ariel-os", default-features = false }
 ariel-os-alloc = { path = "src/ariel-os-alloc", default-features = false }
 ariel-os-bench = { path = "src/ariel-os-bench", default-features = false }
@@ -150,6 +152,7 @@ ariel-os-stm32 = { path = "src/ariel-os-stm32" }
 ariel-os-storage = { path = "src/ariel-os-storage" }
 ariel-os-threads = { path = "src/ariel-os-threads" }
 ariel-os-utils = { path = "src/ariel-os-utils", default-features = false }
+ariel-os-mpu = { path = "src/ariel-os-mpu"}
 
 # Built-in sensor drivers.
 ariel-os-sensor-aht20 = { path = "src/sensors/ariel-os-sensor-aht20" }

--- a/src/ariel-os-mpu/Cargo.toml
+++ b/src/ariel-os-mpu/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ariel-os-mpu"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+bitflags.workspace = true
+cfg-if.workspace = true
+critical-section.workspace = true
+ariel-os-debug.workspace = true
+ariel-os-utils = { workspace = true }
+
+[target.'cfg(context = "cortex-m")'.dependencies]
+cortex-m = { workspace = true }

--- a/src/ariel-os-mpu/laze.yml
+++ b/src/ariel-os-mpu/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-mpu
+    selects:
+      - host-test-only

--- a/src/ariel-os-mpu/src/arch/cortex_m_v8.rs
+++ b/src/ariel-os-mpu/src/arch/cortex_m_v8.rs
@@ -1,0 +1,108 @@
+#![expect(unsafe_code)]
+
+use crate::{Mpu, MpuRegionUsage};
+use cortex_m::{self as _, Peripherals};
+
+use crate::arch::MemoryAccess;
+
+#[cfg(not(any(armv8m)))]
+compile_error!("no supported ARM variant selected");
+
+pub struct Cpu;
+
+impl Mpu for Cpu {
+    const N_REGIONS: usize = 8; // Armv8-M supports 8 regions
+
+    fn init() {
+        unsafe {
+            const MEMFAULTENA: u32 = 0b1 << 16;
+            let mut peripherals = Peripherals::steal();
+
+            // The MemoryManagement handler gets a higher priority than the PendSV handler
+            // PendSV needs to have the lowest priority in the system.
+            peripherals.SCB.set_priority(
+                cortex_m::peripheral::scb::SystemHandler::MemoryManagement,
+                0xFE,
+            );
+
+            // Configure the CPU to trigger a MemoryManagement fault rather then a hardfault when an access violation occurs.
+            peripherals.SCB.shcsr.modify(|reg| reg | MEMFAULTENA);
+        }
+
+        Self::enable();
+    }
+
+    fn enable() {
+        unsafe {
+            let mpu = { &*cortex_m::peripheral::MPU::PTR };
+            // Enable the MPU with the default memory map as a background region for privileged access. This allows all regions in the memory map to be accessed by privileged code.
+            const ENABLE: u32 = 0b1;
+            const PRIVDEFENA: u32 = 0b1 << 2;
+            mpu.ctrl.write(ENABLE | PRIVDEFENA);
+            // ARM recommends a data and instruction barrier after enabling the MPU to ensure that all subsequent instructions are fetched with the new MPU settings.
+            cortex_m::asm::dsb();
+            cortex_m::asm::isb();
+        }
+    }
+    fn disable() {
+        unsafe {
+            let mpu = { &*cortex_m::peripheral::MPU::PTR };
+            mpu.ctrl.write(0x00);
+        }
+    }
+
+    fn configure_region(
+        range: core::ops::RangeInclusive<usize>,
+        region_n: usize,
+        access: MemoryAccess,
+    ) {
+        unsafe {
+            let mpu = { &*cortex_m::peripheral::MPU::PTR };
+
+            const OUTER_NON_CACHEABLE: u32 = 0b0100 << 4;
+            const INNER_NON_CACHEABLE: u32 = 0b0100;
+
+            // Caching is disabled at the moment
+            mpu.mair[0].write(INNER_NON_CACHEABLE | OUTER_NON_CACHEABLE);
+
+            // Select region number that should be configured.
+            mpu.rnr.write(region_n as u32);
+
+            // Only the upper 27 bits are used for addressing.
+            // The lower 5 bits are automatically set to zero.
+            //[BASE=31:5|4:3=SH|AP=2:1|XN=0]
+            let start_address_truncated = (*range.start() as u32) & !0b1_1111;
+            // Memory is not shared at the moment
+            let shareability = 0b00u32 << 2;
+            // Armv8-M does not support non reading permissions, so only write can be enabled or disabled.
+            let access_permission = if access.contains(MemoryAccess::WRITEABLE) {
+                const READ_WRITE_PRIVILEGED: u32 = 0;
+                READ_WRITE_PRIVILEGED
+            } else {
+                const READ_ONLY_PRIVILEGED: u32 = 0b10 << 1;
+                READ_ONLY_PRIVILEGED
+            };
+
+            // Execute permission
+            let execute_never: u32 = !access.contains(MemoryAccess::EXECUTABLE) as u32;
+
+            mpu.rbar
+                .write(start_address_truncated | shareability | access_permission | execute_never);
+
+            // Only the upper 27 bits are used for addressing.
+            // The lower 5 bits are automatically set to zero.
+            // [LIMIT=31:5|4=PXN|ATTRIndx=3:1|EN=0]
+            let end_address_truncated = (*range.end() as u32) & !0b1_1111;
+
+            // Ariel-OS does not support user mode, so all regions are privileged. We still don't allow execution a privileged region from non privileged code as a good safety measure for further development
+            const PRIVILEGED_EXECUTE_NEVER: u32 = 0b0 << 4;
+            // We do not use this at the moment
+            let attribute_idx = 0b0u32 << 1;
+            // Enable this region
+            let enable = 0b1u32;
+
+            mpu.rlar
+                .write(end_address_truncated | PRIVILEGED_EXECUTE_NEVER | attribute_idx | enable);
+        };
+    }
+}

--- a/src/ariel-os-mpu/src/arch/mod.rs
+++ b/src/ariel-os-mpu/src/arch/mod.rs
@@ -1,0 +1,31 @@
+bitflags::bitflags! {
+    pub struct MemoryAccess : u8 {
+        const READABLE = 0b1 << 0; // Region is readable
+        const WRITEABLE = 0b1 << 1; // Region is writeable
+        const EXECUTABLE = 0b1 << 2; // Region is executable
+    }
+}
+
+pub trait Mpu {
+    const N_REGIONS: usize; // Maximum number of supported regions
+
+    fn init();
+    fn enable();
+    fn disable();
+    fn configure_region(
+        range: core::ops::RangeInclusive<usize>,
+        region_n: usize,
+        access: MemoryAccess,
+    );
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(all(any(armv8m)))] {
+        mod cortex_m;
+        pub use cortex_m::Cpu;
+    }
+    else
+    {
+        compile_error!("Unsupported mpu architecture");
+    }
+}

--- a/src/ariel-os-mpu/src/lib.rs
+++ b/src/ariel-os-mpu/src/lib.rs
@@ -1,0 +1,37 @@
+#![no_std]
+#![expect(unsafe_code)]
+
+mod arch;
+
+use arch::{Cpu, Mpu};
+
+use crate::arch::MemoryAccess;
+
+// Other regions can be added in the future here
+pub enum MpuRegionUsage {
+   StackRedzone = 0
+}
+
+pub unsafe fn init_mpu() {
+    <Cpu as Mpu>::init();
+}
+
+pub fn context_switch(stack_begin: usize) {
+    let truncated_start = stack_begin & !0b1_1111;
+
+    const PAGESIZE: usize = 32;
+
+    // Make sure we do not run into an underflow that will interfere with a stack of another thread
+    let redzone_range = if truncated_start == stack_begin {
+        stack_begin..=stack_begin
+    } else {
+        stack_begin.saturating_add(PAGESIZE)..=stack_begin.saturating_add(PAGESIZE)
+    };
+
+    // Disallow access, so that we detect a stack overflow with redzone
+    <Cpu as Mpu>::configure_region(
+        redzone_range,
+        MpuRegionUsage::StackRedzone as usize,
+        MemoryAccess::READABLE,
+    );
+}

--- a/src/ariel-os-rt/src/cortexm.rs
+++ b/src/ariel-os-rt/src/cortexm.rs
@@ -1,7 +1,9 @@
 #![expect(unsafe_code)]
 
-use cortex_m as _;
-use cortex_m_rt::{__RESET_VECTOR, ExceptionFrame, entry, exception};
+use ariel_os_debug::ExitCodeCoeeCo;
+
+use cortex_m::{self as _, Peripherals};
+use cortex_m_rt::{__RESET_VECTORETEVECTORETFrame, entry, exception};
 
 use crate::stack::Stack;
 
@@ -25,6 +27,43 @@ pub fn ipsr_isr_number_to_str(isr_number: usize) -> &'static str {
         16..=255 => "IRQn",
         _ => "(Unknown! Illegal value?)",
     }
+}
+
+#[allow(non_snake_case)]
+#[allow(unsafe_op_in_unsafe_fn)]
+#[exception]
+unsafe fn MemoryManagement() {
+    // info!("Memory protection unit has called the MemoryManagement handler, reason: ");
+    // let peripherals = unsafe { Peripherals::steal() };
+
+    // let cfsr: u32 = peripherals.SCB.cfsr.read();
+
+    // let mmfsr = (cfsr & 0xFF) as u8;
+
+    // if mmfsr & (1 << 0) != 0 {
+    //     info!("Instruction Access Violation (IACCVIOL)");
+    // }
+    // if mmfsr & (1 << 1) != 0 {
+    //     info!("Data Access Violation (DACCVIOL)");
+    // }
+    // if mmfsr & (1 << 3) != 0 {
+    //     info!("Fault on Unstacking (MUNSTKERR)");
+    // }
+    // if mmfsr & (1 << 4) != 0 {
+    //     info!("Fault on Stacking (MSTKERR)");
+    // }
+    // if mmfsr & (1 << 5) != 0 {
+    //     info!("Fault on Lazy FP State Preservation (MLSPERR)");
+    // }
+
+    // if mmfsr & (1 << 7) != 0 {
+    //     let fault_addr = peripherals.SCB.mmfar.read();
+    //     info!("Fault Address (MMFAR): 0x{:08X}", fault_addr);
+    // } else {
+    //     info!("MMFAR not available");
+    // }
+
+    exit(ExitCode::FAILURE);
 }
 
 /// Extra verbose Cortex-M HardFault handler

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -181,6 +181,14 @@ fn startup() -> ! {
         f();
     }
 
+    #[cfg(feature = "mpu")]
+    {
+        // SAFETY: this function must not be called more than once
+        unsafe {
+            ariel_os_mpu::init_mpu();
+        }
+    }
+
     #[cfg(feature = "threading")]
     {
         // SAFETY: this function must not be called more than once

--- a/src/ariel-os-threads/Cargo.toml
+++ b/src/ariel-os-threads/Cargo.toml
@@ -12,6 +12,7 @@ include = ["src/**/*", "README.md"]
 ariel-os-log = { workspace = true }
 ariel-os-runqueue = { workspace = true }
 ariel-os-utils = { workspace = true }
+ariel-os-mpu = { workspace = true }
 critical-section = { workspace = true }
 embassy-time = { workspace = true }
 embassy-time-driver = { workspace = true }
@@ -69,6 +70,7 @@ multi-core = [
 infini-core = []
 core-affinity = ["multi-core"]
 idle-threads = []
+mpu = ["dep:ariel-os-mpu"]
 
 _test = ["single-core"]
 

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -37,6 +37,7 @@ ariel-os-sensors-registry = { workspace = true, optional = true }
 ariel-os-storage = { workspace = true, optional = true }
 ariel-os-threads = { path = "../ariel-os-threads", optional = true }
 ariel-os-utils = { workspace = true }
+ariel-os-mpu = { path = "../ariel-os-mpu", optional = true }
 document-features = { workspace = true }
 linkme = { workspace = true }
 static_cell = { workspace = true }

--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -39,6 +39,9 @@ pub use ariel_os_hal::api::*;
 pub use ariel_os_identity as identity;
 #[doc(inline)]
 pub use ariel_os_log as log;
+#[cfg(feature = "mpu")]
+#[doc(inline)]
+pub use ariel_os_mpu as mpu;
 #[doc(inline)]
 pub use ariel_os_power as power;
 #[cfg(feature = "random")]

--- a/src/laze.yml
+++ b/src/laze.yml
@@ -15,5 +15,6 @@ subdirs:
   - ariel-os-sensors-utils
   - ariel-os-stm32
   - ariel-os-threads
+  - ariel-os-mpu
   - lib
   - sensors


### PR DESCRIPTION
# Description
This will add support for the memory protection unit on Armv8-M microcontrollers. That makes it possible to detect stack overflows. It does so by using the last 32 bytes of the current threads stack as a redzone, that triggers a memory management exception if the stack is growing into it. 

## Testing

I tested that on my STM32L552ZE Nucleo board. I did so by writing a small program that calls a function recursively. At some point, the stack overflows by pushing data. I will follow up with unit tests soon.

## Open Questions

- At the moment, the context switching is not implemented. I did some testing in the past with successful results, but I still want to ask the developers of Ariel-OS, what the best place is to query the stack address to calculate the limit address and also where we exactly want to place it in the context switch handler. 
- Also, we might need to improve the API for other microcontroller architectures or more advanced use cases like sandboxing, protecting external storage, etc. 
- In the `MemoryManagement` handler, how we log that we had a memory fault. Do we just use `info!`, or what would be the correct way to display it to the user?
- The MPU might be, in this context, a bit useless. Armv8-M already has the `psplim` register, which checks for stack overflows. It might be useful for other microcontrollers like Armv7-M, because they don't have the `psplim register. And of course, more advanced protection schemes.

I'm open for feedback. :)

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash